### PR TITLE
Introduce case-centric operational layer into vNext architecture doc

### DIFF
--- a/docs/ai-shift/16-vnext-target-architecture.md
+++ b/docs/ai-shift/16-vnext-target-architecture.md
@@ -8,7 +8,7 @@ This document defines Kalita's target architecture as an event-driven enterprise
 ### From what -> to what
 Kalita must evolve:
 - from a schema-driven CRUD/meta platform with partial workflow proposal ideas
-- to an event-driven enterprise agent runtime built around `Event -> Command -> Execution`
+- to an event-driven enterprise agent runtime built around `Event -> Case -> Plan -> Execution`
 
 The operating center of gravity therefore moves:
 - from HTTP handlers mutating records directly
@@ -38,7 +38,7 @@ Digital employees are long-lived operational actors. They must:
 - retry safely after transient failures
 - expose deterministic execution history for audit and debugging
 
-That requires an event-driven runtime with durable execution state, explicit commands, and replayable history. The runtime must be the place where decisions become controlled actions.
+That requires an event-driven runtime with durable execution state, explicit commands, and replayable history. The runtime must be the place where decisions become controlled actions, but it cannot be the only business construct. Real departments operate through owned cases, staffed queues, and daily plans, so Kalita needs an operational layer between signals and execution.
 
 ## 2. Core architecture layers
 
@@ -85,8 +85,43 @@ Every event and command must carry:
 
 This turns opaque automation into traceable enterprise execution graphs.
 
-### Layer 2 - Execution Runtime
-The execution runtime converts events and commands into controlled multi-step work.
+### Layer 2 - Case-Centric Operations
+The operational layer converts events into department work before any execution starts. It is the missing business department model between raw signals and runtime mechanics.
+
+#### Why a case-centric layer is required
+A real department does not react to every event by immediately executing tools. It groups related facts into business matters, decides who owns them, places them into work queues, and plans the day before workers perform actions. Kalita therefore needs first-class operational objects for:
+- cases as the unit of departmental responsibility
+- queues as the unit of work intake and balancing
+- daily plans as the unit of managerial prioritization
+- assignments as the unit of accountability
+
+#### Case model
+A `Case` is the durable business container for a matter that may span many events, reviews, approvals, promises, and executions over time. Examples include:
+- a debt collection case for one debtor and invoice cluster
+- a dispute resolution case
+- a missing-document follow-up case
+
+Cases are not generic workflow records. They represent the department's active responsibility for an outcome.
+
+#### Work model
+The operational layer creates work items from cases instead of handing events directly to executors. This enables:
+- queue-based intake
+- employee assignment
+- manager-directed rebalancing
+- SLA monitoring by queue and stage
+- controlled carry-over from prior days
+
+#### Planning model
+A department works from a daily plan rather than a flat stream of triggers. Planning decides:
+- what must be handled today
+- what can wait
+- which employee owns which cases
+- which escalations or high-risk actions require manager attention
+
+Only after the case is in plan does Kalita authorize concrete execution steps.
+
+### Layer 3 - Execution Runtime
+The execution runtime converts planned case work into controlled multi-step work.
 
 #### ExecutionInstance
 An `ExecutionInstance` is the durable state machine for one business execution. It tracks:
@@ -126,7 +161,7 @@ Retries and timeouts are runtime semantics, not ad hoc handler code. Each execut
 - timeout budget
 - escalation path after repeated failure
 
-### Layer 3 - Digital Employees
+### Layer 4 - Digital Employees
 Digital employees are enterprise actors defined by responsibility boundaries, not chat personas.
 
 #### Role
@@ -158,7 +193,7 @@ Subscriptions determine when the runtime considers that employee for execution.
 #### Allowed actions
 Allowed actions enumerate which commands and tool contracts the employee may request. This prevents accidental overreach and creates a deterministic control surface.
 
-### Layer 4 - Policy & Control
+### Layer 5 - Policy & Control
 Policy is mandatory infrastructure between proposal and execution.
 
 #### Policy rules
@@ -196,7 +231,7 @@ Policy enforcement must occur at every action boundary:
 
 No execution path may bypass policy because of transport choice or LLM involvement.
 
