### PR TITLE
Introduce eventcore and CommandBus and integrate command admission into HTTP actions

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServer(":"+result.Config.Port, result.Storage)
+	http.RunServerWithCommandBus(":"+result.Config.Port, result.Storage, result.CommandBus)
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -7,7 +7,9 @@ import (
 
 	"kalita/internal/blob"
 	"kalita/internal/catalog"
+	"kalita/internal/command"
 	"kalita/internal/config"
+	"kalita/internal/eventcore"
 	"kalita/internal/postgres"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
@@ -15,8 +17,10 @@ import (
 
 // BootstrapResult holds the initialized application components
 type BootstrapResult struct {
-	Storage *runtime.Storage
-	Config  config.Config
+	Storage    *runtime.Storage
+	EventLog   eventcore.EventLog
+	CommandBus command.CommandBus
+	Config     config.Config
 }
 
 // Bootstrap initializes the application with all required components
@@ -67,14 +71,18 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 
 	// In-memory API (данные пока в памяти; PG — только схема)
 	st := runtime.NewStorage(entities, enumCatalog)
+	eventLog := eventcore.NewInMemoryEventLog()
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, eventcore.RealClock{}, eventcore.NewULIDGenerator())
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
 	st.Blob = &blob.LocalBlobStore{Root: cfg.FilesRoot}
 
 	return &BootstrapResult{
-		Storage: st,
-		Config:  cfg,
+		Storage:    st,
+		EventLog:   eventLog,
+		CommandBus: commandBus,
+		Config:     cfg,
 	}, nil
 }
 

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBootstrapProvidesEventCenter(t *testing.T) {
+	cfg := `{
+  "port": "8080",
+  "dslDir": "../../dsl",
+  "enumsDir": "../../reference/enums",
+  "dbUrl": "",
+  "autoMigrate": false,
+  "blobDriver": "local",
+  "filesRoot": "../../uploads"
+}`
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	result, err := Bootstrap(cfgPath)
+	if err != nil {
+		t.Fatalf("Bootstrap error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("Bootstrap result is nil")
+	}
+	if result.Storage == nil {
+		t.Fatal("Storage is nil")
+	}
+	if result.EventLog == nil {
+		t.Fatal("EventLog is nil")
+	}
+	if result.CommandBus == nil {
+		t.Fatal("CommandBus is nil")
+	}
+}

--- a/internal/command/interfaces.go
+++ b/internal/command/interfaces.go
@@ -1,0 +1,15 @@
+package command
+
+import (
+	"context"
+
+	"kalita/internal/eventcore"
+)
+
+type AdmissionPolicy interface {
+	Admit(ctx context.Context, cmd eventcore.Command) error
+}
+
+type CommandBus interface {
+	Submit(ctx context.Context, cmd eventcore.Command) (eventcore.Command, error)
+}

--- a/internal/command/service.go
+++ b/internal/command/service.go
@@ -1,0 +1,73 @@
+package command
+
+import (
+	"context"
+
+	"kalita/internal/eventcore"
+)
+
+type PassThroughAdmissionPolicy struct{}
+
+func (PassThroughAdmissionPolicy) Admit(context.Context, eventcore.Command) error {
+	return nil
+}
+
+type Service struct {
+	policy AdmissionPolicy
+	log    eventcore.EventLog
+	clock  eventcore.Clock
+	ids    eventcore.IDGenerator
+}
+
+func NewService(log eventcore.EventLog, policy AdmissionPolicy, clock eventcore.Clock, ids eventcore.IDGenerator) *Service {
+	if policy == nil {
+		policy = PassThroughAdmissionPolicy{}
+	}
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &Service{policy: policy, log: log, clock: clock, ids: ids}
+}
+
+func (s *Service) Submit(ctx context.Context, cmd eventcore.Command) (eventcore.Command, error) {
+	if cmd.ID == "" {
+		cmd.ID = s.ids.NewID()
+	}
+	if cmd.RequestedAt.IsZero() {
+		cmd.RequestedAt = s.clock.Now()
+	}
+	if cmd.CorrelationID == "" {
+		cmd.CorrelationID = s.ids.NewID()
+	}
+	if cmd.ExecutionID == "" {
+		cmd.ExecutionID = s.ids.NewID()
+	}
+
+	if err := s.policy.Admit(ctx, cmd); err != nil {
+		return eventcore.Command{}, err
+	}
+	if s.log != nil {
+		execEvent := eventcore.ExecutionEvent{
+			ID:            s.ids.NewID(),
+			ExecutionID:   cmd.ExecutionID,
+			CaseID:        cmd.CaseID,
+			Step:          "command_admission",
+			Status:        "admitted",
+			OccurredAt:    s.clock.Now(),
+			CorrelationID: cmd.CorrelationID,
+			CausationID:   cmd.ID,
+			Payload: map[string]any{
+				"command_type": cmd.Type,
+				"target_ref":   cmd.TargetRef,
+			},
+		}
+		if err := s.log.AppendExecutionEvent(ctx, execEvent); err != nil {
+			return eventcore.Command{}, err
+		}
+	}
+
+	return cmd, nil
+}

--- a/internal/command/service_test.go
+++ b/internal/command/service_test.go
@@ -1,0 +1,136 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"kalita/internal/eventcore"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDGenerator struct {
+	ids []string
+	i   int
+}
+
+func (f *fakeIDGenerator) NewID() string {
+	if f.i >= len(f.ids) {
+		return ""
+	}
+	id := f.ids[f.i]
+	f.i++
+	return id
+}
+
+type denyPolicy struct{ err error }
+
+func (p denyPolicy) Admit(context.Context, eventcore.Command) error { return p.err }
+
+func TestServiceSubmitFillsMissingFieldsDeterministically(t *testing.T) {
+	t.Parallel()
+
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "evt-1"}}
+	service := NewService(log, PassThroughAdmissionPolicy{}, clock, ids)
+
+	cmd, err := service.Submit(context.Background(), eventcore.Command{Type: "workflow.action", TargetRef: "test.WorkflowTask/rec-1"})
+	if err != nil {
+		t.Fatalf("Submit error = %v", err)
+	}
+
+	if cmd.ID != "cmd-1" || cmd.CorrelationID != "corr-1" || cmd.ExecutionID != "exec-1" {
+		t.Fatalf("normalized IDs = %#v", cmd)
+	}
+	if !cmd.RequestedAt.Equal(clock.now) {
+		t.Fatalf("RequestedAt = %v, want %v", cmd.RequestedAt, clock.now)
+	}
+
+	_, executionEvents, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(executionEvents) != 1 {
+		t.Fatalf("executionEvents len = %d, want 1", len(executionEvents))
+	}
+	got := executionEvents[0]
+	if got.ID != "evt-1" {
+		t.Fatalf("execution event ID = %s, want evt-1", got.ID)
+	}
+	if got.Step != "command_admission" || got.Status != "admitted" {
+		t.Fatalf("execution event = %#v", got)
+	}
+	if got.CausationID != "cmd-1" || got.ExecutionID != "exec-1" || got.CorrelationID != "corr-1" {
+		t.Fatalf("execution event linkage = %#v", got)
+	}
+	if got.Payload["command_type"] != "workflow.action" || got.Payload["target_ref"] != "test.WorkflowTask/rec-1" {
+		t.Fatalf("execution payload = %#v", got.Payload)
+	}
+}
+
+func TestServiceSubmitDeniedCommandAppendsNothing(t *testing.T) {
+	t.Parallel()
+
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "evt-1"}}
+	denyErr := errors.New("denied")
+	service := NewService(log, denyPolicy{err: denyErr}, clock, ids)
+
+	_, err := service.Submit(context.Background(), eventcore.Command{Type: "workflow.action"})
+	if !errors.Is(err, denyErr) {
+		t.Fatalf("Submit error = %v, want %v", err, denyErr)
+	}
+
+	events, executionEvents, listErr := log.ListByCorrelation(context.Background(), "corr-1")
+	if listErr != nil {
+		t.Fatalf("ListByCorrelation error = %v", listErr)
+	}
+	if len(events) != 0 || len(executionEvents) != 0 {
+		t.Fatalf("log mutated after denied command: %d events, %d execution events", len(events), len(executionEvents))
+	}
+}
+
+func TestServiceSubmitPreservesProvidedIDs(t *testing.T) {
+	t.Parallel()
+
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"evt-1"}}
+	service := NewService(log, PassThroughAdmissionPolicy{}, clock, ids)
+
+	requestedAt := time.Date(2026, 3, 20, 8, 30, 0, 0, time.UTC)
+	input := eventcore.Command{
+		ID:            "cmd-existing",
+		RequestedAt:   requestedAt,
+		CorrelationID: "corr-existing",
+		ExecutionID:   "exec-existing",
+		Type:          "workflow.action",
+	}
+	cmd, err := service.Submit(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Submit error = %v", err)
+	}
+	if cmd.ID != input.ID || cmd.CorrelationID != input.CorrelationID || cmd.ExecutionID != input.ExecutionID {
+		t.Fatalf("normalized cmd = %#v, want preserved IDs from %#v", cmd, input)
+	}
+	if !cmd.RequestedAt.Equal(requestedAt) {
+		t.Fatalf("RequestedAt = %v, want %v", cmd.RequestedAt, requestedAt)
+	}
+
+	_, executionEvents, err := log.ListByCorrelation(context.Background(), "corr-existing")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(executionEvents) != 1 {
+		t.Fatalf("executionEvents len = %d, want 1", len(executionEvents))
+	}
+	if executionEvents[0].ExecutionID != "exec-existing" || executionEvents[0].CausationID != "cmd-existing" {
+		t.Fatalf("execution event = %#v", executionEvents[0])
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,21 +101,23 @@ func LoadWithPath(jsonPath string) Config {
 	cfg.S3Endpoint = getenv("KALITA_S3_ENDPOINT", cfg.S3Endpoint)
 
 	// Flags overrides
-	configPath := flag.String("config", jsonPath, "Path to config JSON")
-	port := flag.String("port", cfg.Port, "HTTP port")
-	dsl := flag.String("dsl", cfg.DSLDir, "Path to DSL directory")
-	enums := flag.String("enums", cfg.EnumsDir, "Path to enums directory")
-	db := flag.String("db", cfg.DBURL, "Postgres URL (empty = in-memory)")
-	auto := flag.String("auto-migrate", strconv.FormatBool(cfg.AutoMigrate), "Auto-migrate add-only (true/false)")
+	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	configPath := fs.String("config", jsonPath, "Path to config JSON")
+	port := fs.String("port", cfg.Port, "HTTP port")
+	dsl := fs.String("dsl", cfg.DSLDir, "Path to DSL directory")
+	enums := fs.String("enums", cfg.EnumsDir, "Path to enums directory")
+	db := fs.String("db", cfg.DBURL, "Postgres URL (empty = in-memory)")
+	auto := fs.String("auto-migrate", strconv.FormatBool(cfg.AutoMigrate), "Auto-migrate add-only (true/false)")
 
-	blob := flag.String("blob-driver", cfg.BlobDriver, "Blob driver (local/s3)")
-	files := flag.String("files-root", cfg.FilesRoot, "Local files root (if blob=local)")
-	s3r := flag.String("s3-region", cfg.S3Region, "S3 region")
-	s3b := flag.String("s3-bucket", cfg.S3Bucket, "S3 bucket")
-	s3p := flag.String("s3-prefix", cfg.S3Prefix, "S3 key prefix")
-	s3e := flag.String("s3-endpoint", cfg.S3Endpoint, "S3 custom endpoint")
+	blob := fs.String("blob-driver", cfg.BlobDriver, "Blob driver (local/s3)")
+	files := fs.String("files-root", cfg.FilesRoot, "Local files root (if blob=local)")
+	s3r := fs.String("s3-region", cfg.S3Region, "S3 region")
+	s3b := fs.String("s3-bucket", cfg.S3Bucket, "S3 bucket")
+	s3p := fs.String("s3-prefix", cfg.S3Prefix, "S3 key prefix")
+	s3e := fs.String("s3-endpoint", cfg.S3Endpoint, "S3 custom endpoint")
 
-	flag.Parse()
+	_ = fs.Parse(os.Args[1:])
 
 	// Если через флаг передали другой конфиг — перечитаем
 	if *configPath != jsonPath {

--- a/internal/eventcore/ids.go
+++ b/internal/eventcore/ids.go
@@ -1,0 +1,27 @@
+package eventcore
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+type RealClock struct{}
+
+func (RealClock) Now() time.Time {
+	return time.Now().UTC()
+}
+
+type ULIDGenerator struct {
+	entropy *ulid.MonotonicEntropy
+}
+
+func NewULIDGenerator() *ULIDGenerator {
+	src := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return &ULIDGenerator{entropy: ulid.Monotonic(src, 0)}
+}
+
+func (g *ULIDGenerator) NewID() string {
+	return ulid.MustNew(ulid.Timestamp(time.Now().UTC()), g.entropy).String()
+}

--- a/internal/eventcore/log.go
+++ b/internal/eventcore/log.go
@@ -1,0 +1,57 @@
+package eventcore
+
+import (
+	"context"
+	"sync"
+)
+
+type EventLog interface {
+	AppendEvent(ctx context.Context, e Event) error
+	AppendExecutionEvent(ctx context.Context, e ExecutionEvent) error
+	ListByCorrelation(ctx context.Context, correlationID string) ([]Event, []ExecutionEvent, error)
+}
+
+type InMemoryEventLog struct {
+	mu              sync.RWMutex
+	events          []Event
+	executionEvents []ExecutionEvent
+}
+
+func NewInMemoryEventLog() *InMemoryEventLog {
+	return &InMemoryEventLog{}
+}
+
+func (l *InMemoryEventLog) AppendEvent(_ context.Context, e Event) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.events = append(l.events, e)
+	return nil
+}
+
+func (l *InMemoryEventLog) AppendExecutionEvent(_ context.Context, e ExecutionEvent) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.executionEvents = append(l.executionEvents, e)
+	return nil
+}
+
+func (l *InMemoryEventLog) ListByCorrelation(_ context.Context, correlationID string) ([]Event, []ExecutionEvent, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	events := make([]Event, 0)
+	for _, e := range l.events {
+		if e.CorrelationID == correlationID {
+			events = append(events, e)
+		}
+	}
+
+	executionEvents := make([]ExecutionEvent, 0)
+	for _, e := range l.executionEvents {
+		if e.CorrelationID == correlationID {
+			executionEvents = append(executionEvents, e)
+		}
+	}
+
+	return events, executionEvents, nil
+}

--- a/internal/eventcore/log_test.go
+++ b/internal/eventcore/log_test.go
@@ -1,0 +1,126 @@
+package eventcore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestInMemoryEventLogPreservesEventOrder(t *testing.T) {
+	t.Parallel()
+
+	log := NewInMemoryEventLog()
+	ctx := context.Background()
+	corr := "corr-1"
+
+	first := Event{ID: "evt-1", CorrelationID: corr, OccurredAt: time.Unix(1, 0).UTC()}
+	second := Event{ID: "evt-2", CorrelationID: corr, OccurredAt: time.Unix(2, 0).UTC()}
+
+	if err := log.AppendEvent(ctx, first); err != nil {
+		t.Fatalf("AppendEvent(first) error = %v", err)
+	}
+	if err := log.AppendEvent(ctx, second); err != nil {
+		t.Fatalf("AppendEvent(second) error = %v", err)
+	}
+
+	events, executionEvents, err := log.ListByCorrelation(ctx, corr)
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(executionEvents) != 0 {
+		t.Fatalf("executionEvents len = %d, want 0", len(executionEvents))
+	}
+	if len(events) != 2 {
+		t.Fatalf("events len = %d, want 2", len(events))
+	}
+	if events[0].ID != first.ID || events[1].ID != second.ID {
+		t.Fatalf("event order = [%s %s], want [%s %s]", events[0].ID, events[1].ID, first.ID, second.ID)
+	}
+}
+
+func TestInMemoryEventLogSeparatesExecutionEvents(t *testing.T) {
+	t.Parallel()
+
+	log := NewInMemoryEventLog()
+	ctx := context.Background()
+	corr := "corr-2"
+
+	if err := log.AppendEvent(ctx, Event{ID: "evt-1", CorrelationID: corr}); err != nil {
+		t.Fatalf("AppendEvent error = %v", err)
+	}
+	execEvent := ExecutionEvent{ID: "exec-1", CorrelationID: corr, ExecutionID: "run-1"}
+	if err := log.AppendExecutionEvent(ctx, execEvent); err != nil {
+		t.Fatalf("AppendExecutionEvent error = %v", err)
+	}
+
+	events, executionEvents, err := log.ListByCorrelation(ctx, corr)
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(events))
+	}
+	if len(executionEvents) != 1 {
+		t.Fatalf("executionEvents len = %d, want 1", len(executionEvents))
+	}
+	if executionEvents[0].ID != execEvent.ID {
+		t.Fatalf("execution event ID = %s, want %s", executionEvents[0].ID, execEvent.ID)
+	}
+}
+
+func TestInMemoryEventLogListByCorrelationHandlesEmptyCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	log := NewInMemoryEventLog()
+	ctx := context.Background()
+
+	if err := log.AppendEvent(ctx, Event{ID: "evt-empty", CorrelationID: ""}); err != nil {
+		t.Fatalf("AppendEvent error = %v", err)
+	}
+	if err := log.AppendExecutionEvent(ctx, ExecutionEvent{ID: "exec-empty", CorrelationID: ""}); err != nil {
+		t.Fatalf("AppendExecutionEvent error = %v", err)
+	}
+
+	events, executionEvents, err := log.ListByCorrelation(ctx, "")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(events) != 1 || len(executionEvents) != 1 {
+		t.Fatalf("got %d events and %d execution events, want 1 and 1", len(events), len(executionEvents))
+	}
+}
+
+func TestInMemoryEventLogConcurrentAppendSmoke(t *testing.T) {
+	t.Parallel()
+
+	log := NewInMemoryEventLog()
+	ctx := context.Background()
+	const n = 64
+
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			_ = log.AppendEvent(ctx, Event{ID: fmt.Sprintf("evt-%d", i), CorrelationID: "corr-concurrent"})
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_ = log.AppendExecutionEvent(ctx, ExecutionEvent{ID: fmt.Sprintf("exec-%d", i), CorrelationID: "corr-concurrent"})
+		}(i)
+	}
+	wg.Wait()
+
+	events, executionEvents, err := log.ListByCorrelation(ctx, "corr-concurrent")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(events) != n {
+		t.Fatalf("events len = %d, want %d", len(events), n)
+	}
+	if len(executionEvents) != n {
+		t.Fatalf("executionEvents len = %d, want %d", len(executionEvents), n)
+	}
+}

