### PR TITLE
docs: refresh architecture sanity review

### DIFF
--- a/plans/architecture_review.md
+++ b/plans/architecture_review.md
@@ -1,146 +1,20 @@
-# Architecture Review
+## Overall architecture
+Kalita is organized as a modular monolith: `cmd/server` boots the app, `internal/app` composes runtime dependencies, `internal/http` exposes transport handlers, and domain-support packages (`schema`, `validation`, `runtime`, `postgres`, `catalog`, `blob`, `config`) provide core capabilities.
 
-## 1. Architecture Overview
+## Good decisions
+- Clear top-level layering (`cmd` entrypoint → app bootstrap → package-level subsystems) makes startup and ownership easy to follow.
+- Core concerns are split into dedicated packages: schema parsing/linting, validation, runtime storage/querying, Postgres DDL/connect/apply, enum catalogs, blob storage, and config loading.
+- A small interface seam exists for file storage (`blob.BlobStore`), which supports future backend swaps.
+- Router initialization is centralized and fail-fast schema linting happens before serving traffic.
 
-**Architecture Style:** Modular Monolith
+## Architectural problems
+- `internal/http/handlers.go` is very large and aggregates CRUD, bulk, filtering, restore, and delete semantics; this is a God-module trend.
+- Transport and business logic are tightly coupled: handlers directly orchestrate storage and validation behavior instead of calling a service layer.
+- Persistence boundaries are blurred: Postgres is used for schema migration while runtime data remains in-memory, creating a split-brain architecture.
+- Cross-cutting concerns (validation, query parsing, relation checks) are spread across `http` + `runtime`, so responsibilities are only partially separated.
+- Module boundaries are mostly reasonable for a small system, but weak around `http` ↔ `runtime` where orchestration and domain rules overlap.
 