-### Layer 5 - Tool System
+### Layer 6 - Tool System
 Tools are controlled execution adapters, not arbitrary model permissions.
 
 #### Tool definition
@@ -226,7 +261,7 @@ Tools execute only when:
 
 LLMs may recommend a tool call, but they never invoke tools directly.
 
-### Layer 6 - Observability
+### Layer 7 - Observability
 Observability must explain business execution, not only infrastructure events.
 
 #### Event log
@@ -260,7 +295,7 @@ Debugging should support:
 - deterministic re-run of non-side-effecting steps
 - side-by-side comparison of proposal vs approved execution
 
-### Layer 7 - Access Layer (NOT CORE)
+### Layer 8 - Access Layer (NOT CORE)
 The access layer provides compatibility and operator access, but it must not own execution semantics.
 
 #### CRUD (optional)
@@ -392,9 +427,104 @@ These are adapters onto the runtime and event model, not the architectural cente
 **Lifecycle role**
 - Travels with events, commands, approvals, and tool calls so policy and audit are actor-aware.
 
+### Case
+**Purpose**
+- Durable business container representing a matter the department is responsible for progressing to an outcome.
+
+**Fields**
+- `case_id`
+- `case_type`
+- `case_reference`
+- `status` (`open`, `active`, `waiting_customer`, `waiting_external`, `planned`, `in_progress`, `resolved`, `closed`, `cancelled`)
+- `stage` (department-specific stage such as `new`, `collector_review`, `promise_to_pay`, `escalated`, `legal_hold`)
+- `priority`
+- `severity`
+- `department`
+- `queue_id`
+- `owning_employee_id` (optional)
+- `managing_team_id`
+- `subject_type`
+- `subject_id`
+- `account_id` or `counterparty_id`
+- `opened_at`
+- `last_activity_at`
+- `next_review_at`
+- `sla_deadline_at`
+- `resolution_code` (optional)
+- `correlation_id`
+- `source_event_ids`
+
+**Lifecycle role**
+- Aggregates business events into a managed matter, holds responsibility and stage, and supplies the operational context from which plans and executions are derived.
+
+### WorkQueue
+**Purpose**
+- Department intake and balancing surface where cases compete for attention under explicit operational rules.
+
+**Fields**
+- `queue_id`
+- `name`
+- `department`
+- `queue_type` (`intake`, `specialist`, `manager_review`, `exception`, `follow_up`)
+- `entry_criteria`
+- `priority_policy`
+- `assignment_policy`
+- `capacity_policy`
+- `sla_policy`
+- `manager_role`
+- `status`
+
+**Lifecycle role**
+- Receives case-derived work, orders demand, and exposes assignable backlog to digital and human employees.
+
+### WorkItem
+**Purpose**
+- Concrete unit of departmental effort representing what an employee needs to advance on a case now.
+
+**Fields**
+- `work_item_id`
+- `case_id`
+- `queue_id`
+- `work_type`
+- `status` (`ready`, `planned`, `assigned`, `in_progress`, `blocked`, `done`, `cancelled`)
+- `required_role`
+- `assigned_employee_id` (optional)
+- `planned_for_date` (optional)
+- `priority_score`
+- `reason`
+- `due_at`
+- `created_from_event_id`
+- `created_at`
+- `completed_at` (optional)
+
+**Lifecycle role**
+- Bridges case state into daily actionable effort without losing case ownership or queue accountability.
+
+### DailyPlan
+**Purpose**
+- Explicit operational plan for what an employee or team should handle during a working day.
+
+**Fields**
+- `daily_plan_id`
+- `plan_date`
+- `department`
+- `employee_id` or `team_id`
+- `queue_scope`
+- `planning_status` (`draft`, `published`, `in_progress`, `completed`, `superseded`)
+- `planning_inputs`
+- `capacity_budget`
+- `priority_rules_snapshot`
+- `manager_overrides`
+- `planned_work_item_ids`
+- `created_at`
+- `published_at` (optional)
+
+**Lifecycle role**
+- Converts backlog into a bounded, prioritized sequence of case work for the day and records manager direction.
+
 ### DigitalEmployee
 **Purpose**
-- Configured enterprise actor that owns a bounded responsibility domain.
+- Configured enterprise actor that owns a bounded responsibility domain and operates like a department worker, not merely an executor.
 
 **Fields**
 - `digital_employee_id`
