### PR TITLE
docs: narrow second workflow action slice

### DIFF
--- a/docs/ai-shift/11-second-slice.md
+++ b/docs/ai-shift/11-second-slice.md
@@ -1,22 +1,23 @@
-# Second minimal vertical slice: reviewable workflow action requests
+# Second minimal vertical slice: persisted workflow action requests
 
 ## Proposed next slice
-The next smallest meaningful slice should add **submission and persistence of a workflow action request** after proposal validation, without executing the action.
+The next smallest meaningful slice should add **create-and-retrieve of a validated workflow action request** after proposal validation, without executing the action and without introducing approval workflow behavior.
 
 In concrete terms:
 - the existing workflow action endpoint continues to support **proposal-only validation**;
-- a new additive endpoint lets a client say **"submit this validated action proposal for review"**;
-- Kalita stores a small immutable request record that captures the requested action, the target record/version, the computed transition preview, and basic submission metadata;
-- the requested business record is **not** mutated, and no committed transition path is introduced yet.
+- a new additive endpoint lets a client say **"create a request from this validated proposal"**;
+- Kalita stores a **minimal server-tracked request artifact** that captures the validated action intent and preview;
+- a client can retrieve that stored request by ID;
+- the requested business record is **not** mutated, and no approval or execution path is introduced yet.
 
-This is the narrowest step from "validate an action" toward an actual **execution-control layer** because it adds a durable control object between intent and execution.
+This is the narrowest step from "validate an action" toward an execution-control layer because it adds exactly one persisted-in-runtime control object between intent and any later execution work.
 
 ---
 
 ## New capability introduced
 This slice introduces one new capability:
 
-### A durable execution-intent envelope for workflow actions
+### A minimal persisted request artifact for workflow actions
 Today, Kalita can validate that:
 - an action exists,
 - the action is allowed from the current status,
@@ -24,19 +25,20 @@ Today, Kalita can validate that:
 - and the system can compute the `from` → `to` proposal preview.
 
 With the second slice, Kalita would also be able to:
-- accept a request to **submit** that proposal,
-- persist a reviewable record of the request,
-- assign it a stable request ID,
-- expose its current review state (initially just something like `pending`),
-- and let clients retrieve/list those requests later.
+- accept a request to **create** a stored action request from that validated proposal,
+- assign it a stable request ID within the running server instance,
+- persist the request in the current in-memory runtime store,
+- and let clients **retrieve that request by ID**.
 
-That is a meaningful control-plane capability because it turns a transient HTTP validation result into a **server-tracked execution request**.
+That is the entire control-plane gain for this slice: turning a transient HTTP validation result into a **server-tracked request artifact** that exists beyond the immediate request/response cycle of a single API call.
 
 What it still does **not** do:
 - no approval engine,
+- no review workflow,
 - no execution of the action,
 - no mutation of the target business record,
 - no role-based authorization redesign,
+- no list/discovery/meta expansion,
 - no generalized agent framework.
 
 ---
@@ -51,24 +53,24 @@ The first slice established:
 - an HTTP action endpoint,
 - and proposal-only execution.
 
-A submission/review-request slice reuses all of that. The new flow would be:
+A request-creation slice reuses all of that. The new flow would be:
 1. validate the action exactly as today,
-2. snapshot the validated proposal,
-3. store it as a pending request.
+2. capture the validated action/from/to/version result,
+3. store it as a pending request,
+4. retrieve it later by request ID.
 
 That is a direct continuation, not a redesign.
 
-### 2. It moves toward execution control without enabling execution yet
+### 2. It moves toward execution control without enabling review or execution yet
 An execution-control layer needs a place where the system can say:
 - *this action was requested*,
-- *this is what was evaluated*,
-- *this is waiting for a later decision*.
+- *this is what was validated at request time*,
+- *this request now has a stable server-side identifier*.
 
 Persisting a request object creates that seam. It is the minimal predecessor to any future:
-- review,
 - approval,
-- audit,
-- or explicit execute-approved-action behavior.
+- audit expansion,
+- or explicit execute-request behavior.
 
 ### 3. It stays safer than adding commit mode next
 Adding immediate committed execution would widen risk quickly:
@@ -78,10 +80,10 @@ Adding immediate committed execution would widen risk quickly:
 - future authorization coupling,
 - ambiguity about whether actions and CRUD should share exactly the same mutation pipeline.
 
-By contrast, storing a request record is bounded and reversible in architectural impact. It creates control-plane structure first, before allowing controlled execution.
+By contrast, storing a minimal request record is bounded and reversible in architectural impact. It creates control-plane structure first, before allowing controlled execution.
 
