### PR TITLE
Add focused CI workflow to verify first workflow-action slice

### DIFF
--- a/.github/workflows/first-slice-verification.yml
+++ b/.github/workflows/first-slice-verification.yml
@@ -1,0 +1,47 @@
+name: First Slice Verification
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/first-slice-verification.yml'
+      - 'internal/schema/**'
+      - 'internal/runtime/**'
+      - 'internal/http/**'
+      - 'docs/ai-shift/**'
+      - 'go.mod'
+      - 'go.sum'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/first-slice-verification.yml'
+      - 'internal/schema/**'
+      - 'internal/runtime/**'
+      - 'internal/http/**'
+      - 'docs/ai-shift/**'
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch:
+
+jobs:
+  first-slice-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify schema workflow tests
+        run: go test ./internal/schema -run Workflow -count=1
+
+      - name: Verify runtime workflow action tests
+        run: go test ./internal/runtime -run 'TestExecuteWorkflowAction(ReturnsProposalForValidTransition|RejectsDisallowedState|RejectsUnknownAction|RejectsVersionMismatch)$' -count=1
+
+      - name: Verify HTTP workflow action handler tests
+        run: go test ./internal/http -run 'TestActionHandler(ReturnsProposalAndMetaWorkflow|ReturnsConflictOnStaleVersion|RejectsMissingRecordVersion|RejectsIgnoredPayloadFields)$' -count=1 -v

--- a/docs/ai-shift/10-ci-verification.md
+++ b/docs/ai-shift/10-ci-verification.md
@@ -1,0 +1,15 @@
+# First-slice CI verification
+
+## Added CI check
+- Added a dedicated GitHub Actions workflow: `.github/workflows/first-slice-verification.yml`.
+- The workflow is intentionally narrow: it only verifies the first workflow-action slice test commands and can be run in GitHub Actions through pull requests, pushes to `main`, or `workflow_dispatch`.
+
+## Commands run by CI
+- `go test ./internal/schema -run Workflow -count=1`
+- `go test ./internal/runtime -run 'TestExecuteWorkflowAction(ReturnsProposalForValidTransition|RejectsDisallowedState|RejectsUnknownAction|RejectsVersionMismatch)$' -count=1`
+- `go test ./internal/http -run 'TestActionHandler(ReturnsProposalAndMetaWorkflow|ReturnsConflictOnStaleVersion|RejectsMissingRecordVersion|RejectsIgnoredPayloadFields)$' -count=1 -v`
+
+## How to use this before approving future slices
+- Treat this workflow as the minimum CI gate for the first workflow slice.
+- Before approving follow-on workflow slices, confirm this GitHub Actions check passes in CI instead of relying only on local timing in timeout-prone environments.
+- Keep broader test expansion separate from this check unless a future slice explicitly widens the approval baseline.


### PR DESCRIPTION
### Motivation
- Local verification of the first workflow-action slice is unreliable because the focused HTTP tests can hang in this environment, so a CI gate is needed to validate the slice in a normal runner.  
- The change must be minimal and narrowly scoped to the first slice tests to avoid touching production code or widening the test baseline.  
- Providing a repeatable GitHub Actions check lets reviewers rely on CI instead of local timing-sensitive runs before approving follow-on slices.  

### Description
- Add a new GitHub Actions workflow at `/.github/workflows/first-slice-verification.yml` that triggers on `pull_request` (path filters), `push` to `main`, and `workflow_dispatch`.  
- The workflow runs three narrowly scoped test steps that execute the first-slice verification commands for schema, runtime, and HTTP handlers.  
- Add documentation at `docs/ai-shift/10-ci-verification.md` describing what CI check was added, the exact commands it runs, and guidance for using this check before approving future slices.  

### Testing
- Ran `go test ./internal/schema -run Workflow -count=1` which completed successfully in this environment.  
- Ran `go test ./internal/runtime -run 'TestExecuteWorkflowAction(ReturnsProposalForValidTransition|RejectsDisallowedState|RejectsUnknownAction|RejectsVersionMismatch)$' -count=1` which completed successfully in this environment.  
- Attempted `go test ./internal/http -run 'TestActionHandler(ReturnsProposalAndMetaWorkflow|ReturnsConflictOnStaleVersion|RejectsMissingRecordVersion|RejectsIgnoredPayloadFields)$' -count=1 -v` which hung in this local environment, so the workflow was added to run that command reliably in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb309794083249cf8da3a83e7c4cf)