--- a/internal/eventcore/types.go
+++ b/internal/eventcore/types.go
@@ -1,0 +1,68 @@
+package eventcore
+
+import "time"
+
+type ActorType string
+
+const (
+	ActorHuman           ActorType = "human"
+	ActorService         ActorType = "service"
+	ActorDigitalEmployee ActorType = "digital_employee"
+	ActorSystem          ActorType = "system"
+)
+
+type ActorContext struct {
+	ActorID      string
+	ActorType    ActorType
+	DisplayName  string
+	Roles        []string
+	Capabilities []string
+	RequestID    string
+}
+
+type Event struct {
+	ID            string
+	Type          string
+	OccurredAt    time.Time
+	Source        string
+	CorrelationID string
+	CausationID   string
+	ExecutionID   string
+	CaseID        string
+	Actor         ActorContext
+	Payload       map[string]any
+}
+
+type Command struct {
+	ID             string
+	Type           string
+	RequestedAt    time.Time
+	CorrelationID  string
+	CausationID    string
+	ExecutionID    string
+	CaseID         string
+	Actor          ActorContext
+	TargetRef      string
+	Payload        map[string]any
+	IdempotencyKey string
+}
+
+type ExecutionEvent struct {
+	ID            string
+	ExecutionID   string
+	CaseID        string
+	Step          string
+	Status        string
+	OccurredAt    time.Time
+	CorrelationID string
+	CausationID   string
+	Payload       map[string]any
+}
+
+type IDGenerator interface {
+	NewID() string
+}
+
+type Clock interface {
+	Now() time.Time
+}

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 
+	"kalita/internal/command"
+	"kalita/internal/eventcore"
 	"kalita/internal/runtime"
 	"kalita/internal/validation"
 