-### 4. It creates a durable API contract that future slices can reuse
-If a later slice adds approval or execution, it can operate on a stored request ID rather than on a one-shot HTTP call. That is a cleaner and safer progression than jumping straight from proposal preview to mutation.
+### 4. It creates a reusable seam without expanding API surface prematurely
+A later slice can build approval, execution, or list/discoverability behavior on top of a stored request ID. This slice does not need to expose those broader surfaces yet. It only needs the smallest proof that a validated action proposal can become a retrievable request artifact.
 
 ### 5. It remains backward-compatible
 The existing proposal endpoint can remain unchanged. Existing clients that only validate actions do not need to change. The new behavior can be entirely additive.
@@ -92,22 +94,21 @@ The existing proposal endpoint can remain unchanged. Existing clients that only 
 The second slice should be intentionally narrow.
 
 ### In scope
-1. **A new additive request type for workflow action submissions**
-   - A new internal model such as `WorkflowActionRequest` or `ActionSubmission`.
-   - It stores:
+1. **A minimal request artifact for validated workflow action submissions**
+   - A new internal model such as `WorkflowActionRequest` or `ActionRequest`.
+   - It stores only the fields required for this slice:
      - request ID,
      - entity FQN,
      - target record ID,
      - target `record_version`,
      - action name,
-     - status field,
-     - `from` and `to` states,
-     - proposal snapshot,
+     - validated `from` state,
+     - validated `to` state,
      - request state (`pending` only in this slice),
-     - timestamps,
-     - optional minimal submitter metadata if already available in request context.
+     - created/updated timestamps.
+   - No reviewer metadata, queue metadata, comments, or broad proposal blobs are required.
 
-2. **A new additive HTTP submission endpoint**
+2. **A new additive HTTP creation endpoint**
    Conceptually something like:
    - `POST /api/:module/:entity/:id/_actions/:action/requests`
 
@@ -116,30 +117,34 @@ The second slice should be intentionally narrow.
    - creates and stores a pending action request;
    - returns the stored request document.
 
-3. **A small read surface for the stored request**
-   At minimum one of:
+3. **A single read path for the stored request**
+   At minimum one route such as:
    - `GET /api/_action_requests/:id`, or
    - `GET /api/:module/:entity/:id/_action_requests/:request_id`
 
-   The exact route can follow Kalita's current API style, but the slice should include at least one retrieval path so the persisted object is testable and inspectable.
+   The exact route can follow Kalita's current API style, but the slice should include **one get-by-id retrieval path only** so the persisted object is testable and inspectable.
 
-4. **Meta/API discoverability updates where useful**
-   If the Meta API already exposes workflow actions, it may add an optional hint that an entity supports request submission in addition to proposal validation. This should be additive only.
-
-5. **Tests for persistence and non-mutation guarantees**
-   The slice must prove that creating a request does not change the target record.
+4. **Tests for persistence-in-runtime and non-mutation guarantees**
+   The slice must prove that creating a request:
+   - stores the request artifact in the running instance,
+   - does not change the target record,
+   - and allows retrieval of the same request by ID.
 
 ### Explicitly out of scope within this slice
 - approving a request,
-- rejecting a request via workflow logic,
-- executing a pending request,
+- rejecting a request,
+- reviewer assignment,
+- execution of a pending request,
 - expiring requests,
 - deduplicating semantically identical requests,
 - policy/risk scoring,
 - human/agent auth model changes,
 - side effects or notifications,
 - generic command bus/orchestrator abstractions,
-- migrations to durable SQL-backed storage.
+- request collection/list endpoints,
+- meta/discoverability exposure,
+- migrations to durable SQL-backed storage,
+- any restart-stable persistence guarantee.
 
 ---
 
@@ -148,41 +153,41 @@ This slice should remain close to the modules already involved in the first slic
 
 ### Runtime / storage
 - `internal/runtime/actions.go`
-  - keep the existing proposal validator as the source of truth for action legality.
-  - add a small helper that converts a valid proposal into a persisted request object.
+  - keep the existing proposal validator as the source of truth for action legality;
+  - add a small helper that converts a valid proposal into a minimal stored request object.
 
 - `internal/runtime/storage.go` or the runtime storage file that currently owns in-memory state
-  - add an in-memory collection for action requests.
+  - add an in-memory collection for action requests;
   - add ID generation and lookup helpers.
 
 - **Possible new file:** `internal/runtime/action_requests.go`