@@ -402,6 +532,10 @@ These are adapters onto the runtime and event model, not the architectural cente
 - `role`
 - `description`
 - `subscriptions`
+- `queue_memberships`
+- `case_types_owned`
+- `planning_policy`
+- `capacity_profile`
 - `capability_set`
 - `allowed_command_types`
 - `allowed_tool_ids`
@@ -411,7 +545,7 @@ These are adapters onto the runtime and event model, not the architectural cente
 - `version`
 
 **Lifecycle role**
-- Selected by runtime for qualifying events, then used to scope planning, proposals, and allowed actions.
+- Takes events into owned queues and cases, participates in plan formation, accepts assignments, and executes allowed actions while remaining accountable for case progression.
 
 ### DecisionProposal
 **Purpose**
@@ -513,41 +647,119 @@ These are adapters onto the runtime and event model, not the architectural cente
 **Lifecycle role**
 - Defines the only legal path for runtime tool execution and gives policy enough structure to control it.
 
-## 4. Execution lifecycle
+## 4. Operational flow: Event -> Case -> Plan -> Employee -> Execution
 1. **Event occurs**
-   - A business fact such as `document_uploaded` is appended to the event log with correlation, causation, and actor context.
+   - A business fact such as `invoice_overdue_detected`, `payment_promise_broken`, or `document_uploaded` is appended to the event log with correlation, causation, and actor context.
 
-2. **Runtime selects executor**
-   - Subscription rules identify candidate digital employees.
-   - Runtime resolves one execution plan owner based on role, capability, scope, and policy.
+2. **Event is correlated into a case**
+   - Case rules decide whether the event opens a new `Case`, reactivates an existing one, or enriches a current matter.
+   - The event updates case stage, deadlines, activity timestamps, and operational indicators such as broken-promise count or dispute status.
+   - A single case may accumulate many events over days or weeks; the department works the case, not isolated events.
 
-3. **Context is built**
-   - The runtime assembles `ActorContext`, event payload, relevant entity state, prior execution history, policy metadata, and referenced artifacts into a deterministic execution context.
+3. **Case generates work in a queue**
+   - Operational rules create or refresh one or more `WorkItem` objects for the case.
+   - The case is routed into a `WorkQueue` based on stage, risk, amount, customer segment, SLA pressure, or exception status.
+   - Queue membership expresses departmental demand and backlog, not yet execution.
 
-4. **LLM (optional) produces proposal**
-   - If the selected employee has proposal capabilities that benefit from model assistance, the LLM receives bounded context and returns a structured `DecisionProposal`.
-   - The proposal may recommend commands, evidence links, and rationale, but it does not execute tools or mutate state.
+4. **Daily planning selects what gets worked today**
+   - At planning time, Kalita builds `DailyPlan` objects per employee or team using queue backlog, SLA deadlines, capacity, priorities, and carry-over work.
+   - Prioritization is not just event recency; it reflects departmental intent such as collector cadence, promised follow-up dates, customer value, and manager escalations.
+   - Managers can override the machine-generated plan by pinning urgent cases, reserving capacity for a campaign, or rerouting high-risk matters to specialists.
 
-5. **Policy evaluates**
-   - Proposed commands and tool intents are checked against `PolicyRule` objects.
+5. **An employee accepts assigned case work**
+   - A `DigitalEmployee` or human employee works from its published queue slice and daily plan.
+   - Assignment rules can be round-robin, skill-based, relationship-based, territory-based, or manager-directed, but responsibility always resolves to a named owner.
+   - The employee becomes accountable for advancing the case stage, not merely executing one command.
+
+6. **Execution is started from planned work**
+   - When the employee begins a `WorkItem`, the runtime creates an `ExecutionInstance` tied to the case, work item, employee, and triggering event set.
+   - The runtime assembles `ActorContext`, case history, queue metadata, plan position, policy metadata, and referenced artifacts into a deterministic execution context.
+
+7. **LLM (optional) produces proposal**
+   - If the selected employee has proposal capabilities that benefit from model assistance, the LLM receives bounded case and plan context and returns a structured `DecisionProposal`.
+   - The proposal may recommend next-best actions, commands, evidence links, and rationale, but it does not execute tools or mutate state.
+
+8. **Policy and approvals evaluate the proposed action**
+   - Proposed commands and tool intents are checked against `PolicyRule` objects together with case stage, owner role, amount at risk, and managerial constraints.
    - The runtime records a `PolicyDecision` explaining whether the proposal is allowed, denied, or requires approval.