-The system follows a modular monolith architecture with clear package boundaries. It provides a REST API backend for a data management system with DSL-based entity definitions, supporting CRUD operations, blob storage, PostgreSQL persistence, and enum reference management.
-
-**Major Subsystems:**
-- **API Layer** (`internal/api/`) - HTTP handlers and request processing
-- **Configuration** (`internal/config/`) - Application configuration management
-- **DSL Parser** (`internal/dsl/`) - Entity definition parsing
-- **PostgreSQL Integration** (`internal/pg/`) - Database schema and DDL execution
-- **Reference Management** (`internal/reference/`) - Enum catalog handling
-
-## 2. Key Architectural Components
-
-### `internal/api/`
-Core API layer handling HTTP requests/responses.
-- **handlers.go** - REST endpoints (Create, List, Get, Update, Patch, Delete, Bulk operations)
-- **storage.go** - In-memory storage with mutex protection for CRUD operations
-- **validation.go** - Schema validation and type coercion
-- **blob.go** - Blob storage interface and local implementation
-- **router.go** - Server initialization and route registration
-- **names.go** - Entity name normalization
-- **query.go** - List parameters parsing and sorting logic
-- **meta.go** - Metadata endpoints for entity/field introspection
-- **schema_lint.go** - DSL schema validation
-
-### `internal/config/`
-Configuration management.
-- **config.go** - Config struct, JSON loading, environment variable overrides
-
-### `internal/dsl/`
-DSL parsing and entity modeling.
-- **parser.go** - Loads and parses `.dsl` files
-- **model.go** - Entity, Field, Constraints definitions
-
-### `internal/pg/`
-PostgreSQL integration.
-- **schema.go** - DDL generation from entities
-- **apply.go** - DDL execution with error handling
-- **conn.go** - Database connection management
-
-### `internal/reference/`
-Enum reference management.
-- **leader.go** - Loads enum catalogs from YAML
-- **model.go** - EnumDirectory, EnumItem models
-
-## 3. Data Flow
-
-### Startup Flow
-1. Load configuration from JSON file + environment variables
-2. Parse DSL entity definitions from `dslDir`
-3. Load enum catalogs from `enumsDir`
-4. Generate DDL from entities (if `autoMigrate` enabled)
-5. Apply DDL to PostgreSQL
-6. Initialize in-memory Storage with schemas and enums
-7. Start HTTP server on configured port
-
-### Request Flow
-1. **HTTP Request** → Gin router
-2. **Handler** (`handlers.go`) → Normalize entity name via `storage.NormalizeEntityName()`
-3. **Validation** (`validation.go`) → Validate payload against schema, coerce types
-4. **Storage** (`storage.go`) → Read/Write in-memory data with RWMutex protection
-5. **Response** → Return JSON to client
-
-### Blob Upload Flow
-1. File upload request → `UploadFileHandler`
-2. Generate unique key: `YYYY/MM/randomHex(16)`
-3. `LocalBlobStore.Put()` → Create directory structure, write file
-4. Store reference in entity data
-
-## 4. Coupling and Boundaries
-
-### Tight Coupling
-- **api/handlers.go** - Large file with many responsibilities (all CRUD operations, filtering, bulk operations, child discovery)
-- **api/storage.go** - Directly couples in-memory storage with business logic; no repository abstraction
-- **api/validation.go** - Strongly coupled to both Storage and DSL models
-
-### Unclear Responsibilities
-- **api/query.go** - Mixed concerns: sorting, filtering, list parameters parsing
-- **api/files.go** - File handling mixed with entity operations
-- **api/meta.go** - Metadata endpoints in same package as core handlers
-
-### Missing Boundaries
-- No clear separation between "service layer" and "data layer"
-- In-memory storage (`storage.go`) mixes data access with business rules (e.g., `FindIncomingRefs`)
-- No transaction management abstraction
-- Blob storage implementation tightly coupled to handlers
-
-## 5. Architectural Strengths
-
-- **Clear package structure** - Logical separation between API, config, DSL, database, and references
-- **Interface-based design** - `BlobStore` interface allows different implementations
-- **Schema-driven** - Entity definitions in DSL files provide flexibility
-- **Mutex protection** - Storage uses RWMutex for concurrent access safety
-- **Configuration flexibility** - JSON + environment variable override pattern
-- **DDL generation** - Automatic schema migration reduces manual database work
-- **Enum catalog** - Externalized enum management via YAML files
-
-## 6. Architectural Weaknesses
-
-- **In-memory storage** - Data not persisted across restarts; unsuitable for production distributed systems
-- **No authentication** - No security middleware; must be added externally
-- **Large handlers.go** - 1000+ lines with too many responsibilities
-- **No async processing** - All operations synchronous; potential blocking
-- **Limited query capabilities** - Basic filtering and sorting only
-- **Generic error handling** - Limited detailed validation feedback
-- **S3 driver not implemented** - Blob storage only supports local filesystem
-
-## 7. Scalability and Maintainability Risks
-
-### Scalability Risks
-- **In-memory storage** - Single instance limitation; no horizontal scaling
-- **No caching layer** - Repeated queries hit in-memory map every time
-- **Synchronous operations** - Blocking I/O limits throughput
-
-### Maintainability Risks
-- **Monolithic handlers.go** - Difficult to navigate and modify
-- **Mixed concerns in api/ package** - File handling, metadata, queries all in one package
-- **Tight coupling to DSL** - Changes to DSL format require code updates
-- **No unit test stubs visible** - Testing may be challenging
-
-### Complexity Hotspots
-- `handlers.go` - Bulk operations, filtering logic, child discovery
-- `storage.go` - Complex locking patterns, reference resolution
-- `validation.go` - Type coercion logic, unique constraint checking
-
-## 8. Refactoring Opportunities
-
-### High Priority
-1. **Split handlers.go** - Separate into distinct handler files per entity type or operation group
-2. **Extract service layer** - Create dedicated service package between handlers and storage
-3. **Add repository interface** - Abstract storage to enable different backends
-
-### Medium Priority
-4. **Separate query logic** - Move `query.go` parsing to dedicated package
-5. **Isolate file handling** - Move `files.go` to separate package or integrate with blob package
-6. **Add caching layer** - Introduce cache interface for frequently accessed data
-
-### Lower Priority
-7. **Implement S3 blob driver** - Complete the blob storage abstraction
-8. **Add authentication middleware** - Security boundary at router level
-9. **Async operation support** - Consider message queue for long-running operations
-10. **Transaction management** - Add database transaction support for multi-step operations
+## Biggest risks
+1. Continued growth of the HTTP layer into a single change hotspot (`handlers.go`) will reduce maintainability and increase regression risk.
+2. Mixed persistence model (in-memory data + Postgres DDL) can create operational confusion and production-readiness gaps.
+3. Lack of an explicit service/domain boundary makes it hard to evolve business rules, transactions, and testing strategy independently of transport.


### PR DESCRIPTION
### Motivation
- The long-form architecture document was outdated and noisy, so it was consolidated into a concise, high-level sanity review aligned to the current repository layout to make risks and actionables easier to consume.

### Description
- Rewrote `plans/architecture_review.md` to a shorter, focused summary that covers overall architecture, good decisions, main architectural problems, and the three biggest risks.

### Testing
- Ran `go test ./...` and the test run completed without failures (packages report no test files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec34e2f288324ab7600d705e19f9c)