-  - define the request model and request-store helpers.
+  - define the minimal request model and request-store helpers;
   - keep request persistence logic separate from HTTP concerns.
 
 ### HTTP
 - `internal/http/actions.go`
-  - keep the current proposal endpoint unchanged.
-  - add a new handler for submission.
+  - keep the current proposal endpoint unchanged;
+  - add a new handler for request creation.
 
 - `internal/http/router.go`
-  - register the new submission and retrieval routes.
+  - register the new create route and one get route.
 
 - **Possible new file:** `internal/http/action_requests.go`
-  - add focused handlers for create/get/list request resources.
+  - add focused handlers for create and get request resources.
 
 ### Schema / metadata
-- likely **no DSL grammar changes required** for this slice.
-- possibly `internal/http/meta.go` if optional discoverability fields are added.
+- **no DSL grammar changes required** for this slice;
+- **no Meta API changes required** for this slice.
 
-That is an important part of why this is the right next step: the second slice can advance the execution-control boundary **without expanding the DSL again**.
+That is an important part of why this is the right next step: the second slice can advance the execution-control boundary **without expanding the DSL or meta surface again**.
 
 ### Tests
 - `internal/runtime/actions_test.go`
-  - keep proposal tests intact.
-  - add submission persistence and non-mutation coverage.
+  - keep proposal tests intact;
+  - add request creation, retrieval, and non-mutation coverage.
 
 - `internal/http/actions_test.go`
-  - add endpoint coverage for submit-and-read request flows.
+  - add endpoint coverage for create-and-get request flows.
 
 If existing test files become crowded, a new `internal/http/action_requests_test.go` would be reasonable.
 
@@ -198,31 +203,32 @@ The slice should commit to the following guarantees.
 - It still does not create a request implicitly.
 
 ### 2. No DSL changes required
-Entities that already declare workflow actions should automatically support request submission.
+Entities that already declare workflow actions should automatically support request creation.
 - No new required YAML/DSL syntax.
 - No schema migration burden for current models.
 
 ### 3. Existing CRUD behavior remains unchanged
 Create/read/update/patch/delete semantics remain exactly as they are today.
-- Submitting an action request does not alter CRUD contracts.
+- Creating an action request does not alter CRUD contracts.
 - Direct CRUD writes are not blocked by the existence of pending requests in this slice.
 
-### 4. Target records are never mutated by request submission
-A successful request submission:
+### 4. Target records are never mutated by request creation
+A successful request creation:
 - does not update the target record status,
 - does not increment the target record version,
 - does not alter unrelated fields,
 - does not change existing action-proposal semantics.
 
 ### 5. New API surface is additive only
-Clients that do not know about request submission can ignore it safely.
+Clients that do not know about request creation can ignore it safely.
 - No current endpoint is removed.
 - No current response contract is narrowed.
 
-### 6. Request persistence is internal-state additive, not a storage redesign
-The slice may store requests in the existing in-memory runtime store for now.
-- No commitment to long-term durable persistence yet.
-- No immediate dependency on PostgreSQL or schema migrations.
+### 6. Persistence expectations are explicitly limited
+The request artifact is persisted only in the current in-memory runtime store for this slice.
+- It is server-tracked within a running instance.
+- It is **not** guaranteed to survive process restarts.
+- It does **not** imply SQL-backed durability, migrations, or cross-instance persistence.
 
 ---
 
@@ -230,37 +236,37 @@ The slice may store requests in the existing in-memory runtime store for now.
 The second slice should be testable with a compact, explicit matrix.
 
 ### Runtime tests
-1. **Submit valid request from a valid proposal**
+1. **Create valid request from a valid proposal**
    - given a record in `Draft`,
-   - when `submit` is requested with the matching `record_version`,
+   - when request creation is submitted with the matching `record_version`,
    - then an action request is created with state `pending` and the correct `from`/`to` snapshot.
 
-2. **Submission reuses proposal validation rules**
+2. **Request creation reuses proposal validation rules**
    - unknown action is rejected,
    - disallowed source state is rejected,
    - stale `record_version` is rejected.
 
-3. **Submission does not mutate target record**
+3. **Request creation does not mutate target record**
    - record status remains unchanged,
    - record version remains unchanged,
    - timestamps on the target record remain unchanged.
 
-4. **Stored request is immutable enough for the slice contract**
-   - proposal snapshot in the request remains the computed snapshot from submission time.
-
-5. **Retrieval returns the same stored request**
+4. **Retrieval returns the same stored request**
    - get by request ID returns the expected request payload.
 