@@ -19,10 +21,26 @@ type actionRequest struct {
 }
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
+	return ActionHandlerWithCommandBus(storage, nil)
+}
+
+func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.CommandBus) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		fqn, action, req, ok := parseActionRequest(c, storage)
 		if !ok {
 			return
+		}
+
+		if commandBus != nil {
+			cmd := buildWorkflowActionCommand(c, fqn, action, req)
+			if _, err := commandBus.Submit(c.Request.Context(), cmd); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+					Code:    validation.ErrTypeMismatch,
+					Field:   "action",
+					Message: err.Error(),
+				}}})
+				return
+			}
 		}
 
 		result, errs := runtime.ExecuteWorkflowAction(storage, fqn, c.Param("id"), action, req.RecordVersion)
@@ -95,4 +113,28 @@ func mustReadBody(c *gin.Context) []byte {
 	}
 	c.Request.Body = io.NopCloser(bytes.NewReader(body))
 	return body
+}
+
+func buildWorkflowActionCommand(c *gin.Context, fqn, action string, req actionRequest) eventcore.Command {
+	requestID := c.GetHeader("X-Request-Id")
+	if requestID == "" {
+		requestID = c.GetHeader("X-Request-ID")
+	}
+
+	return eventcore.Command{
+		Type:           "workflow.action",
+		CaseID:         c.Param("id"),
+		TargetRef:      fmt.Sprintf("%s/%s", fqn, c.Param("id")),
+		IdempotencyKey: fmt.Sprintf("%s:%s:%d", fqn, action, req.RecordVersion),
+		Actor: eventcore.ActorContext{
+			ActorType: eventcore.ActorHuman,
+			RequestID: requestID,
+		},
+		Payload: map[string]any{
+			"entity":         fqn,
+			"record_id":      c.Param("id"),
+			"action":         action,
+			"record_version": req.RecordVersion,
+		},
+	}
 }

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -2,12 +2,15 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"kalita/internal/eventcore"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
 