+   - If needed, the runtime emits `approval_requested`, persists an `ApprovalRequest`, and pauses the execution instance in `waiting_approval` until an approval outcome event arrives.
 
-6. **Approval (if needed)**
-   - If policy requires approval, the runtime emits `approval_requested`, persists an `ApprovalRequest`, and pauses the execution instance in `waiting_approval`.
-   - Approval outcomes re-enter as events such as `approval_granted` or `approval_rejected`.
+9. **Tool or action executes under control**
+   - Only after policy allows and approvals clear does the runtime invoke a `ToolDefinition` or emit a side-effecting command through the execution adapter.
+   - The invocation uses typed inputs, idempotency keys, timeout budgets, retry semantics, and the current case responsibility envelope.
 
-7. **Tool executes**
-   - Only after policy allows and approvals clear does the runtime invoke a `ToolDefinition` through the execution adapter.
-   - The invocation uses typed inputs, idempotency keys, timeout budgets, and retry semantics.
+10. **Results update both execution and operations**
+   - Tool outcomes and business results are turned into durable events such as `contact_attempt_logged`, `promise_to_pay_recorded`, `patch_applied`, or `tool_execution_failed`.
+   - Those results update the `ExecutionInstance`, the `Case` stage/lifecycle, queue ordering, next review date, and the next day's planning inputs.
+   - Kalita closes the work item only when the employee's operational responsibility for that step is satisfied; the case remains open until the business matter is actually resolved.
 
-8. **Result emitted as events**
-   - Tool outcomes and business results are turned into durable events such as `issues_detected`, `patch_applied`, or `tool_execution_failed`.
-   - These events may trigger downstream employees or follow-up steps.
+## 5. Operational model details
 
-9. **Execution state updated**
-   - The runtime records `ExecutionEvent` entries, updates the `ExecutionInstance` status, schedules retries or timers if needed, and marks the execution completed only when all required steps are finalized.
+### Case lifecycle
+A case lifecycle must reflect departmental operations rather than generic workflow statuses. A typical lifecycle is:
+- `open`: the matter has been created from one or more triggering events
+- `active`: the department has accepted responsibility and the case is in an owned queue
+- `planned`: the case has scheduled work in an employee or team daily plan
+- `in_progress`: a worker is currently performing an execution step on behalf of the case
+- `waiting_customer`: the department is waiting on debtor/customer response or promised action
+- `waiting_external`: the department is waiting on another system, department, or legal dependency
+- `resolved`: the operational outcome has been achieved and no further work is expected
+- `closed`: the case is administratively complete and removed from active queues
+- `cancelled`: the case was invalidated or merged into another case
 
