### PR TITLE
Add in-memory workflow action requests (create + get)

### DIFF
--- a/docs/ai-shift/13-second-slice-change-report.md
+++ b/docs/ai-shift/13-second-slice-change-report.md
@@ -1,0 +1,26 @@
+# Second slice change report
+
+## What changed
+- Added a minimal in-memory `WorkflowActionRequest` model and runtime helpers to create a pending request from the existing validated workflow proposal path and retrieve it by request ID.
+- Added one additive HTTP creation route for workflow action requests and one get-by-id route for stored requests.
+- Reused the existing workflow action request body parsing and validation behavior so proposal validation rules remain the single source of truth.
+- Added focused runtime and HTTP tests for create, get, validation reuse, non-mutation, and proposal endpoint backward compatibility.
+
+## What stayed compatible
+- `POST /api/:module/:entity/:id/_actions/:action` remains proposal-only and does not create requests implicitly.
+- Workflow request creation still does not mutate the target record, update its status, or increment record version.
+- No DSL, meta, CRUD, or persistence-contract changes were introduced.
+
+## What is intentionally not implemented
+- No approval, rejection, assignment, comments, or richer request lifecycle.
+- No execution or commit behavior for pending requests.
+- No list endpoints, discoverability/meta expansion, or storage redesign.
+- No persistence beyond the current in-memory runtime instance.
+
+## Residual risks
+- Request artifacts are lost on server restart because storage is runtime-memory only.
+- The global get-by-id route is intentionally narrow; any future scoping or auth concerns remain unresolved for later slices.
+- Future execution slices will need to decide whether request replay should revalidate against current record state or rely on captured request data.
+
+## Next smallest step
+- Add a single explicit execute-pending-request path that revalidates version/state at execution time while keeping approval and list/discovery concerns out of scope.

--- a/internal/http/action_requests.go
+++ b/internal/http/action_requests.go
@@ -1,0 +1,63 @@
+package http
+
+import (
+	"net/http"
+	"time"
+
+	"kalita/internal/runtime"
+	"kalita/internal/validation"
+
+	"github.com/gin-gonic/gin"
+)
+
+func CreateActionRequestHandler(storage *runtime.Storage) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		fqn, action, req, ok := parseActionRequest(c, storage)
+		if !ok {
+			return
+		}
+
+		request, errs := runtime.CreateWorkflowActionRequest(storage, fqn, c.Param("id"), action, req.RecordVersion)
+		if len(errs) > 0 {
+			c.JSON(statusForErrors(toValidationErrors(errs)), gin.H{"errors": toValidationErrors(errs)})
+			return
+		}
+
+		c.JSON(http.StatusCreated, workflowActionRequestResponse(request))
+	}
+}
+
+func GetActionRequestHandler(storage *runtime.Storage) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		request, ok := runtime.GetWorkflowActionRequest(storage, c.Param("request_id"))
+		if !ok {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Action request not found"})
+			return
+		}
+		c.JSON(http.StatusOK, workflowActionRequestResponse(request))
+	}
+}
+
+func toValidationErrors(errs []runtime.ActionError) []validation.FieldError {
+	verrs := make([]validation.FieldError, 0, len(errs))
+	for _, err := range errs {
+		verrs = append(verrs, validation.FieldError{Code: err.Code, Field: err.Field, Message: err.Message})
+	}
+	return verrs
+}
+
+func workflowActionRequestResponse(request *runtime.WorkflowActionRequest) gin.H {
+	return gin.H{
+		"id":             request.ID,
+		"entity":         request.Entity,
+		"target_id":      request.TargetID,
+		"record_version": request.RecordVersion,
+		"action":         request.Action,
+		"status_field":   request.StatusField,
+		"from":           request.From,
+		"to":             request.To,
+		"state":          request.State,
+		"created_at":     request.CreatedAt.Format(time.RFC3339),
+		"updated_at":     request.UpdatedAt.Format(time.RFC3339),
+	}
+}

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -20,51 +20,14 @@ type actionRequest struct {
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		mod := c.Param("module")
-		ent := c.Param("entity")
-		id := c.Param("id")
-		action := c.Param("action")
-
-		fqn, ok := storage.NormalizeEntityName(mod, ent)
+		fqn, action, req, ok := parseActionRequest(c, storage)
 		if !ok {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Entity not found"})
 			return
 		}
 
-		var req actionRequest
-		dec := json.NewDecoder(bytes.NewReader(mustReadBody(c)))
-		dec.DisallowUnknownFields()
-		if err := dec.Decode(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
-			return
-		}
-		if req.Action != "" && req.Action != action {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
-				Code:    validation.ErrTypeMismatch,
-				Field:   "action",
-				Message: fmt.Sprintf("body action %q does not match path action %q", req.Action, action),
-			}}})
-			return
-		}
-		if req.RecordVersion <= 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
-				Code:    validation.ErrRequired,
-				Field:   "record_version",
-				Message: "record_version is required for workflow actions",
-			}}})
-			return
-		}
-
-		result, errs := runtime.ExecuteWorkflowAction(storage, fqn, id, action, req.RecordVersion)
+		result, errs := runtime.ExecuteWorkflowAction(storage, fqn, c.Param("id"), action, req.RecordVersion)
 		if len(errs) > 0 {
-			verrs := make([]validation.FieldError, 0, len(errs))
-			for _, err := range errs {
-				verrs = append(verrs, validation.FieldError{
-					Code:    err.Code,
-					Field:   err.Field,
-					Message: err.Message,
-				})
-			}
+			verrs := toValidationErrors(errs)
 			c.JSON(statusForErrors(verrs), gin.H{"errors": verrs})
 			return
 		}
