### PR TITLE
Add local first-slice verification script

### DIFF
--- a/docs/ai-shift/10-ci-verification.md
+++ b/docs/ai-shift/10-ci-verification.md
@@ -1,15 +1,15 @@
 # First-slice CI verification
 
-## Added CI check
-- Added a dedicated GitHub Actions workflow: `.github/workflows/first-slice-verification.yml`.
-- The workflow is intentionally narrow: it only verifies the first workflow-action slice test commands and can be run in GitHub Actions through pull requests, pushes to `main`, or `workflow_dispatch`.
+## Local verification command
+- Run `./scripts/verify-first-slice.sh` before merge to verify the first workflow-action slice in a normal local environment.
+- The script prints each verification step, stops on the first failure, and returns a non-zero exit code when any command fails.
 
-## Commands run by CI
+## Commands run by the local script
 - `go test ./internal/schema -run Workflow -count=1`
 - `go test ./internal/runtime -run 'TestExecuteWorkflowAction(ReturnsProposalForValidTransition|RejectsDisallowedState|RejectsUnknownAction|RejectsVersionMismatch)$' -count=1`
 - `go test ./internal/http -run 'TestActionHandler(ReturnsProposalAndMetaWorkflow|ReturnsConflictOnStaleVersion|RejectsMissingRecordVersion|RejectsIgnoredPayloadFields)$' -count=1 -v`
 
 ## How to use this before approving future slices
-- Treat this workflow as the minimum CI gate for the first workflow slice.
-- Before approving follow-on workflow slices, confirm this GitHub Actions check passes in CI instead of relying only on local timing in timeout-prone environments.
+- Treat `./scripts/verify-first-slice.sh` as the minimum local gate for the first workflow slice.
+- Run the script before merge instead of depending on a dedicated GitHub Actions workflow for this narrow verification slice.
 - Keep broader test expansion separate from this check unless a future slice explicitly widens the approval baseline.

--- a/scripts/verify-first-slice.sh
+++ b/scripts/verify-first-slice.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_step() {
+  local description="$1"
+  shift
+
+  echo
+  echo "==> ${description}"
+  echo "+ $*"
+  "$@"
+}
+
+run_step \
+  "Running schema workflow tests" \
+  go test ./internal/schema -run Workflow -count=1
+
+run_step \
+  "Running runtime workflow action tests" \
+  go test ./internal/runtime -run 'TestExecuteWorkflowAction(ReturnsProposalForValidTransition|RejectsDisallowedState|RejectsUnknownAction|RejectsVersionMismatch)$' -count=1
+
+run_step \
+  "Running HTTP workflow handler tests" \
+  go test ./internal/http -run 'TestActionHandler(ReturnsProposalAndMetaWorkflow|ReturnsConflictOnStaleVersion|RejectsMissingRecordVersion|RejectsIgnoredPayloadFields)$' -count=1 -v
+
+echo
+
+echo "First workflow slice verification passed."


### PR DESCRIPTION
### Motivation
- Provide a simple local command developers can run before merge to verify the first workflow-action slice instead of depending on a narrow GitHub Actions job. 
- Keep the change minimal and non-invasive by adding a lightweight script and a short doc update that do not alter production code.

### Description
- Add `scripts/verify-first-slice.sh`, a small bash script that prints each step, stops on failure (`set -euo pipefail`), and returns non-zero on error. 
- The script runs the focused verification commands for the first slice: `go test ./internal/schema -run Workflow -count=1`, `go test ./internal/runtime -run 'TestExecuteWorkflowAction(ReturnsProposalForValidTransition|RejectsDisallowedState|RejectsUnknownAction|RejectsVersionMismatch)$' -count=1`, and `go test ./internal/http -run 'TestActionHandler(ReturnsProposalAndMetaWorkflow|ReturnsConflictOnStaleVersion|RejectsMissingRecordVersion|RejectsIgnoredPayloadFields)$' -count=1 -v`.
- Update `docs/ai-shift/10-ci-verification.md` to document running `./scripts/verify-first-slice.sh` as the local minimum gate for the first workflow slice.
- Skills used: none (change is small and self-contained, no special skill workflow required).

### Testing
- Ran `./scripts/verify-first-slice.sh`, which executed the three focused test commands and completed successfully (all tests passed). 
- Commands run by the script and verified to pass locally were: `go test ./internal/schema -run Workflow -count=1`, `go test ./internal/runtime -run 'TestExecuteWorkflowAction(ReturnsProposalForValidTransition|RejectsDisallowedState|RejectsUnknownAction|RejectsVersionMismatch)$' -count=1`, and `go test ./internal/http -run 'TestActionHandler(ReturnsProposalAndMetaWorkflow|ReturnsConflictOnStaleVersion|RejectsMissingRecordVersion|RejectsIgnoredPayloadFields)$' -count=1 -v`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb54f84088324934fc2d59b4bd4f5)