-## 5. Mapping from current system
+Stages sit inside lifecycle states and are domain-specific. For example, an accounts receivable case may move through `new -> collector_review -> contact_due -> promise_to-pay -> escalation_review -> external_agency`. Stages explain what kind of departmental work is needed now, while lifecycle status explains whether the case is still operationally active.
+
+### Event-to-case relationship
+Events do not disappear after case creation. They continue to:
+- open cases when no matching responsibility container exists
+- enrich the evidence and history of an open case
+- change stage, urgency, or due dates
+- create new work items for follow-up
+- close or reopen cases when business conditions change
+
+The key correction is that execution is usually not triggered straight from the event. The event first changes operational reality, and then operational reality determines if and when execution is warranted.
+
+### Work queues and assignment rules
+Queues should feel like a department manager's whiteboard, not a transport retry table. Useful queue rules include:
+- **intake queue** for newly opened cases awaiting first touch
+- **follow-up queue** for cases whose next promised action date is today
+- **exception queue** for disputes, bounced emails, or policy blocks
+- **manager review queue** for high-value or high-risk matters
+- **specialist queue** for legal, multilingual, or enterprise-account handling
+
+Assignment rules should combine business reality and fairness:
+- fixed owner when an account already has a responsible collector
+- relationship-based routing to preserve continuity with the customer
+- skill-based routing for disputes, legal sensitivity, or language needs
+- capacity-aware balancing across employees in the same queue
+- manager-directed assignment for escalations or strategic accounts
+
+### Daily planning and manager influence
+`DailyPlan` is the mechanism that makes Kalita feel like a staffed department. Planning should account for:
+- backlog and SLA deadlines across queues
+- fixed-date follow-ups such as promised callbacks or payment dates
+- employee capacity budgets and shift constraints
+- aging, amount, customer tier, strategic importance, and collection strategy
+- carry-over work not completed yesterday
+
+Managers influence planning by:
+- pinning specific cases to the top of today's plan
+- reserving capacity for campaigns or month-end pushes
+- changing queue priority weights
+- approving reassignment between employees or teams
+- forcing specialist review before any execution step proceeds
+
+A digital employee can auto-draft a plan, but managerial policy and overrides remain first-class operating signals.
+
+### DigitalEmployee upgrade
+A `DigitalEmployee` must now behave like a department worker with the following operational properties:
+- **work queue membership**: it belongs to one or more queues and only draws work from those operational backlogs
+- **planning behavior**: it helps draft and execute its daily plan according to capacity, priority rules, and manager overrides
+- **case ownership**: it can become the named owner of a case for a period of responsibility, including follow-up deadlines
+- **responsibility continuity**: it must maintain case history, next actions, and accountability across multiple executions rather than acting as a stateless tool caller
+- **execution discipline**: it starts executions only from assigned or self-planned case work, except for explicitly allowed emergency triggers
+
+## 6. Mapping from current system
 
 | Current Component | Future Role | Action |
 | ----------------- | ----------- | ------ |
@@ -562,7 +774,7 @@ These are adapters onto the runtime and event model, not the architectural cente
 | Existing workflow proposal support | Proposal subsystem for digital employees | Generalize into structured `DecisionProposal` generation that feeds policy and approvals instead of directly shaping CRUD flows. |
 | CRUD/meta APIs | Access-layer compatibility surface | Keep as optional adapters and projections; do not let them define core architecture. |
 
-## 6. Minimal migration strategy
+## 7. Minimal migration strategy
 Do not rewrite the repository. Introduce runtime-first seams in small steps.
 
 ### Introduce event model
@@ -574,6 +786,16 @@ Do not rewrite the repository. Introduce runtime-first seams in small steps.
 - Define an explicit command object for any operation that intends side effects.
 - Route existing action endpoints and selected CRUD mutations through command admission before execution.
 - Preserve current API shapes by translating transport requests into commands internally.
+
+### Introduce case and queue operations
+- Add case-correlation rules so triggering events open or enrich cases before execution begins.
+- Persist `Case`, `WorkQueue`, and `WorkItem` state as operational records instead of treating events as self-sufficient work orders.
+- Expose queue and case projections for operators and managers.
+
+### Introduce daily planning
+- Add `DailyPlan` generation for one department with capacity, due-date, and manager-override support.
+- Ensure work is executed from planned or explicitly assigned items rather than raw event arrival.
+- Record plan publication and assignment decisions as durable operational facts.
 
 ### Extract execution from HTTP
 - Create a transport-agnostic runtime service that receives commands/events and manages execution instances.
@@ -590,7 +812,7 @@ Do not rewrite the repository. Introduce runtime-first seams in small steps.
 - Do not start with a full event-sourced rewrite; start with durable append-only records plus read projections.
 - Ensure interrupted executions can resume without relying on in-memory request context.
 
-## 7. First 5 implementation slices
+## 8. First 7 implementation slices
 
 ### Slice 1 - Event envelope and event emission
 **Goal**
@@ -622,37 +844,67 @@ Do not rewrite the repository. Introduce runtime-first seams in small steps.
 - Unit test command validation, idempotency behavior, and rejection scenarios.
 - Integration test that admitted commands are recorded and correlated to source events.
 
-### Slice 3 - Execution runtime skeleton
+### Slice 3 - Case and queue skeleton
 **Goal**