@@ -82,6 +45,44 @@ func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
 			"record":       result.Record,
 		})
 	}
+}
+
+func parseActionRequest(c *gin.Context, storage *runtime.Storage) (string, string, actionRequest, bool) {
+	mod := c.Param("module")
+	ent := c.Param("entity")
+	action := c.Param("action")
+
+	fqn, ok := storage.NormalizeEntityName(mod, ent)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Entity not found"})
+		return "", "", actionRequest{}, false
+	}
+
+	var req actionRequest
+	dec := json.NewDecoder(bytes.NewReader(mustReadBody(c)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
+		return "", "", actionRequest{}, false
+	}
+	if req.Action != "" && req.Action != action {
+		c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+			Code:    validation.ErrTypeMismatch,
+			Field:   "action",
+			Message: fmt.Sprintf("body action %q does not match path action %q", req.Action, action),
+		}}})
+		return "", "", actionRequest{}, false
+	}
+	if req.RecordVersion <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+			Code:    validation.ErrRequired,
+			Field:   "record_version",
+			Message: "record_version is required for workflow actions",
+		}}})
+		return "", "", actionRequest{}, false
+	}
+
+	return fqn, action, req, true
 }
 
 func mustReadBody(c *gin.Context) []byte {

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -191,3 +191,93 @@ func testHTTPWorkflowStorage() (*runtime.Storage, *runtime.Record) {
 	st.Data["test.WorkflowTask"] = map[string]*runtime.Record{rec.ID: rec}
 	return st, rec
 }
+
+func TestCreateActionRequestAndGetByID(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandler(storage))
+	router.POST("/api/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
+	router.GET("/api/_action_requests/:request_id", GetActionRequestHandler(storage))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	createReq := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit/requests", bytes.NewReader(raw))
+	createReq.Header.Set("Content-Type", "application/json")
+	createW := httptest.NewRecorder()
+	router.ServeHTTP(createW, createReq)
+
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s", createW.Code, createW.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(createW.Body.Bytes(), &created); err != nil {
+		t.Fatalf("json.Unmarshal(create) error = %v", err)
+	}
+	requestID, _ := created["id"].(string)
+	if requestID == "" {
+		t.Fatalf("request id missing: %#v", created)
+	}
+	if created["entity"] != "test.WorkflowTask" || created["target_id"] != rec.ID {
+		t.Fatalf("unexpected request target = %#v", created)
+	}
+	if created["state"] != "pending" || created["from"] != "Draft" || created["to"] != "InApproval" {
+		t.Fatalf("unexpected request transition = %#v", created)
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/_action_requests/"+requestID, nil)
+	getW := httptest.NewRecorder()
+	router.ServeHTTP(getW, getReq)
+	if getW.Code != http.StatusOK {
+		t.Fatalf("get status = %d body=%s", getW.Code, getW.Body.String())
+	}
+	if getW.Body.String() != createW.Body.String() {
+		t.Fatalf("get body = %s, want %s", getW.Body.String(), createW.Body.String())
+	}
+}
+
+func TestCreateActionRequestReusesValidationAndProposalEndpointStaysCompatible(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandler(storage))
+	router.POST("/api/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
+
+	invalidBody, _ := json.Marshal(map[string]any{"record_version": 2})
+	invalidReq := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit/requests", bytes.NewReader(invalidBody))
+	invalidReq.Header.Set("Content-Type", "application/json")
+	invalidW := httptest.NewRecorder()
+	router.ServeHTTP(invalidW, invalidReq)
+	if invalidW.Code != http.StatusConflict {
+		t.Fatalf("invalid create status = %d body=%s", invalidW.Code, invalidW.Body.String())
+	}
+	if len(storage.ActionRequests) != 0 {
+		t.Fatalf("request store mutated after invalid create: %#v", storage.ActionRequests)
+	}
+
+	proposalBody, _ := json.Marshal(map[string]any{"record_version": 3})
+	proposalReq := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(proposalBody))
+	proposalReq.Header.Set("Content-Type", "application/json")
+	proposalW := httptest.NewRecorder()
+	router.ServeHTTP(proposalW, proposalReq)
+	if proposalW.Code != http.StatusOK {
+		t.Fatalf("proposal status = %d body=%s", proposalW.Code, proposalW.Body.String())
+	}
+	var proposalResp map[string]any
+	if err := json.Unmarshal(proposalW.Body.Bytes(), &proposalResp); err != nil {
+		t.Fatalf("json.Unmarshal(proposal) error = %v", err)
+	}
+	if proposalResp["committed"] != false {
+		t.Fatalf("committed = %v", proposalResp["committed"])
+	}
+	if len(storage.ActionRequests) != 0 {
+		t.Fatalf("proposal endpoint created request unexpectedly: %#v", storage.ActionRequests)
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -30,6 +30,8 @@ func RunServer(addr string, storage *runtime.Storage) {
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandler(storage))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
+		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))
 
 		r.POST("/api/admin/reload", AdminReloadHandler(storage))