+5. **Stored request reflects the validated submission-time preview**
+   - the stored `from`, `to`, action, and `record_version` match the values computed during creation.
+
 ### HTTP integration tests
-6. **POST submission route returns created request**
+6. **POST creation route returns created request**
    - returns 201 or the chosen success status,
    - includes request ID and `pending` state,
-   - includes target entity/id/action/from/to snapshot.
+   - includes target entity/id/action/from/to fields.
 
 7. **GET request route returns the stored request**
    - request can be fetched after creation.
 
-8. **Invalid submission returns same error shape as proposal validation**
+8. **Invalid creation returns the same error shape as proposal validation**
    - version conflict,
    - unknown action,
    - invalid state.
@@ -268,108 +274,124 @@ The second slice should be testable with a compact, explicit matrix.
 9. **Proposal route remains unchanged**
    - existing first-slice tests continue to pass unchanged.
 
-10. **Submission does not change underlying record fetch result**
-   - reading the original record after submission shows the original status/version.
-
-### Optional meta tests
-11. **Meta output stays backward compatible**
-   - if request-submission hints are added, old fields remain unchanged and new fields are optional.
+10. **Request creation does not change underlying record fetch result**
+   - reading the original record after request creation shows the original status/version.
 
 ---
 
 ## Risks
 This slice is intentionally low-risk, but there are still a few design hazards to contain.
 
-### 1. Accidental drift between proposal and submission validation
-If proposal and submission use separate validation paths, they may diverge.
+### 1. Accidental drift between proposal and request-creation validation
+If proposal and request creation use separate validation paths, they may diverge.
 
 **Mitigation:**
-- submission must call the same runtime action-validation helper already used by the proposal endpoint.
+- request creation must call the same runtime action-validation helper already used by the proposal endpoint;
 - avoid re-encoding action legality in the HTTP layer.
 
-### 2. Implicitly creating a review/approval model that is too broad
+### 2. Implicitly creating an approval model that is too broad
 Once requests are persisted, it is tempting to add reviewers, approvals, comments, queues, and policies immediately.
 
 **Mitigation:**
-- keep request state minimal, ideally just `pending` in this slice.
-- do not add approval transitions yet.
+- keep request state minimal, ideally just `pending` in this slice;
+- do not add approval transitions;
+- do not add reviewer-oriented fields.
 
 ### 3. Overcommitting to storage shape too early
 A rich request model or relational design would make the slice larger than necessary.
 
 **Mitigation:**
-- store only the fields needed to preserve the validated action intent and preview.
+- store only the fields needed to preserve validated action intent and preview;
 - keep storage in-memory and internal for now.
 
 ### 4. Confusion between "request created" and "action executed"
-API consumers may misread a successful submission as a committed state change.
+API consumers may misread a successful request creation as a committed state change.
 
 **Mitigation:**
-- response fields should clearly distinguish request state from execution state.
-- include explicit markers such as `state: pending` and `committed: false` or equivalent semantics.
+- response fields should clearly distinguish request state from execution state;
+- document that request creation does not mutate the target record;
+- keep request state as `pending` only.
 
-### 5. Interaction with future direct CRUD writes
-If the target record changes after a request is submitted, the stored request may become stale.
+### 5. Misleading durability expectations
+Calling the artifact durable while storing it only in memory risks a misleading contract.
 
 **Mitigation:**
-- treat staleness handling as a later execution-time concern.
-- preserve the original target `record_version` in the request so future slices can detect drift.
+- describe the artifact as persisted in the running server instance, not restart-durable;
+- state explicitly that restart survival is out of scope for this slice.
 
 ---
 
 ## Why this slice remains bounded
-This slice is bounded because it introduces only one new durable artifact: **the action request record**.
+This slice is bounded because it introduces only one new persisted-in-runtime artifact: **the action request record**.
 
 It does **not** also introduce:
-- execution,
 - approval workflows,
+- execution,
 - authorization policy engines,
 - side effects,
 - DSL redesign,
 - background processing,
+- list/read collections,
+- meta/discoverability expansion,
 - or broad runtime refactoring.
 
 The implementation can remain small if it follows this boundary:
 - reuse the existing action proposal validator,
-- persist the resulting proposal as a pending request,
-- expose create/get APIs,
-- test non-mutation and retrieval.
+- persist the resulting validated action intent as a pending request,
+- expose create/get APIs only,
+- test non-mutation and retrieval,
+- and make in-memory persistence expectations explicit.
 
 That is a true vertical slice, but still a small one.
 
 ---
 