-- Create durable `ExecutionInstance` and `ExecutionEvent` records with a minimal step runner.
+- Create durable `Case`, `WorkQueue`, and `WorkItem` records with event-to-case correlation.
 
 **Scope**
-- Start a runtime execution from a command or event.
-- Record statuses such as `pending`, `running`, `succeeded`, and `failed`.
+- Open or enrich a case from one selected business event.
+- Route the resulting work into a queue with a visible priority and owner policy.
 
 **Why it matters**
-- Moves orchestration responsibility out of HTTP and into a dedicated runtime core.
+- Establishes the operational layer so work is owned as a department matter before execution begins.
 
 **Testability**
-- Unit test state transitions.
-- Integration test crash-safe resume semantics for a simple non-side-effecting execution.
+- Unit test case correlation, reopening, and queue routing rules.
+- Integration test that repeated related events enrich the same case rather than spawning disconnected executions.
 
-### Slice 4 - Actor context injection
+### Slice 4 - Daily planning and assignment
+**Goal**
+- Add a minimal `DailyPlan` generator and assignment mechanism for one queue.
+
+**Scope**
+- Produce a dated plan from queue backlog, deadlines, and employee capacity.
+- Allow a manager override and publish assignments to a named employee.
+
+**Why it matters**
+- Makes Kalita operate like a real staffed department instead of an always-fire execution engine.
+
+**Testability**
+- Unit test prioritization and manager override behavior.
+- Integration test that only planned or assigned work can start execution.
+
+### Slice 5 - Execution runtime skeleton
+**Goal**
+- Create durable `ExecutionInstance` and `ExecutionEvent` records with a minimal step runner for planned work.
+
+**Scope**
+- Start a runtime execution from an assigned `WorkItem` rather than directly from raw event arrival.
+- Record statuses such as `pending`, `running`, `waiting_approval`, `succeeded`, and `failed`.
+
+**Why it matters**
+- Preserves the operational layer while still moving orchestration responsibility out of HTTP and into a dedicated runtime core.
+
+**Testability**
+- Unit test state transitions and work-item-to-execution linkage.
+- Integration test crash-safe resume semantics for a simple non-side-effecting planned execution.
+
+### Slice 6 - Actor context injection
 **Goal**
 - Ensure all ingress paths produce `ActorContext` and propagate it through runtime records.
 
 **Scope**
 - Add actor metadata capture in HTTP and admin flows.
-- Store actor context IDs on commands, events, and executions.
+- Store actor context IDs on commands, events, cases, and executions.
 
 **Why it matters**
-- Enables policy, audit, and approval to be actor-aware from the beginning.
+- Enables policy, audit, assignment, and approval to be actor-aware from the beginning.
 
 **Testability**
 - Unit test actor context construction and propagation.
 - Integration test that audit/event records include actor identity and origin.
 
-### Slice 5 - Policy hook before tool/action execution
+### Slice 7 - Policy hook before tool/action execution
 **Goal**
 - Introduce a policy decision point before executing side effects.
 
@@ -667,7 +919,7 @@ Do not rewrite the repository. Introduce runtime-first seams in small steps.
 - Unit test rule matching and decision outcomes.
 - Integration test that high-risk commands pause for approval instead of executing immediately.
 
-## 8. Anti-patterns
+## 9. Anti-patterns
 Kalita vNext must not do the following:
 - **Chat-first architecture**: do not model digital employees as conversational agents waiting for user prompts.
 - **Direct LLM tool execution**: LLM output must never invoke tools or mutate systems without runtime control.
@@ -678,60 +930,85 @@ Kalita vNext must not do the following:
 - **Opaque automation**: every proposal, decision, action, and outcome must be attributable and auditable.
 - **In-memory-only execution**: long-running digital employee work must survive process restarts.
 
-## 9. MVP scenario: Document Review Digital Employee
+## 10. Accounts Receivable example: debt collection department
 
-### Actor definition
-A `Document Review Digital Employee` owns first-pass review of uploaded documents and can propose safe patches, but cannot apply changes without runtime and policy clearance.
+### Department definition
+An `Accounts Receivable Collection Digital Employee` owns debt collection work for a bounded customer segment. It does not simply react to overdue events by firing actions. It operates like a collector inside a department with queues, daily targets, promises to follow up, and manager oversight.
 
