### PR TITLE
Add optional workflow DSL and action endpoint for validated status transitions

### DIFF
--- a/docs/ai-shift/05-change-report.md
+++ b/docs/ai-shift/05-change-report.md
@@ -1,0 +1,40 @@
+# Change report: first workflow-action vertical slice
+
+## What changed
+- Added an optional additive `workflow:` entity block to the DSL schema model with:
+  - `status_field`
+  - `actions`
+  - per-action `from` and `to` states
+- Extended the DSL parser to read the new workflow block without changing existing field or constraints syntax.
+- Extended schema linting to validate:
+  - the workflow status field exists
+  - action `from`/`to` states match enum values when the status field is an inline enum
+  - action declarations are structurally complete
+- Added a focused runtime workflow-action executor that:
+  - loads an existing record
+  - verifies optimistic version when provided
+  - validates the requested action against declared workflow metadata
+  - updates only the configured status field
+  - increments version and updates timestamp
+- Added a new additive endpoint:
+  - `POST /api/:module/:entity/:id/_actions/:action`
+- Extended entity meta output to expose declared workflow metadata so clients can discover actions.
+- Added one minimal example entity with workflow metadata: `test.WorkflowTask`.
+- Added focused parser/lint/runtime/HTTP tests for the new slice.
+
+## What stayed compatible
+- Existing DSL files still load without modification.
+- Existing YAML enum catalog format is unchanged.
+- Existing CRUD routes and behavior remain available.
+- Entities without workflow metadata remain pass-through and unaffected.
+- Direct `PUT`/`PATCH` writes to `status` are still allowed exactly as before.
+- No major modules were renamed and no architecture was redesigned.
+
+## Remaining risks
+- Workflow state validation currently checks declared enum states only when the configured status field is an inline `enum[...]`; catalog-backed status fields are not yet cross-validated against YAML catalog values.
+- The action endpoint currently executes the transition immediately once validated; it does not yet support proposal-only/dry-run mode or review gating.
+- Workflow metadata is supported only in the DSL parser path used by this repository’s current schema format; no separate sidecar workflow YAML has been introduced in this slice.
+- No authorization, approval, or side-effect model is included yet by design.
+
+## Next smallest step
+- Add a non-mutating proposal/dry-run mode for the same action endpoint or a sibling endpoint so clients can ask Kalita to validate a transition before execution, while reusing the same workflow metadata and transition validator.

--- a/dsl/core/entities.dsl
+++ b/dsl/core/entities.dsl
@@ -36,3 +36,13 @@ module test
 entity Item:
   code: string required unique
   name: string
