### PR TITLE
Prevent duplicate workflow action requests

### DIFF
--- a/docs/ai-shift/15-second-slice-concurrency-patch.md
+++ b/docs/ai-shift/15-second-slice-concurrency-patch.md
@@ -1,0 +1,22 @@
+# Second slice concurrency patch
+
+## What was fixed
+- Fixed the in-memory correctness gap where concurrent `CreateWorkflowActionRequest` calls could create multiple pending requests for the same logical action request.
+- The guarded duplicate case is the same `(entity, target_id, action, record_version)` being requested at the same time within one running server instance.
+
+## How duplicates are prevented
+- Request creation now derives a deterministic in-memory key from:
+  - entity,
+  - target record ID,
+  - action,
+  - record version.
+- The runtime store keeps a small key-to-request-ID index beside the existing request map.
+- After proposal validation succeeds, creation checks that key while holding the existing storage mutex:
+  - if a request already exists for the key, the existing request is returned;
+  - otherwise, the new request is inserted and the key is reserved.
+- This keeps behavior deterministic without expanding the API or redesigning persistence.
+
+## Residual risks
+- The guard is runtime-memory only, so it does not survive process restart.
+- The patch prevents duplicate request creation for the same logical key, but it does not redesign broader record/request concurrency semantics outside this slice.
+- If future slices introduce request deletion or terminal-state cleanup, they will also need to define whether and when the in-memory key can be released.