-### Flow
-1. **`document_uploaded`**
-   - A document enters the system through upload or integration.
-   - Kalita emits `document_uploaded` with document metadata, uploader actor context, and storage reference.
+### Case model in the scenario
+A debt collection `Case` represents one actionable collection matter, typically scoped to an account, debtor, or invoice cluster. The case holds:
+- overdue balance and aging
+- debtor contact history
+- promise-to-pay commitments
+- dispute indicators
+- next promised action date
+- assigned collector or queue
+- stage such as `new_overdue`, `contact_due`, `promise_monitoring`, `dispute_review`, `escalation_review`, or `resolved`
 
-2. **`analyze_document`**
-   - The runtime matches the document review employee subscription.
-   - A command `analyze_document` starts an execution instance.
+### Queue model in the scenario
+The department operates several queues:
+- `new-overdue-intake`: first-touch cases opened by newly overdue invoices
+- `follow-up-today`: cases with callback or payment promises due today
+- `broken-promise`: high-priority cases where a promised payment was missed
+- `dispute-exception`: cases requiring evidence gathering or specialist review
+- `manager-escalation`: high-balance or sensitive accounts requiring supervisory direction
 
-3. **`issues_detected`**
-   - The employee builds context from the document, metadata, and relevant rules.
-   - An optional LLM produces a `DecisionProposal` listing detected issues and evidence spans.
-   - The runtime emits `issues_detected` as a fact about the analysis outcome.
+### Daily planning in the scenario
+At the start of each day, Kalita drafts a `DailyPlan` for each collector or digital employee using:
+- cases due for follow-up today
+- aging and amount-based priority
+- broken promises and SLA breaches
+- collector capacity and campaign targets
+- manager-pinned strategic accounts
 
-4. **`patch_proposed`**
-   - If remediations are possible, the proposal includes a structured patch recommendation.
-   - The runtime records `patch_proposed` with the proposed change set and supporting rationale.
+A collection manager can move a large debtor to the top of the plan, reserve time for month-end calls, or redirect disputed cases away from standard collectors to specialists.
 
-5. **`approval_requested`**
-   - Policy evaluates the patch based on document class, impact, and side-effect level.
-   - If human authorization is required, the runtime creates an `ApprovalRequest` and emits `approval_requested`.
+### End-to-end flow
+1. **`invoice_overdue_detected` event arrives**
+   - ERP or billing emits an event that invoice `INV-10482` is now overdue.
+   - Kalita correlates it to the debtor account and opens a collection `Case` if no active collection matter exists.
 
-6. **`patch_applied`**
-   - After approval, the runtime invokes the patch application tool using the approved payload.
-   - The tool result becomes `patch_applied` or `tool_execution_failed`.
+2. **Case is created or refreshed**
+   - The case enters lifecycle state `open`, stage `new_overdue`, and queue `new-overdue-intake`.
+   - If prior invoices already exist for the same debtor, the event may enrich the existing case instead of creating a new one.
 
-7. **`audit recorded`**
-   - Throughout the flow, Kalita records event history, execution timeline, proposal summary, policy decisions, approval outcome, and tool result summaries for audit and debugging.
+3. **Work item enters queue**
+   - Kalita creates a `WorkItem` such as `perform_first_contact` with due date, amount-based priority, and collector skill requirements.
+   - No tool executes yet; the department now simply has work to manage.
 
-### Why this is a good MVP
-This scenario proves the target architecture because it requires:
-- event trigger ingestion
-- runtime ownership of execution
-- optional LLM proposal generation
-- policy gate before action
-- approval pause/resume
-- controlled tool execution
-- durable audit trail
+4. **Daily plan selects the case**
+   - During morning planning, the system places the work item into collector Ana's `DailyPlan` because she owns the territory and has capacity.
+   - The manager raises its priority because the debtor is strategically important.
 
-It demonstrates digital employee behavior without collapsing back into CRUD or chat patterns.
+5. **Collector/digital employee works the case**
+   - Ana's digital employee context opens the case, reviews history, and starts an `ExecutionInstance` for the assigned work item.
+   - An LLM may propose the next best contact approach, but only within the case history and policy boundaries.
 