--- a/internal/runtime/action_requests.go
+++ b/internal/runtime/action_requests.go
@@ -1,0 +1,59 @@
+package runtime
+
+import "time"
+
+type WorkflowActionRequest struct {
+	ID            string    `json:"id"`
+	Entity        string    `json:"entity"`
+	TargetID      string    `json:"target_id"`
+	RecordVersion int64     `json:"record_version"`
+	Action        string    `json:"action"`
+	StatusField   string    `json:"status_field"`
+	From          string    `json:"from"`
+	To            string    `json:"to"`
+	State         string    `json:"state"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+func CreateWorkflowActionRequest(storage *Storage, entityFQN, id, actionName string, expectedVersion int64) (*WorkflowActionRequest, []ActionError) {
+	result, errs := ExecuteWorkflowAction(storage, entityFQN, id, actionName, expectedVersion)
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	now := time.Now().UTC()
+	request := &WorkflowActionRequest{
+		ID:            storage.NewID(),
+		Entity:        result.Entity,
+		TargetID:      result.ID,
+		RecordVersion: result.Version,
+		Action:        result.Action,
+		StatusField:   result.StatusField,
+		From:          result.From,
+		To:            result.To,
+		State:         "pending",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	storage.Mu.Lock()
+	if storage.ActionRequests == nil {
+		storage.ActionRequests = make(map[string]*WorkflowActionRequest)
+	}
+	storage.ActionRequests[request.ID] = request
+	storage.Mu.Unlock()
+
+	return request, nil
+}
+
+func GetWorkflowActionRequest(storage *Storage, id string) (*WorkflowActionRequest, bool) {
+	storage.Mu.RLock()
+	defer storage.Mu.RUnlock()
+	request := storage.ActionRequests[id]
+	if request == nil {
+		return nil, false
+	}
+	copy := *request
+	return &copy, true
+}

--- a/internal/runtime/actions_test.go
+++ b/internal/runtime/actions_test.go
@@ -104,3 +104,56 @@ func workflowTestStorage() (*Storage, *Record) {
 	st.Data["test.WorkflowTask"] = map[string]*Record{rec.ID: rec}
 	return st, rec
 }
+
+func TestCreateWorkflowActionRequestStoresPendingRequestWithoutMutatingRecord(t *testing.T) {
+	t.Parallel()
+
+	storage, rec := workflowTestStorage()
+	beforeUpdated := rec.UpdatedAt
+
+	request, errs := CreateWorkflowActionRequest(storage, "test.WorkflowTask", rec.ID, "submit", 3)
+	if len(errs) > 0 {
+		t.Fatalf("CreateWorkflowActionRequest() errs = %#v", errs)
+	}
+	if request.ID == "" {
+		t.Fatalf("request ID is empty")
+	}
+	if request.Entity != "test.WorkflowTask" || request.TargetID != rec.ID {
+		t.Fatalf("unexpected request target = %#v", request)
+	}
+	if request.RecordVersion != 3 || request.Action != "submit" {
+		t.Fatalf("unexpected request payload = %#v", request)
+	}
+	if request.From != "Draft" || request.To != "InApproval" || request.State != "pending" {
+		t.Fatalf("unexpected request transition = %#v", request)
+	}
+	if got := rec.Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
+	if rec.Version != 3 {
+		t.Fatalf("version = %d, want 3", rec.Version)
+	}
+	if !rec.UpdatedAt.Equal(beforeUpdated) {
+		t.Fatalf("updated_at changed")
+	}
+	stored, ok := GetWorkflowActionRequest(storage, request.ID)
+	if !ok {
+		t.Fatalf("stored request %q not found", request.ID)
+	}
+	if *stored != *request {
+		t.Fatalf("stored request = %#v, want %#v", stored, request)
+	}
+}
+
+func TestCreateWorkflowActionRequestReusesProposalValidation(t *testing.T) {
+	t.Parallel()
+
+	storage, rec := workflowTestStorage()
+	_, errs := CreateWorkflowActionRequest(storage, "test.WorkflowTask", rec.ID, "submit", 2)
+	if len(errs) != 1 || errs[0].Code != "version_conflict" {
+		t.Fatalf("unexpected errs = %#v", errs)
+	}
+	if len(storage.ActionRequests) != 0 {
+		t.Fatalf("request store mutated on invalid proposal: %#v", storage.ActionRequests)
+	}
+}

--- a/internal/runtime/storage.go
+++ b/internal/runtime/storage.go
@@ -23,22 +23,24 @@ type Record struct {
 }
 
 type Storage struct {
-	Mu      sync.RWMutex
-	Schemas map[string]*schema.Entity        // FQN ("module.name") -> схема
-	Data    map[string]map[string]*Record    // FQN -> id -> запись
-	Enums   map[string]catalog.EnumDirectory // каталог enum'ов (если нужен на валидации/UI)
-	entropy io.Reader
-	Blob    blob.BlobStore
+	Mu             sync.RWMutex
+	Schemas        map[string]*schema.Entity     // FQN ("module.name") -> схема
+	Data           map[string]map[string]*Record // FQN -> id -> запись
+	ActionRequests map[string]*WorkflowActionRequest
+	Enums          map[string]catalog.EnumDirectory // каталог enum'ов (если нужен на валидации/UI)
+	entropy        io.Reader
+	Blob           blob.BlobStore
 }
 
 // NewStorage наполняет схемы/энумы и готов к работе
 func NewStorage(entities []*schema.Entity, enumCatalog map[string]catalog.EnumDirectory) *Storage {
 	src := rand.New(rand.NewSource(time.Now().UnixNano()))
 	s := &Storage{
-		Schemas: make(map[string]*schema.Entity),
-		Data:    make(map[string]map[string]*Record),
-		Enums:   enumCatalog,
-		entropy: ulid.Monotonic(src, 0),
+		Schemas:        make(map[string]*schema.Entity),
+		Data:           make(map[string]map[string]*Record),
+		ActionRequests: make(map[string]*WorkflowActionRequest),
+		Enums:          enumCatalog,
+		entropy:        ulid.Monotonic(src, 0),
 	}
 	for _, e := range entities {
 		fqn := e.Module + "." + e.Name


### PR DESCRIPTION
### Motivation
- Implement the narrowed second slice from `docs/ai-shift/11-second-slice.md`: allow turning a validated workflow action proposal into a server-tracked, in-memory request artifact and retrieve it by ID. 
- Reuse the existing proposal validation logic so the request creation path is a thin, additive layer on top of the current proposal preview behavior. 
- Keep strict compatibility and safety guarantees by avoiding any approval, execution, list, or durable storage changes and by ensuring the proposal endpoint remains unchanged. 

### Description
- Added a minimal runtime model `WorkflowActionRequest` and helpers `CreateWorkflowActionRequest` and `GetWorkflowActionRequest` in `internal/runtime/action_requests.go` and wired an in-memory `ActionRequests` map into `internal/runtime/storage.go`. 
- Implemented two HTTP handlers `CreateActionRequestHandler` and `GetActionRequestHandler` in `internal/http/action_requests.go`, factored request parsing into `parseActionRequest` in `internal/http/actions.go`, and registered the routes `POST /api/:module/:entity/:id/_actions/:action/requests` and `GET /api/_action_requests/:request_id` in `internal/http/router.go`. 
- The create flow calls the same `ExecuteWorkflowAction` validation used by the proposal endpoint and stores only a minimal pending request (id, entity, target id, record_version, action, status_field, from/to, state, timestamps) without mutating the target record. 
- Added focused tests and a short change report: updated `internal/runtime/actions_test.go` and `internal/http/actions_test.go` to cover create, get, validation reuse, non-mutation, and proposal-endpoint backward compatibility, and added `docs/ai-shift/13-second-slice-change-report.md`. 

### Testing
- Ran `go test ./internal/runtime` and the runtime tests passed. 
- Ran `go test ./internal/http` and the HTTP package tests (including the focused tests for create/get and compatibility) passed. 
- The new tests exercise `CreateWorkflowActionRequest` and `GetWorkflowActionRequest` behavior, verify that invalid proposals do not persist requests, and assert that the existing proposal endpoint remains proposal-only and does not mutate the target record.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe0869b7883248e2a8e0c572c30a8)