--- a/internal/runtime/action_requests.go
+++ b/internal/runtime/action_requests.go
@@ -1,6 +1,9 @@
 package runtime
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type WorkflowActionRequest struct {
 	ID            string    `json:"id"`
@@ -23,6 +26,22 @@ func CreateWorkflowActionRequest(storage *Storage, entityFQN, id, actionName str
 	}
 
 	now := time.Now().UTC()
+	key := workflowActionRequestKey(result.Entity, result.ID, result.Action, result.Version)
+
+	storage.Mu.Lock()
+	defer storage.Mu.Unlock()
+	if storage.ActionRequests == nil {
+		storage.ActionRequests = make(map[string]*WorkflowActionRequest)
+	}
+	if storage.ActionRequestKeys == nil {
+		storage.ActionRequestKeys = make(map[string]string)
+	}
+	if existingID, ok := storage.ActionRequestKeys[key]; ok {
+		if existing := storage.ActionRequests[existingID]; existing != nil {
+			copy := *existing
+			return &copy, nil
+		}
+	}
 	request := &WorkflowActionRequest{
 		ID:            storage.NewID(),
 		Entity:        result.Entity,
@@ -36,15 +55,14 @@ func CreateWorkflowActionRequest(storage *Storage, entityFQN, id, actionName str
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
-
-	storage.Mu.Lock()
-	if storage.ActionRequests == nil {
-		storage.ActionRequests = make(map[string]*WorkflowActionRequest)
-	}
 	storage.ActionRequests[request.ID] = request
-	storage.Mu.Unlock()
+	storage.ActionRequestKeys[key] = request.ID
 
 	return request, nil
+}
+
+func workflowActionRequestKey(entityFQN, id, actionName string, recordVersion int64) string {
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%d", entityFQN, id, actionName, recordVersion)
 }
 
 func GetWorkflowActionRequest(storage *Storage, id string) (*WorkflowActionRequest, bool) {

--- a/internal/runtime/actions_test.go
+++ b/internal/runtime/actions_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -155,5 +156,59 @@ func TestCreateWorkflowActionRequestReusesProposalValidation(t *testing.T) {
 	}
 	if len(storage.ActionRequests) != 0 {
 		t.Fatalf("request store mutated on invalid proposal: %#v", storage.ActionRequests)
+	}
+}
+
+func TestCreateWorkflowActionRequestDeduplicatesConcurrentCreates(t *testing.T) {
+	t.Parallel()
+
+	storage, rec := workflowTestStorage()
+
+	const attempts = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	results := make(chan *WorkflowActionRequest, attempts)
+	errsCh := make(chan []ActionError, attempts)
+
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			request, errs := CreateWorkflowActionRequest(storage, "test.WorkflowTask", rec.ID, "submit", 3)
+			results <- request
+			errsCh <- errs
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errsCh)
+
+	var requestID string
+	for errs := range errsCh {
+		if len(errs) > 0 {
+			t.Fatalf("CreateWorkflowActionRequest() errs = %#v", errs)
+		}
+	}
+	for request := range results {
+		if request == nil {
+			t.Fatalf("request is nil")
+		}
+		if requestID == "" {
+			requestID = request.ID
+			continue
+		}
+		if request.ID != requestID {
+			t.Fatalf("request ID = %q, want %q", request.ID, requestID)
+		}
+	}
+
+	if len(storage.ActionRequests) != 1 {
+		t.Fatalf("stored requests = %d, want 1", len(storage.ActionRequests))
+	}
+	if len(storage.ActionRequestKeys) != 1 {
+		t.Fatalf("stored request keys = %d, want 1", len(storage.ActionRequestKeys))
 	}
 }

--- a/internal/runtime/storage.go
+++ b/internal/runtime/storage.go
@@ -23,24 +23,26 @@ type Record struct {
 }
 
 type Storage struct {
-	Mu             sync.RWMutex
-	Schemas        map[string]*schema.Entity     // FQN ("module.name") -> схема
-	Data           map[string]map[string]*Record // FQN -> id -> запись
-	ActionRequests map[string]*WorkflowActionRequest
-	Enums          map[string]catalog.EnumDirectory // каталог enum'ов (если нужен на валидации/UI)
-	entropy        io.Reader
-	Blob           blob.BlobStore
+	Mu                sync.RWMutex
+	Schemas           map[string]*schema.Entity     // FQN ("module.name") -> схема
+	Data              map[string]map[string]*Record // FQN -> id -> запись
+	ActionRequests    map[string]*WorkflowActionRequest
+	ActionRequestKeys map[string]string
+	Enums             map[string]catalog.EnumDirectory // каталог enum'ов (если нужен на валидации/UI)
+	entropy           io.Reader
+	Blob              blob.BlobStore
 }
 
 // NewStorage наполняет схемы/энумы и готов к работе
 func NewStorage(entities []*schema.Entity, enumCatalog map[string]catalog.EnumDirectory) *Storage {
 	src := rand.New(rand.NewSource(time.Now().UnixNano()))
 	s := &Storage{
-		Schemas:        make(map[string]*schema.Entity),
-		Data:           make(map[string]map[string]*Record),
-		ActionRequests: make(map[string]*WorkflowActionRequest),
-		Enums:          enumCatalog,
-		entropy:        ulid.Monotonic(src, 0),
+		Schemas:           make(map[string]*schema.Entity),
+		Data:              make(map[string]map[string]*Record),
+		ActionRequests:    make(map[string]*WorkflowActionRequest),
+		ActionRequestKeys: make(map[string]string),
+		Enums:             enumCatalog,
+		entropy:           ulid.Monotonic(src, 0),
 	}
 	for _, e := range entities {
 		fqn := e.Module + "." + e.Name


### PR DESCRIPTION
### Motivation
- Fix a correctness bug where concurrent calls could create multiple pending workflow action requests for the same logical key `(entity, target_id, action, record_version)` in the in-memory runtime. 
- The existing flow validated proposals first and only recorded requests later, allowing races where two goroutines both validated the same record/version and each inserted a distinct request.

### Description
- Add a small in-memory dedupe index `ActionRequestKeys` to `Storage` that maps a deterministic key to a request ID to represent the logical tuple `(entity, id, action, record_version)`.
- During `CreateWorkflowActionRequest` derive the key with `workflowActionRequestKey(...)`, hold the storage mutex, check the index, and return an existing request if present; otherwise allocate the request ID inside the same lock and insert both the request and the key atomically.
- Move ID generation into the storage critical section to avoid ULID entropy races when creating IDs concurrently.
- Add a focused concurrent test `TestCreateWorkflowActionRequestDeduplicatesConcurrentCreates` and a short slice document `docs/ai-shift/15-second-slice-concurrency-patch.md` describing the fix and residual risks.
- Touched files: `internal/runtime/action_requests.go`, `internal/runtime/storage.go`, `internal/runtime/actions_test.go`, `docs/ai-shift/15-second-slice-concurrency-patch.md`.

### Testing
- Ran the focused runtime tests: `go test ./internal/runtime -run 'TestCreateWorkflowActionRequest(DeduplicatesConcurrentCreates|StoresPendingRequestWithoutMutatingRecord|ReusesProposalValidation)$' -count=1` and they passed.
- Ran the relevant HTTP tests: `go test ./internal/http -run 'Test(CreateActionRequestAndGetByID|CreateActionRequestReusesValidationAndProposalEndpointStaysCompatible)$' -count=1` and they passed.
- The added concurrent test verifies that multiple simultaneous create attempts observe the same request ID and only one request is stored in-memory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe8fa94008324bbb7d2e0d972725b)