@@ -190,6 +193,35 @@ func testHTTPWorkflowStorage() (*runtime.Storage, *runtime.Record) {
 	}
 	st.Data["test.WorkflowTask"] = map[string]*runtime.Record{rec.ID: rec}
 	return st, rec
+}
+
+type denyCommandBus struct{}
+
+func (denyCommandBus) Submit(_ context.Context, _ eventcore.Command) (eventcore.Command, error) {
+	return eventcore.Command{}, errors.New("command denied")
+}
+
+func TestActionHandlerReturnsValidationErrorWhenCommandAdmissionFails(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithCommandBus(storage, denyCommandBus{}))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
 }
 
 func TestCreateActionRequestAndGetByID(t *testing.T) {

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -3,6 +3,7 @@ package http
 import (
 	"log"
 
+	"kalita/internal/command"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
 
@@ -10,6 +11,10 @@ import (
 )
 
 func RunServer(addr string, storage *runtime.Storage) {
+	RunServerWithCommandBus(addr, storage, nil)
+}
+
+func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus command.CommandBus) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -29,7 +34,7 @@ func RunServer(addr string, storage *runtime.Storage) {
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
-		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandler(storage))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithCommandBus(storage, commandBus))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
 		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))


### PR DESCRIPTION
### Motivation