-## Explicit out-of-scope list
-To keep the second slice minimal, the following should be explicitly excluded:
-- executing approved requests,
-- commit flags on the current action route,
-- approval roles or reviewer assignment,
-- generic policy DSL or risk engine,
-- notifications/webhooks,
-- request comments/history threads,
-- bulk request submission,
-- cancellation semantics beyond simple deletion/no-op handling,
-- record locking,
-- idempotency-key infrastructure,
-- persistence beyond the current in-memory runtime,
-- any redesign of CRUD, workflow DSL, or handler architecture beyond what is required for this feature.
+## Exact items removed from scope
+- request list endpoints or collection reads,
+- meta/API discoverability updates,
+- reviewer metadata,
+- submitter metadata as a required field,
+- broad proposal snapshot blobs beyond minimal explicit fields,
+- approval/rejection transitions,
+- comments, queues, assignment, or history,
+- any claim of restart-stable durability,
+- storage/database migration work.
+
+## Exact items kept in scope
+- one additive request-creation endpoint,
+- reuse of the existing proposal validator,
+- one minimal in-memory request artifact,
+- one get-by-id retrieval endpoint,
+- explicit non-mutation guarantees for the target record,
+- tests covering create, get, validation reuse, and non-mutation.
+
+## Exact items postponed
+- list/filter/search request APIs,
+- discoverability/meta exposure,
+- richer request lifecycle states,
+- approval/review logic,
+- execution of pending requests,
+- dedupe/idempotency infrastructure,
+- notifications and policy hooks,
+- SQL-backed or restart-stable persistence.
 
 ---
 
 ## Concise summary
-The next minimal vertical slice should add **reviewable workflow action requests**:
+The next minimal vertical slice should add **create-and-get workflow action requests**:
 - keep the current action route proposal-only,
-- add a new additive endpoint that persists a validated action proposal as a `pending` request,
-- expose that request for later retrieval,
-- and still do **no execution**.
+- add a new additive endpoint that stores a validated action proposal as a minimal `pending` request,
+- expose that request by ID,
+- and still do **no approval and no execution**.
 
 ## Why this slice is safe
 It is safe because it does not widen the mutation boundary:
 - the target record is still not changed,
 - existing CRUD and proposal semantics stay intact,
 - the new behavior is additive,
-- and all validation continues to flow through the same workflow-action rules already introduced in the first slice.
+- request state remains minimal,
+- and persistence expectations are explicit: stored in memory for the running instance only.
 
 ## Why it is not too big
-It is not too big because it adds only one new concept: a persisted action-request object.
-It deliberately avoids approvals, execution, policy engines, side effects, storage redesign, and DSL expansion. That keeps the slice narrow, testable, and directly connected to the first workflow-action slice.
+It is not too big because it adds only one new concept: a minimal server-tracked request artifact.
+It deliberately avoids approvals, execution, list APIs, discoverability work, policy engines, side effects, storage redesign, and DSL expansion. That keeps the slice narrow, testable, and directly connected to the first workflow-action slice.


### PR DESCRIPTION
### Motivation
- Align the second-slice specification with the review guidance by reducing scope to the smallest safe implementation: a create-and-get request artifact for validated workflow actions. 
- Remove approval/review, list/discoverability, and broad request-shape expansion so the slice remains clearly additive and low-risk. 
- Make durability expectations explicit and non-misleading by limiting persistence to the in-memory runtime for this slice.

### Description
- Edited `docs/ai-shift/11-second-slice.md` to replace the previous "submission/review" narrative with a focused "create-and-retrieve" scope that requires exactly one create route and one get-by-id route. 
- Reduced the required request artifact to a minimal set of fields: `request_id`, `entity FQN`, `record_id`, `record_version`, `action`, validated `from` and `to`, `state: pending`, and timestamps; removed reviewer/submitter metadata and broad proposal blobs. 
- Removed list/collection and meta/discoverability work from scope and postponed SQL/migration or restart-durable persistence; clarified that the request is persisted only in the running in-memory runtime and is not restart-durable. 
- Updated the affected-files guidance and test-plan to reflect only `internal/runtime` helpers for request storage, `internal/http` create/get handlers, and tests proving non-mutation and retrieval behavior.

### Testing
- This change is documentation-only; no automated unit or integration tests were modified or run as part of this PR. 
- The change does not affect runtime behavior or test suites; existing automated tests remain applicable and unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfdc4729188324804ce2a76a509d9a)