-## 10. Final recommendation
-The first thing to implement in the repository right now is **a first-class event and command envelope with a minimal durable execution runtime skeleton**.
+6. **Controlled execution happens**
+   - The runtime may invoke an approved communication tool to send an email or prepare a call script.
+   - Policy may require manager approval before sending a legal-warning template or before escalating to an external agency.
+
+7. **Business results feed the case**
+   - If the debtor promises payment by Friday, Kalita emits `promise_to_pay_recorded`, updates the case stage to `promise_monitoring`, and creates a follow-up work item for the promised date.
+   - If Friday passes without payment, event `payment_promise_broken` re-prioritizes the case into the `broken-promise` queue for tomorrow's plan.
+   - If payment arrives, event `payment_received` moves the case to `resolved` and removes remaining work items from active queues.
+
+### Why this example matters
+This example demonstrates the corrected architecture because:
+- events create and evolve cases instead of directly triggering generic execution
+- queues expose real departmental backlog
+- daily plans express what gets worked today
+- assignment creates named responsibility
+- execution is subordinate to case operations, not the architectural center
+
+## 11. Final recommendation
+The first thing to implement in the repository right now is **a first-class event and command envelope plus the case-centric operational layer that sits in front of execution**.
 
 Concretely, the immediate repo priority should be:
-1. define `Event`, `Command`, `ExecutionInstance`, and `ActorContext` as core runtime models
-2. emit events from one existing action path and one document/file path
-3. create a transport-agnostic runtime service that starts and records execution instances
-4. store execution and policy history durably
-5. keep CRUD intact, but route new side-effecting flows through the runtime boundary
+1. define `Event`, `Case`, `WorkQueue`, `WorkItem`, `DailyPlan`, `ExecutionInstance`, and `ActorContext` as core runtime and operational models
+2. emit events from one existing action path and one document/file path, then correlate them into cases rather than direct execution alone
+3. create a transport-agnostic operational service that owns case creation, queue routing, assignment, and daily planning
+4. let the execution runtime start only from planned or explicitly assigned case work
+5. store case history, queue state, execution history, policy decisions, and approvals durably while keeping CRUD as an access adapter
 
-This is the smallest change that establishes Kalita's real architectural center of gravity. Once that exists, policy, approvals, digital employees, and tool control can all accumulate on the correct foundation instead of being bolted onto CRUD handlers later.
+This is the smallest change that establishes Kalita as a true business department runtime rather than a more elaborate execution engine. Once that exists, policy, approvals, digital employees, and tool control can accumulate on the correct operational foundation instead of being bolted onto CRUD handlers later.


### PR DESCRIPTION
### Motivation
- The previous design was execution-centric (`Event -> Command -> Execution`) and lacked an operational layer that models how a real department organizes work. 
- Kalita must treat business matters as owned, long-lived `Case` objects with queues, daily plans, and named accountability before execution begins. 
- Adding a case-centric layer ensures planning, assignment, SLA monitoring, and manager influence become first-class operating concepts instead of ad-hoc execution triggers. 

### Description
- Updated `docs/ai-shift/16-vnext-target-architecture.md` to reframe the core flow as `Event -> Case -> Plan -> Execution` and to add the rationale for an operational layer. 
- Added first-class operational entities and their contracts including `Case`, `WorkQueue`, `WorkItem`, and `DailyPlan` with fields, lifecycle roles, and event-to-case correlation semantics. 
- Upgraded the `DigitalEmployee` model to include `queue_memberships`, `case_types_owned`, `planning_policy`, `capacity_profile`, and explicit case ownership and responsibility continuity. 
- Reworked migration and implementation guidance and slices to introduce case correlation, queue operations, daily planning, planned-work-driven execution, and replaced the prior scenario with an Accounts Receivable (debt collection) example that walks the full Event→Case→Plan→Employee→Execution path. 

### Testing
- Ran a lightweight automated structural check (`python` snippet) that asserts the document contains the `Event -> Case -> Plan -> Execution` flow and the new sections `Case`, `WorkQueue`, and `DailyPlan`, and the check passed. 
- No runtime unit/integration changes were made in this PR since the change is documentation and architecture guidance only, so no additional automated code tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03ed53b1083249ced700e5a4bf504)