- Provide a pluggable command admission pipeline and an in-memory event log for workflow-related commands and execution events. 
- Ensure commands get deterministic IDs, timestamps and linkage, and allow admission policies to reject commands before state mutation. 
- Wire command handling into HTTP action endpoints and make flag parsing non-global to avoid side effects in tests.

### Description

- Added `internal/eventcore` with core types (`Event`, `Command`, `ExecutionEvent`, clocks and `IDGenerator`) and an in-memory `EventLog` plus a ULID `IDGenerator` and `RealClock` implementation. 
- Added `internal/command` package with `AdmissionPolicy` and `CommandBus` interfaces and a `Service` implementation that fills missing command fields, enforces admission policy, and appends an execution event on admission. 
- Updated application bootstrap (`Bootstrap`) to instantiate an `EventLog` and `CommandBus` and return them in `BootstrapResult`. 
- Wired command submission into HTTP layer by adding `ActionHandlerWithCommandBus` and `RunServerWithCommandBus` and using `buildWorkflowActionCommand` to create commands for workflow actions, preserving previous behavior when no command bus is provided. 
- Reworked config flag parsing to use a `flag.NewFlagSet` and `fs.Parse(os.Args[1:])` to avoid parsing the global flags during library use or tests. 

### Testing

- Added unit tests for the event log (`internal/eventcore/log_test.go`) which validate ordering, separation of execution events, empty correlation handling and concurrent appends, and they passed. 
- Added unit tests for the command service (`internal/command/service_test.go`) which validate deterministic ID/clock filling, admission rejection behavior, and preservation of provided IDs, and they passed. 
- Added a bootstrap test (`internal/app/bootstrap_test.go`) verifying `Storage`, `EventLog`, and `CommandBus` are provided, and it passed. 
- Added an HTTP-level test (`internal/http/actions_test.go`) that checks admission rejection returns `400` without mutating storage, and it passed when running `go test ./...`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c043c93a0083249ff027b5c3a5a2a8)