+
+entity WorkflowTask:
+  title: string required
+  status: enum[Draft, InApproval, Approved] required default=Draft
+  workflow:
+    status_field: status
+    actions:
+      submit:
+        from: [Draft]
+        to: InApproval

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -1,0 +1,64 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+
+	"kalita/internal/runtime"
+	"kalita/internal/validation"
+
+	"github.com/gin-gonic/gin"
+)
+
+type actionRequest struct {
+	RecordVersion int64                  `json:"record_version"`
+	Payload       map[string]interface{} `json:"payload"`
+}
+
+func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		mod := c.Param("module")
+		ent := c.Param("entity")
+		id := c.Param("id")
+		action := c.Param("action")
+
+		fqn, ok := storage.NormalizeEntityName(mod, ent)
+		if !ok {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Entity not found"})
+			return
+		}
+
+		var req actionRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
+			return
+		}
+
+		result, errs := runtime.ExecuteWorkflowAction(storage, fqn, id, action, req.RecordVersion, req.RecordVersion > 0)
+		if len(errs) > 0 {
+			verrs := make([]validation.FieldError, 0, len(errs))
+			for _, err := range errs {
+				verrs = append(verrs, validation.FieldError{
+					Code:    err.Code,
+					Field:   err.Field,
+					Message: err.Message,
+				})
+			}
+			c.JSON(statusForErrors(verrs), gin.H{"errors": verrs})
+			return
+		}
+
+		c.Header("ETag", fmt.Sprintf(`"%d"`, result.Version))
+		c.JSON(http.StatusOK, gin.H{
+			"id":           result.ID,
+			"entity":       result.Entity,
+			"action":       result.Action,
+			"status_field": result.StatusField,
+			"from":         result.From,
+			"to":           result.To,
+			"version":      result.Version,
+			"committed":    result.Committed,
+			"record":       result.Record,
+		})
+	}
+}

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -1,0 +1,142 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"kalita/internal/runtime"
+	"kalita/internal/schema"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestActionHandlerSuccessAndMetaWorkflow(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandler(storage))
+	router.GET("/api/meta/:module/:entity", MetaEntityHandler(storage))
+
+	body := map[string]any{
+		"action":         "submit",
+		"record_version": 3,
+		"payload": map[string]any{
+			"comment": "ready for approval",
+		},
+	}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST action status = %d body=%s", w.Code, w.Body.String())
+	}
+	var actionResp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &actionResp); err != nil {
+		t.Fatalf("json.Unmarshal(action) error = %v", err)
+	}
+	if got := actionResp["to"]; got != "InApproval" {
+		t.Fatalf("to = %v", got)
+	}
+	if got := actionResp["version"]; got.(float64) != 4 {
+		t.Fatalf("version = %v", got)
+	}
+
+	metaReq := httptest.NewRequest(http.MethodGet, "/api/meta/test/WorkflowTask", nil)
+	metaW := httptest.NewRecorder()
+	router.ServeHTTP(metaW, metaReq)
+	if metaW.Code != http.StatusOK {
+		t.Fatalf("meta status = %d body=%s", metaW.Code, metaW.Body.String())
+	}
+	var metaResp map[string]any
+	if err := json.Unmarshal(metaW.Body.Bytes(), &metaResp); err != nil {
+		t.Fatalf("json.Unmarshal(meta) error = %v", err)
+	}
+	workflow := metaResp["workflow"].(map[string]any)
+	if workflow["status_field"] != "status" {
+		t.Fatalf("meta workflow status_field = %v", workflow["status_field"])
+	}
+}
+
+func TestActionHandlerReturnsConflictOnStaleVersion(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandler(storage))
+
+	body := map[string]any{"record_version": 2}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestExistingPatchCompatibilityStillWorks(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	router := gin.New()
+	router.PATCH("/api/:module/:entity/:id", PatchHandler(storage))
+
+	body := map[string]any{"title": "Updated title"}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/api/test/WorkflowTask/"+rec.ID, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("If-Match", `"3"`)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["title"]; got != "Updated title" {
+		t.Fatalf("title = %v", got)
+	}
+}
+
+func testHTTPWorkflowStorage() (*runtime.Storage, *runtime.Record) {
+	entity := &schema.Entity{
+		Name:   "WorkflowTask",
+		Module: "test",
+		Fields: []schema.Field{
+			{Name: "title", Type: "string", Options: map[string]string{}},
+			{Name: "status", Type: "enum", Enum: []string{"Draft", "InApproval", "Approved"}, Options: map[string]string{}},
+		},
+		Workflow: &schema.Workflow{
+			StatusField: "status",
+			Actions: map[string]schema.WorkflowAction{
+				"submit": {From: []string{"Draft"}, To: "InApproval"},
+			},
+		},
+	}
+	st := runtime.NewStorage([]*schema.Entity{entity}, nil)
+	now := time.Now().UTC().Add(-time.Minute)
+	rec := &runtime.Record{
+		ID:        "rec-1",
+		Version:   3,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Data: map[string]interface{}{
+			"title":  "Original",
+			"status": "Draft",
+		},
+	}
+	st.Data["test.WorkflowTask"] = map[string]*runtime.Record{rec.ID: rec}
+	return st, rec
+}

--- a/internal/http/meta.go
+++ b/internal/http/meta.go
@@ -42,6 +42,7 @@ type metaEntity struct {
 	Entity      string         `json:"entity"`
 	Fields      []metaField    `json:"fields"`
 	Constraints map[string]any `json:"constraints,omitempty"` // {"unique":[["code"],["base","quote","date"]]}
+	Workflow    map[string]any `json:"workflow,omitempty"`
 }
 
 func MetaEntityHandler(storage *runtime.Storage) gin.HandlerFunc {
@@ -109,12 +110,28 @@ func MetaEntityHandler(storage *runtime.Storage) gin.HandlerFunc {
 			constraints = map[string]any{"unique": uniq}
 		}
 
+		var workflow map[string]any
+		if entitySchema.Workflow != nil {
+			actions := make(map[string]any, len(entitySchema.Workflow.Actions))
+			for name, action := range entitySchema.Workflow.Actions {
+				actions[name] = map[string]any{
+					"from": append([]string(nil), action.From...),
+					"to":   action.To,
+				}
+			}
+			workflow = map[string]any{
+				"status_field": entitySchema.Workflow.StatusField,
+				"actions":      actions,
+			}
+		}
+
 		m, e := splitFQN(fqn)
 		c.JSON(http.StatusOK, metaEntity{
 			Module:      m,
 			Entity:      e,
 			Fields:      fields,
 			Constraints: constraints,
+			Workflow:    workflow,
 		})
 	}
 }

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -29,6 +29,7 @@ func RunServer(addr string, storage *runtime.Storage) {
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))
 
 		r.POST("/api/admin/reload", AdminReloadHandler(storage))

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -1,0 +1,126 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"kalita/internal/schema"
+)
+
+type ActionResult struct {
+	Entity       string                 `json:"entity"`
+	ID           string                 `json:"id"`
+	Action       string                 `json:"action"`
+	StatusField  string                 `json:"status_field"`
+	From         string                 `json:"from"`
+	To           string                 `json:"to"`
+	Version      int64                  `json:"version"`
+	Record       map[string]interface{} `json:"record"`
+	Committed    bool                   `json:"committed"`
+	UpdatedAtUTC time.Time              `json:"-"`
+}
+
+func ExecuteWorkflowAction(storage *Storage, entityFQN, id, actionName string, expectedVersion int64, requireVersion bool) (*ActionResult, []ActionError) {
+	entitySchema := storage.Schemas[entityFQN]
+	if entitySchema == nil {
+		return nil, []ActionError{{Code: "not_found", Field: "entity", Message: "Entity not found"}}
+	}
+
+	workflow := entitySchema.Workflow
+	if workflow == nil {
+		return nil, []ActionError{{Code: "not_found", Field: "action", Message: "Workflow is not declared for entity"}}
+	}
+
+	action, ok := workflow.Actions[actionName]
+	if !ok {
+		return nil, []ActionError{{Code: "not_found", Field: "action", Message: "Action not declared for entity"}}
+	}
+
+	storage.Mu.Lock()
+	defer storage.Mu.Unlock()
+
+	rec := storage.Data[entityFQN][id]
+	if rec == nil || rec.Deleted {
+		return nil, []ActionError{{Code: "not_found", Field: "id", Message: "Record not found"}}
+	}
+	if requireVersion && rec.Version != expectedVersion {
+		return nil, []ActionError{{
+			Code:    "version_conflict",
+			Field:   "record_version",
+			Message: fmt.Sprintf("expected %d, got %d", expectedVersion, rec.Version),
+		}}
+	}
+
+	currentStatus := fmt.Sprintf("%v", rec.Data[workflow.StatusField])
+	if !contains(action.From, currentStatus) {
+		return nil, []ActionError{{
+			Code:    "enum_invalid",
+			Field:   workflow.StatusField,
+			Message: fmt.Sprintf("Action %q is not allowed from status %q", actionName, currentStatus),
+		}}
+	}
+
+	rec.Data[workflow.StatusField] = action.To
+	rec.Version++
+	rec.UpdatedAt = time.Now().UTC()
+
+	return &ActionResult{
+		Entity:       entityFQN,
+		ID:           rec.ID,
+		Action:       actionName,
+		StatusField:  workflow.StatusField,
+		From:         currentStatus,
+		To:           action.To,
+		Version:      rec.Version,
+		Record:       flattenRecord(rec),
+		Committed:    true,
+		UpdatedAtUTC: rec.UpdatedAt,
+	}, nil
+}
+
+type ActionError struct {
+	Code    string `json:"code"`
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func flattenRecord(rec *Record) map[string]interface{} {
+	out := map[string]interface{}{
+		"id":         rec.ID,
+		"version":    rec.Version,
+		"created_at": rec.CreatedAt.Format(time.RFC3339),
+		"updated_at": rec.UpdatedAt.Format(time.RFC3339),
+	}
+	for k, v := range rec.Data {
+		if _, clash := out[k]; clash {
+			out["data."+k] = v
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func contains(items []string, want string) bool {
+	for _, item := range items {
+		if strings.EqualFold(item, want) || item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func WorkflowActions(entity *schema.Entity) map[string]schema.WorkflowAction {
+	if entity == nil || entity.Workflow == nil {
+		return nil
+	}
+	out := make(map[string]schema.WorkflowAction, len(entity.Workflow.Actions))
+	for k, v := range entity.Workflow.Actions {
+		out[k] = schema.WorkflowAction{
+			From: append([]string(nil), v.From...),
+			To:   v.To,
+		}
+	}
+	return out
+}

--- a/internal/runtime/actions_test.go
+++ b/internal/runtime/actions_test.go
@@ -1,0 +1,100 @@
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"kalita/internal/schema"
+)
+
+func TestExecuteWorkflowActionAllowsValidTransition(t *testing.T) {
+	t.Parallel()
+
+	storage, rec := workflowTestStorage()
+	beforeUpdated := rec.UpdatedAt
+	result, errs := ExecuteWorkflowAction(storage, "test.WorkflowTask", rec.ID, "submit", 3, true)
+	if len(errs) > 0 {
+		t.Fatalf("ExecuteWorkflowAction() errs = %#v", errs)
+	}
+	if result.To != "InApproval" || result.From != "Draft" {
+		t.Fatalf("unexpected transition result = %#v", result)
+	}
+	if got := rec.Data["status"]; got != "InApproval" {
+		t.Fatalf("status = %v, want InApproval", got)
+	}
+	if got := rec.Data["title"]; got != "Keep me" {
+		t.Fatalf("title mutated to %v", got)
+	}
+	if rec.Version != 4 {
+		t.Fatalf("version = %d, want 4", rec.Version)
+	}
+	if !rec.UpdatedAt.After(beforeUpdated) {
+		t.Fatalf("updated_at did not change")
+	}
+}
+
+func TestExecuteWorkflowActionRejectsDisallowedState(t *testing.T) {
+	t.Parallel()
+
+	storage, rec := workflowTestStorage()
+	rec.Data["status"] = "Approved"
+
+	_, errs := ExecuteWorkflowAction(storage, "test.WorkflowTask", rec.ID, "submit", 3, true)
+	if len(errs) != 1 {
+		t.Fatalf("expected one error, got %#v", errs)
+	}
+	if errs[0].Code != "enum_invalid" {
+		t.Fatalf("error code = %q", errs[0].Code)
+	}
+}
+
+func TestExecuteWorkflowActionRejectsUnknownAction(t *testing.T) {
+	t.Parallel()
+
+	storage, rec := workflowTestStorage()
+	_, errs := ExecuteWorkflowAction(storage, "test.WorkflowTask", rec.ID, "reject", 3, true)
+	if len(errs) != 1 || errs[0].Field != "action" {
+		t.Fatalf("unexpected errs = %#v", errs)
+	}
+}
+
+func TestExecuteWorkflowActionRejectsVersionMismatch(t *testing.T) {
+	t.Parallel()
+
+	storage, rec := workflowTestStorage()
+	_, errs := ExecuteWorkflowAction(storage, "test.WorkflowTask", rec.ID, "submit", 2, true)
+	if len(errs) != 1 || errs[0].Code != "version_conflict" {
+		t.Fatalf("unexpected errs = %#v", errs)
+	}
+}
+
+func workflowTestStorage() (*Storage, *Record) {
+	entity := &schema.Entity{
+		Name:   "WorkflowTask",
+		Module: "test",
+		Fields: []schema.Field{
+			{Name: "title", Type: "string"},
+			{Name: "status", Type: "enum", Enum: []string{"Draft", "InApproval", "Approved"}},
+		},
+		Workflow: &schema.Workflow{
+			StatusField: "status",
+			Actions: map[string]schema.WorkflowAction{
+				"submit": {From: []string{"Draft"}, To: "InApproval"},
+			},
+		},
+	}
+	st := NewStorage([]*schema.Entity{entity}, nil)
+	now := time.Now().UTC().Add(-time.Minute)
+	rec := &Record{
+		ID:        "rec-1",
+		Version:   3,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Data: map[string]interface{}{
+			"title":  "Keep me",
+			"status": "Draft",
+		},
+	}
+	st.Data["test.WorkflowTask"] = map[string]*Record{rec.ID: rec}
+	return st, rec
+}

--- a/internal/schema/lint.go
+++ b/internal/schema/lint.go
@@ -17,7 +17,9 @@ func Lint(schemas map[string]*Entity) []SchemaIssue {
 	var issues []SchemaIssue
 
 	for fqn, e := range schemas {
+		fieldByName := make(map[string]Field, len(e.Fields))
 		for _, f := range e.Fields {
+			fieldByName[f.Name] = f
 			// валидность on_delete
 			if od := strings.TrimSpace(strings.ToLower(f.Options["on_delete"])); od != "" {
 				switch od {
@@ -57,6 +59,69 @@ func Lint(schemas map[string]*Entity) []SchemaIssue {
 
 			// array[ref] — set_null допустим (мы уже реализовали очистку массива при удалении),
 			// конфликтов тут не поднимаем.
+		}
+
+		if e.Workflow != nil {
+			if strings.TrimSpace(e.Workflow.StatusField) == "" {
+				issues = append(issues, SchemaIssue{
+					Entity:  fqn,
+					Code:    "workflow_status_field_missing",
+					Message: "workflow.status_field must be set",
+				})
+			} else {
+				statusField, ok := fieldByName[e.Workflow.StatusField]
+				if !ok {
+					issues = append(issues, SchemaIssue{
+						Entity:  fqn,
+						Field:   e.Workflow.StatusField,
+						Code:    "workflow_status_field_unknown",
+						Message: "workflow status_field does not exist on entity",
+					})
+				} else {
+					allowed := make(map[string]struct{}, len(statusField.Enum))
+					for _, v := range statusField.Enum {
+						allowed[v] = struct{}{}
+					}
+					for name, action := range e.Workflow.Actions {
+						if len(action.From) == 0 {
+							issues = append(issues, SchemaIssue{
+								Entity:  fqn,
+								Field:   e.Workflow.StatusField,
+								Code:    "workflow_action_from_empty",
+								Message: fmt.Sprintf("workflow action %q must declare at least one from state", name),
+							})
+						}
+						if strings.TrimSpace(action.To) == "" {
+							issues = append(issues, SchemaIssue{
+								Entity:  fqn,
+								Field:   e.Workflow.StatusField,
+								Code:    "workflow_action_to_empty",
+								Message: fmt.Sprintf("workflow action %q must declare target state", name),
+							})
+						}
+						if strings.EqualFold(statusField.Type, "enum") && len(allowed) > 0 {
+							for _, from := range action.From {
+								if _, ok := allowed[from]; !ok {
+									issues = append(issues, SchemaIssue{
+										Entity:  fqn,
+										Field:   e.Workflow.StatusField,
+										Code:    "workflow_from_unknown",
+										Message: fmt.Sprintf("workflow action %q references unknown from state %q", name, from),
+									})
+								}
+							}
+							if _, ok := allowed[action.To]; !ok {
+								issues = append(issues, SchemaIssue{
+									Entity:  fqn,
+									Field:   e.Workflow.StatusField,
+									Code:    "workflow_to_unknown",
+									Message: fmt.Sprintf("workflow action %q references unknown target state %q", name, action.To),
+								})
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 	return issues

--- a/internal/schema/model.go
+++ b/internal/schema/model.go
@@ -5,6 +5,7 @@ type Entity struct {
 	Module      string
 	Fields      []Field
 	Constraints Constraints
+	Workflow    *Workflow
 }
 
 type Constraints struct {
@@ -19,4 +20,14 @@ type Field struct {
 	RefTarget string            // целевая сущность для ref[...], если Type == "ref"
 	ElemType  string            // тип элемента для array[T], если Type == "array" (T без префикса array)
 	Options   map[string]string // required, unique, default...
+}
+
+type Workflow struct {
+	StatusField string
+	Actions     map[string]WorkflowAction
+}
+
+type WorkflowAction struct {
+	From []string
+	To   string
 }

--- a/internal/schema/parser.go
+++ b/internal/schema/parser.go
@@ -19,6 +19,12 @@ var (
 	moduleRe           = regexp.MustCompile(`^\s*module\s+([A-Za-z0-9_.-]+)\s*$`)
 	reConstraintsStart = regexp.MustCompile(`^\s*constraints\s*:\s*$`)
 	reUniqueLine       = regexp.MustCompile(`^\s*unique\s*\(\s*([^)]+)\s*\)\s*$`)
+	reWorkflowStart    = regexp.MustCompile(`^\s*workflow\s*:\s*$`)
+	reActionsStart     = regexp.MustCompile(`^\s*actions\s*:\s*$`)
+	reStatusFieldLine  = regexp.MustCompile(`^\s*status_field\s*:\s*([A-Za-z_][\w]*)\s*$`)
+	reWorkflowAction   = regexp.MustCompile(`^\s*([A-Za-z_][\w]*)\s*:\s*$`)
+	reWorkflowFromLine = regexp.MustCompile(`^\s*from\s*:\s*\[(.*)\]\s*$`)
+	reWorkflowToLine   = regexp.MustCompile(`^\s*to\s*:\s*([^\s#]+)\s*$`)
 )
 
 // // parse: options tokenizer — делит "k=v k2='v 2' pattern=^[A-Z0-9 _-]+$" на токены, не рвёт по пробелам внутри кавычек/скобок
@@ -81,6 +87,9 @@ func LoadEntities(path string) ([]*Entity, error) {
 	var current *Entity
 	currentModule := ""
 	inConstraints := false
+	inWorkflow := false
+	inWorkflowActions := false
+	currentWorkflowAction := ""
 	// карта имён полей текущей сущности (для проверки дублей)
 	var fieldNames map[string]struct{}
 
@@ -106,6 +115,9 @@ func LoadEntities(path string) ([]*Entity, error) {
 			}
 			current = &Entity{Name: m[1], Module: currentModule}
 			inConstraints = false
+			inWorkflow = false
+			inWorkflowActions = false
+			currentWorkflowAction = ""
 			fieldNames = make(map[string]struct{}, 16)
 			continue
 		}
@@ -117,6 +129,9 @@ func LoadEntities(path string) ([]*Entity, error) {
 		// ----- БЛОК CONSTRAINTS -----
 		if reConstraintsStart.MatchString(line) {
 			inConstraints = true
+			inWorkflow = false
+			inWorkflowActions = false
+			currentWorkflowAction = ""
 			continue
 		}
 		if inConstraints {
@@ -144,6 +159,60 @@ func LoadEntities(path string) ([]*Entity, error) {
 			}
 		}
 		// ----- КОНЕЦ БЛОКА CONSTRAINTS -----
+
+		// ----- БЛОК WORKFLOW -----
+		if reWorkflowStart.MatchString(line) {
+			inWorkflow = true
+			inWorkflowActions = false
+			currentWorkflowAction = ""
+			if current.Workflow == nil {
+				current.Workflow = &Workflow{Actions: map[string]WorkflowAction{}}
+			}
+			continue
+		}
+		if inWorkflow {
+			switch {
+			case reStatusFieldLine.MatchString(line):
+				m := reStatusFieldLine.FindStringSubmatch(line)
+				current.Workflow.StatusField = strings.TrimSpace(m[1])
+				continue
+			case reActionsStart.MatchString(line):
+				inWorkflowActions = true
+				currentWorkflowAction = ""
+				continue
+			case inWorkflowActions && reWorkflowAction.MatchString(line):
+				m := reWorkflowAction.FindStringSubmatch(line)
+				currentWorkflowAction = strings.TrimSpace(m[1])
+				if _, exists := current.Workflow.Actions[currentWorkflowAction]; exists {
+					return nil, fmt.Errorf("%s.%s: duplicate workflow action %q", current.Module, current.Name, currentWorkflowAction)
+				}
+				current.Workflow.Actions[currentWorkflowAction] = WorkflowAction{}
+				continue
+			case inWorkflowActions && reWorkflowFromLine.MatchString(line):
+				if currentWorkflowAction == "" {
+					return nil, fmt.Errorf("%s.%s: workflow from declared before action name", current.Module, current.Name)
+				}
+				m := reWorkflowFromLine.FindStringSubmatch(line)
+				act := current.Workflow.Actions[currentWorkflowAction]
+				act.From = parseWorkflowStates(m[1])
+				current.Workflow.Actions[currentWorkflowAction] = act
+				continue
+			case inWorkflowActions && reWorkflowToLine.MatchString(line):
+				if currentWorkflowAction == "" {
+					return nil, fmt.Errorf("%s.%s: workflow to declared before action name", current.Module, current.Name)
+				}
+				m := reWorkflowToLine.FindStringSubmatch(line)
+				act := current.Workflow.Actions[currentWorkflowAction]
+				act.To = strings.Trim(strings.TrimSpace(m[1]), `"'`)
+				current.Workflow.Actions[currentWorkflowAction] = act
+				continue
+			default:
+				inWorkflow = false
+				inWorkflowActions = false
+				currentWorkflowAction = ""
+			}
+		}
+		// ----- КОНЕЦ БЛОКА WORKFLOW -----
 
 		// Поле: name: type [options]
 		if m := fieldRe.FindStringSubmatch(line); m != nil {
@@ -258,6 +327,17 @@ func LoadEntities(path string) ([]*Entity, error) {
 		entities = append(entities, current)
 	}
 	return entities, scanner.Err()
+}
+
+func parseWorkflowStates(raw string) []string {
+	parts := strings.Split(strings.TrimSpace(raw), ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.Trim(strings.TrimSpace(p), `"'`); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func LoadAllEntities(root string) (map[string]*Entity, error) {

--- a/internal/schema/workflow_test.go
+++ b/internal/schema/workflow_test.go
@@ -1,0 +1,140 @@
+package schema
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadEntitiesParsesWorkflowMetadata(t *testing.T) {
+	t.Parallel()
+
+	dsl := `
+module test
+
+entity Ticket:
+  title: string required
+  status: enum[Draft, InApproval, Approved] required default=Draft
+  workflow:
+    status_field: status
+    actions:
+      submit:
+        from: [Draft]
+        to: InApproval
+      approve:
+        from: [InApproval]
+        to: Approved
+`
+	path := writeDSLFile(t, dsl)
+
+	entities, err := LoadEntities(path)
+	if err != nil {
+		t.Fatalf("LoadEntities() error = %v", err)
+	}
+	if len(entities) != 1 {
+		t.Fatalf("expected 1 entity, got %d", len(entities))
+	}
+	got := entities[0].Workflow
+	if got == nil {
+		t.Fatalf("expected workflow metadata to be parsed")
+	}
+	if got.StatusField != "status" {
+		t.Fatalf("status_field = %q, want status", got.StatusField)
+	}
+	if got.Actions["submit"].To != "InApproval" {
+		t.Fatalf("submit.to = %q", got.Actions["submit"].To)
+	}
+	if len(got.Actions["approve"].From) != 1 || got.Actions["approve"].From[0] != "InApproval" {
+		t.Fatalf("approve.from = %#v", got.Actions["approve"].From)
+	}
+}
+
+func TestLoadAllEntitiesExistingDSLStillValid(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	src, err := os.ReadFile(filepath.Join("..", "..", "dsl", "core", "entities.dsl"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "core"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "core", "entities.dsl"), src, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	entities, err := LoadAllEntities(root)
+	if err != nil {
+		t.Fatalf("LoadAllEntities() error = %v", err)
+	}
+	if _, ok := entities["core.Project"]; !ok {
+		t.Fatalf("expected existing core.Project to still load")
+	}
+	if _, ok := entities["test.WorkflowTask"]; !ok {
+		t.Fatalf("expected WorkflowTask example to load")
+	}
+}
+
+func TestLoadEntitiesRejectsDuplicateWorkflowAction(t *testing.T) {
+	t.Parallel()
+
+	dsl := `
+module test
+
+entity Ticket:
+  status: enum[Draft, InApproval] required
+  workflow:
+    status_field: status
+    actions:
+      submit:
+        from: [Draft]
+        to: InApproval
+      submit:
+        from: [InApproval]
+        to: Draft
+`
+	_, err := LoadEntities(writeDSLFile(t, dsl))
+	if err == nil {
+		t.Fatalf("expected duplicate workflow action error")
+	}
+}
+
+func TestLintWorkflowRejectsUnknownStatusFieldAndStates(t *testing.T) {
+	t.Parallel()
+
+	entity := &Entity{
+		Name:   "Ticket",
+		Module: "test",
+		Fields: []Field{
+			{Name: "status", Type: "enum", Enum: []string{"Draft", "Approved"}},
+		},
+		Workflow: &Workflow{
+			StatusField: "lifecycle",
+			Actions: map[string]WorkflowAction{
+				"submit": {From: []string{"Draft"}, To: "Approved"},
+			},
+		},
+	}
+	issues := Lint(map[string]*Entity{"test.Ticket": entity})
+	if len(issues) == 0 {
+		t.Fatalf("expected lint issues for unknown status field")
+	}
+
+	entity.Workflow.StatusField = "status"
+	entity.Workflow.Actions["submit"] = WorkflowAction{From: []string{"Unknown"}, To: "Missing"}
+	issues = Lint(map[string]*Entity{"test.Ticket": entity})
+	if len(issues) < 2 {
+		t.Fatalf("expected issues for unknown workflow states, got %#v", issues)
+	}
+}
+
+func writeDSLFile(t *testing.T, dsl string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entities.dsl")
+	if err := os.WriteFile(path, []byte(dsl), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
### Motivation
- Implement the first minimal vertical slice for workflow-driven action proposals: validate and execute declared status transitions using existing DSL and runtime semantics while remaining additive and backward compatible.
- Provide a discovery surface so clients (including agent clients later) can see declared actions via the Meta API without changing existing CRUD contracts.
- Keep changes small and safe: only status-field transitions are supported, no approvals, no side effects, and workflow metadata is optional.

### Description
- Add optional workflow metadata to the schema model (`internal/schema/model.go`) with `workflow.status_field` and per-action `from`/`to` declarations. 
- Extend the DSL parser (`internal/schema/parser.go`) to parse an additive `workflow:` block and add lint checks (`internal/schema/lint.go`) to validate the presence of the `status` field and that action states match inline enum values when applicable. 
- Implement a focused runtime executor `ExecuteWorkflowAction` in `internal/runtime/actions.go` that validates action existence, checks optimistic `record_version` when provided, enforces allowed `from` states, updates only the configured status field, increments `version`, and updates the timestamp. 
- Add a new HTTP handler and route `POST /api/:module/:entity/:id/_actions/:action` in `internal/http/actions.go` and register it in `internal/http/router.go`, and expose workflow metadata in the entity meta response via `internal/http/meta.go`. 
- Add a minimal example entity `test.WorkflowTask` in `dsl/core/entities.dsl`, focused unit tests for parser/lint (`internal/schema/workflow_test.go`), runtime behavior (`internal/runtime/actions_test.go`), and HTTP integration (`internal/http/actions_test.go`), and a change report at `docs/ai-shift/05-change-report.md`.

### Testing
- Ran parser and lint tests with `go test ./internal/schema` and all tests passed. 
- Ran runtime unit tests with `go test ./internal/runtime` and all tests passed. 
- Ran HTTP handler tests with `go test ./internal/http` and all tests passed. 
- Ran the full test set with `go test ./...` and relevant packages completed successfully (no remaining failing tests in affected packages). 
- Note: an import-cycle regression and a test expectation (If-Match usage) were detected and fixed during implementation, after which the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa2e405d08324a7778f6f041796ea)