### PR TITLE
Add in-memory case runtime (Slice 2)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServerWithCommandBus(":"+result.Config.Port, result.Storage, result.CommandBus)
+	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService)
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"kalita/internal/blob"
+	"kalita/internal/caseruntime"
 	"kalita/internal/catalog"
 	"kalita/internal/command"
 	"kalita/internal/config"
@@ -17,10 +18,13 @@ import (
 
 // BootstrapResult holds the initialized application components
 type BootstrapResult struct {
-	Storage    *runtime.Storage
-	EventLog   eventcore.EventLog
-	CommandBus command.CommandBus
-	Config     config.Config
+	Storage      *runtime.Storage
+	EventLog     eventcore.EventLog
+	CommandBus   command.CommandBus
+	CaseRepo     caseruntime.CaseRepository
+	CaseResolver caseruntime.CaseResolver
+	CaseService  *caseruntime.Service
+	Config       config.Config
 }
 
 // Bootstrap initializes the application with all required components
@@ -72,17 +76,25 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	// In-memory API (данные пока в памяти; PG — только схема)
 	st := runtime.NewStorage(entities, enumCatalog)
 	eventLog := eventcore.NewInMemoryEventLog()
-	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, eventcore.RealClock{}, eventcore.NewULIDGenerator())
+	clock := eventcore.RealClock{}
+	ids := eventcore.NewULIDGenerator()
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseResolver := caseruntime.NewResolver(caseRepo, clock, ids)
+	caseService := caseruntime.NewService(caseResolver, eventLog, clock, ids)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
 	st.Blob = &blob.LocalBlobStore{Root: cfg.FilesRoot}
 
 	return &BootstrapResult{
-		Storage:    st,
-		EventLog:   eventLog,
-		CommandBus: commandBus,
-		Config:     cfg,
+		Storage:      st,
+		EventLog:     eventLog,
+		CommandBus:   commandBus,
+		CaseRepo:     caseRepo,
+		CaseResolver: caseResolver,
+		CaseService:  caseService,
+		Config:       cfg,
 	}, nil
 }
 

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestBootstrapProvidesEventCenter(t *testing.T) {
+func TestBootstrapProvidesEventCenterAndCaseRuntime(t *testing.T) {
 	cfg := `{
   "port": "8080",
   "dslDir": "../../dsl",
@@ -36,5 +36,14 @@ func TestBootstrapProvidesEventCenter(t *testing.T) {
 	}
 	if result.CommandBus == nil {
 		t.Fatal("CommandBus is nil")
+	}
+	if result.CaseRepo == nil {
+		t.Fatal("CaseRepo is nil")
+	}
+	if result.CaseResolver == nil {
+		t.Fatal("CaseResolver is nil")
+	}
+	if result.CaseService == nil {
+		t.Fatal("CaseService is nil")
 	}
 }

--- a/internal/caseruntime/repository.go
+++ b/internal/caseruntime/repository.go
@@ -1,0 +1,104 @@
+package caseruntime
+
+import (
+	"context"
+	"sync"
+)
+
+type InMemoryCaseRepository struct {
+	mu              sync.RWMutex
+	byID            map[string]Case
+	idByCorrelation map[string]string
+	idBySubjectRef  map[string]string
+}
+
+func NewInMemoryCaseRepository() *InMemoryCaseRepository {
+	return &InMemoryCaseRepository{
+		byID:            make(map[string]Case),
+		idByCorrelation: make(map[string]string),
+		idBySubjectRef:  make(map[string]string),
+	}
+}
+
+func (r *InMemoryCaseRepository) Save(_ context.Context, c Case) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.byID[c.ID]; ok {
+		if existing.CorrelationID != "" && existing.CorrelationID != c.CorrelationID {
+			delete(r.idByCorrelation, existing.CorrelationID)
+		}
+		if existing.SubjectRef != "" && existing.SubjectRef != c.SubjectRef {
+			delete(r.idBySubjectRef, existing.SubjectRef)
+		}
+	}
+
+	r.byID[c.ID] = cloneCase(c)
+	if c.CorrelationID != "" {
+		r.idByCorrelation[c.CorrelationID] = c.ID
+	}
+	if c.SubjectRef != "" {
+		r.idBySubjectRef[c.SubjectRef] = c.ID
+	}
+	return nil
+}
+
+func (r *InMemoryCaseRepository) GetByID(_ context.Context, id string) (Case, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	c, ok := r.byID[id]
+	if !ok {
+		return Case{}, false, nil
+	}
+	return cloneCase(c), true, nil
+}
+
+func (r *InMemoryCaseRepository) FindByCorrelation(ctx context.Context, correlationID string) (Case, bool, error) {
+	if correlationID == "" {
+		return Case{}, false, nil
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	id, ok := r.idByCorrelation[correlationID]
+	if !ok {
+		return Case{}, false, nil
+	}
+	c, ok := r.byID[id]
+	if !ok {
+		return Case{}, false, nil
+	}
+	return cloneCase(c), true, nil
+}
+
+func (r *InMemoryCaseRepository) FindBySubjectRef(ctx context.Context, subjectRef string) (Case, bool, error) {
+	if subjectRef == "" {
+		return Case{}, false, nil
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	id, ok := r.idBySubjectRef[subjectRef]
+	if !ok {
+		return Case{}, false, nil
+	}
+	c, ok := r.byID[id]
+	if !ok {
+		return Case{}, false, nil
+	}
+	return cloneCase(c), true, nil
+}
+
+func cloneCase(c Case) Case {
+	out := c
+	if c.Attributes != nil {
+		out.Attributes = make(map[string]any, len(c.Attributes))
+		for k, v := range c.Attributes {
+			out.Attributes[k] = v
+		}
+	}
+	return out
+}

--- a/internal/caseruntime/repository_test.go
+++ b/internal/caseruntime/repository_test.go
@@ -1,0 +1,100 @@
+package caseruntime
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryCaseRepositorySaveAndGetByID(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryCaseRepository()
+	openedAt := time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)
+	input := Case{
+		ID:            "case-1",
+		Kind:          "workflow.action",
+		Status:        string(CaseOpen),
+		Title:         "workflow.action for test.WorkflowTask/rec-1",
+		SubjectRef:    "test.WorkflowTask/rec-1",
+		CorrelationID: "corr-1",
+		OpenedAt:      openedAt,
+		UpdatedAt:     openedAt,
+		Attributes:    map[string]any{"priority": "normal"},
+	}
+
+	if err := repo.Save(context.Background(), input); err != nil {
+		t.Fatalf("Save error = %v", err)
+	}
+
+	got, ok, err := repo.GetByID(context.Background(), "case-1")
+	if err != nil {
+		t.Fatalf("GetByID error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetByID ok = false, want true")
+	}
+	if got.ID != input.ID || got.CorrelationID != input.CorrelationID || got.SubjectRef != input.SubjectRef {
+		t.Fatalf("GetByID case = %#v, want %#v", got, input)
+	}
+	if got.Attributes["priority"] != "normal" {
+		t.Fatalf("attributes = %#v", got.Attributes)
+	}
+}
+
+func TestInMemoryCaseRepositoryFindByCorrelation(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryCaseRepository()
+	_ = repo.Save(context.Background(), Case{ID: "case-1", CorrelationID: "corr-1"})
+
+	got, ok, err := repo.FindByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("FindByCorrelation error = %v", err)
+	}
+	if !ok || got.ID != "case-1" {
+		t.Fatalf("FindByCorrelation = (%#v, %v), want case-1 true", got, ok)
+	}
+}
+
+func TestInMemoryCaseRepositoryFindBySubjectRef(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryCaseRepository()
+	_ = repo.Save(context.Background(), Case{ID: "case-1", SubjectRef: "test.WorkflowTask/rec-1"})
+
+	got, ok, err := repo.FindBySubjectRef(context.Background(), "test.WorkflowTask/rec-1")
+	if err != nil {
+		t.Fatalf("FindBySubjectRef error = %v", err)
+	}
+	if !ok || got.ID != "case-1" {
+		t.Fatalf("FindBySubjectRef = (%#v, %v), want case-1 true", got, ok)
+	}
+}
+
+func TestInMemoryCaseRepositoryOverwriteBySameID(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryCaseRepository()
+	ctx := context.Background()
+	if err := repo.Save(ctx, Case{ID: "case-1", CorrelationID: "corr-1", SubjectRef: "subject-1", Title: "old"}); err != nil {
+		t.Fatalf("Save(old) error = %v", err)
+	}
+	if err := repo.Save(ctx, Case{ID: "case-1", CorrelationID: "corr-2", SubjectRef: "subject-2", Title: "new"}); err != nil {
+		t.Fatalf("Save(new) error = %v", err)
+	}
+
+	got, ok, err := repo.GetByID(ctx, "case-1")
+	if err != nil {
+		t.Fatalf("GetByID error = %v", err)
+	}
+	if !ok || got.Title != "new" || got.CorrelationID != "corr-2" || got.SubjectRef != "subject-2" {
+		t.Fatalf("GetByID = %#v, ok=%v", got, ok)
+	}
+	if _, ok, _ := repo.FindByCorrelation(ctx, "corr-1"); ok {
+		t.Fatal("old correlation index still resolves")
+	}
+	if _, ok, _ := repo.FindBySubjectRef(ctx, "subject-1"); ok {
+		t.Fatal("old subject index still resolves")
+	}
+}

--- a/internal/caseruntime/resolver.go
+++ b/internal/caseruntime/resolver.go
@@ -1,0 +1,72 @@
+package caseruntime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"kalita/internal/eventcore"
+)
+
+type Resolver struct {
+	repo  CaseRepository
+	clock eventcore.Clock
+	ids   eventcore.IDGenerator
+}
+
+func NewResolver(repo CaseRepository, clock eventcore.Clock, ids eventcore.IDGenerator) *Resolver {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &Resolver{repo: repo, clock: clock, ids: ids}
+}
+
+func (r *Resolver) ResolveForCommand(ctx context.Context, cmd eventcore.Command) (Case, bool, error) {
+	if r.repo == nil {
+		return Case{}, false, fmt.Errorf("case repository is nil")
+	}
+
+	if existing, ok, err := r.repo.FindByCorrelation(ctx, cmd.CorrelationID); err != nil || ok {
+		return existing, ok, err
+	}
+	if existing, ok, err := r.repo.FindBySubjectRef(ctx, cmd.TargetRef); err != nil || ok {
+		return existing, ok, err
+	}
+
+	now := r.clock.Now()
+	opened := Case{
+		ID:            r.ids.NewID(),
+		Kind:          caseKindForCommand(cmd.Type),
+		Status:        string(CaseOpen),
+		Title:         caseTitleForCommand(cmd),
+		SubjectRef:    cmd.TargetRef,
+		CorrelationID: cmd.CorrelationID,
+		OpenedAt:      now,
+		UpdatedAt:     now,
+		Attributes: map[string]any{
+			"command_type": cmd.Type,
+		},
+	}
+	if err := r.repo.Save(ctx, opened); err != nil {
+		return Case{}, false, err
+	}
+	return opened, false, nil
+}
+
+func caseKindForCommand(commandType string) string {
+	trimmed := strings.TrimSpace(commandType)
+	if trimmed == "" {
+		return "generic"
+	}
+	return trimmed
+}
+
+func caseTitleForCommand(cmd eventcore.Command) string {
+	if cmd.TargetRef != "" {
+		return fmt.Sprintf("%s for %s", caseKindForCommand(cmd.Type), cmd.TargetRef)
+	}
+	return fmt.Sprintf("%s case", caseKindForCommand(cmd.Type))
+}

--- a/internal/caseruntime/resolver_test.go
+++ b/internal/caseruntime/resolver_test.go
@@ -1,0 +1,172 @@
+package caseruntime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"kalita/internal/eventcore"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDGenerator struct {
+	ids []string
+	i   int
+}
+
+func (f *fakeIDGenerator) NewID() string {
+	if f.i >= len(f.ids) {
+		return ""
+	}
+	id := f.ids[f.i]
+	f.i++
+	return id
+}
+
+type stubResolver struct {
+	caseValue Case
+	existed   bool
+	err       error
+}
+
+func (s stubResolver) ResolveForCommand(context.Context, eventcore.Command) (Case, bool, error) {
+	return s.caseValue, s.existed, s.err
+}
+
+func TestResolverFindsExistingCaseByCorrelation(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryCaseRepository()
+	existing := Case{ID: "case-1", CorrelationID: "corr-1", SubjectRef: "subject-1"}
+	if err := repo.Save(context.Background(), existing); err != nil {
+		t.Fatalf("Save error = %v", err)
+	}
+
+	resolver := NewResolver(repo, fakeClock{}, &fakeIDGenerator{})
+	got, existed, err := resolver.ResolveForCommand(context.Background(), eventcore.Command{CorrelationID: "corr-1", TargetRef: "subject-2"})
+	if err != nil {
+		t.Fatalf("ResolveForCommand error = %v", err)
+	}
+	if !existed || got.ID != existing.ID {
+		t.Fatalf("ResolveForCommand = (%#v, %v), want existing case", got, existed)
+	}
+}
+
+func TestResolverFindsExistingCaseBySubjectRef(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryCaseRepository()
+	existing := Case{ID: "case-1", SubjectRef: "test.WorkflowTask/rec-1"}
+	if err := repo.Save(context.Background(), existing); err != nil {
+		t.Fatalf("Save error = %v", err)
+	}
+
+	resolver := NewResolver(repo, fakeClock{}, &fakeIDGenerator{})
+	got, existed, err := resolver.ResolveForCommand(context.Background(), eventcore.Command{TargetRef: "test.WorkflowTask/rec-1"})
+	if err != nil {
+		t.Fatalf("ResolveForCommand error = %v", err)
+	}
+	if !existed || got.ID != existing.ID {
+		t.Fatalf("ResolveForCommand = (%#v, %v), want existing case", got, existed)
+	}
+}
+
+func TestResolverCreatesNewCaseWhenNoneFound(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryCaseRepository()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 11, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"case-1"}}
+	resolver := NewResolver(repo, clock, ids)
+
+	got, existed, err := resolver.ResolveForCommand(context.Background(), eventcore.Command{Type: "workflow.action", CorrelationID: "corr-1", TargetRef: "test.WorkflowTask/rec-1"})
+	if err != nil {
+		t.Fatalf("ResolveForCommand error = %v", err)
+	}
+	if existed {
+		t.Fatal("existed = true, want false")
+	}
+	if got.ID != "case-1" || got.Status != string(CaseOpen) {
+		t.Fatalf("new case = %#v", got)
+	}
+
+	saved, ok, err := repo.GetByID(context.Background(), "case-1")
+	if err != nil {
+		t.Fatalf("GetByID error = %v", err)
+	}
+	if !ok || saved.ID != "case-1" {
+		t.Fatalf("saved = %#v, ok=%v", saved, ok)
+	}
+}
+
+func TestResolverCreatesDeterministicFields(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryCaseRepository()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 12, 34, 56, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"case-123"}}
+	resolver := NewResolver(repo, clock, ids)
+	cmd := eventcore.Command{Type: "workflow.action", CorrelationID: "corr-9", TargetRef: "test.WorkflowTask/rec-9"}
+
+	got, existed, err := resolver.ResolveForCommand(context.Background(), cmd)
+	if err != nil {
+		t.Fatalf("ResolveForCommand error = %v", err)
+	}
+	if existed {
+		t.Fatal("existed = true, want false")
+	}
+	if got.ID != "case-123" || got.Kind != "workflow.action" || got.Status != string(CaseOpen) {
+		t.Fatalf("case identity fields = %#v", got)
+	}
+	if got.CorrelationID != "corr-9" || got.SubjectRef != "test.WorkflowTask/rec-9" {
+		t.Fatalf("case links = %#v", got)
+	}
+	if got.Title != "workflow.action for test.WorkflowTask/rec-9" {
+		t.Fatalf("Title = %q", got.Title)
+	}
+	if !got.OpenedAt.Equal(clock.now) || !got.UpdatedAt.Equal(clock.now) {
+		t.Fatalf("times = opened %v updated %v want %v", got.OpenedAt, got.UpdatedAt, clock.now)
+	}
+}
+
+func TestCaseServiceResolveCommandNormalizesCommandAndAppendsExecutionEvent(t *testing.T) {
+	t.Parallel()
+
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 13, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"exec-event-1"}}
+	service := NewService(stubResolver{caseValue: Case{ID: "case-1", Kind: "workflow.action", SubjectRef: "target-1"}}, log, clock, ids)
+
+	result, err := service.ResolveCommand(context.Background(), eventcore.Command{ID: "cmd-1", Type: "workflow.action", CorrelationID: "corr-1", ExecutionID: "exec-1", TargetRef: "target-1"})
+	if err != nil {
+		t.Fatalf("ResolveCommand error = %v", err)
+	}
+	if result.Command.CaseID != "case-1" || result.Case.ID != "case-1" {
+		t.Fatalf("result = %#v", result)
+	}
+	_, executionEvents, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(executionEvents) != 1 {
+		t.Fatalf("executionEvents len = %d, want 1", len(executionEvents))
+	}
+	if executionEvents[0].Step != "case_resolution" || executionEvents[0].Status != "opened_new" {
+		t.Fatalf("execution event = %#v", executionEvents[0])
+	}
+}
+
+func TestCaseServiceReturnsResolverFailure(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("resolve failed")
+	service := NewService(stubResolver{err: wantErr}, nil, fakeClock{}, &fakeIDGenerator{})
+	_, err := service.ResolveCommand(context.Background(), eventcore.Command{})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ResolveCommand error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/caseruntime/service.go
+++ b/internal/caseruntime/service.go
@@ -1,0 +1,74 @@
+package caseruntime
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/eventcore"
+)
+
+type Service struct {
+	resolver CaseResolver
+	log      eventcore.EventLog
+	clock    eventcore.Clock
+	ids      eventcore.IDGenerator
+}
+
+type ResolutionResult struct {
+	Command eventcore.Command
+	Case    Case
+	Event   eventcore.ExecutionEvent
+	Existed bool
+}
+
+func NewService(resolver CaseResolver, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *Service {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &Service{resolver: resolver, log: log, clock: clock, ids: ids}
+}
+
+func (s *Service) ResolveCommand(ctx context.Context, cmd eventcore.Command) (ResolutionResult, error) {
+	if s.resolver == nil {
+		return ResolutionResult{}, fmt.Errorf("case resolver is nil")
+	}
+
+	resolvedCase, existed, err := s.resolver.ResolveForCommand(ctx, cmd)
+	if err != nil {
+		return ResolutionResult{}, err
+	}
+
+	cmd.CaseID = resolvedCase.ID
+	status := "opened_new"
+	if existed {
+		status = "resolved_existing"
+	}
+
+	execEvent := eventcore.ExecutionEvent{
+		ID:            s.ids.NewID(),
+		ExecutionID:   cmd.ExecutionID,
+		CaseID:        resolvedCase.ID,
+		Step:          "case_resolution",
+		Status:        status,
+		OccurredAt:    s.clock.Now(),
+		CorrelationID: cmd.CorrelationID,
+		CausationID:   cmd.ID,
+		Payload: map[string]any{
+			"case_id":      resolvedCase.ID,
+			"case_kind":    resolvedCase.Kind,
+			"subject_ref":  resolvedCase.SubjectRef,
+			"command_type": cmd.Type,
+		},
+	}
+
+	if s.log != nil {
+		if err := s.log.AppendExecutionEvent(ctx, execEvent); err != nil {
+			return ResolutionResult{}, err
+		}
+	}
+
+	return ResolutionResult{Command: cmd, Case: resolvedCase, Event: execEvent, Existed: existed}, nil
+}

--- a/internal/caseruntime/types.go
+++ b/internal/caseruntime/types.go
@@ -1,0 +1,40 @@
+package caseruntime
+
+import (
+	"context"
+	"time"
+
+	"kalita/internal/eventcore"
+)
+
+type CaseStatus string
+
+const (
+	CaseOpen   CaseStatus = "open"
+	CaseClosed CaseStatus = "closed"
+)
+
+type Case struct {
+	ID            string
+	Kind          string
+	Status        string
+	Title         string
+	SubjectRef    string
+	CorrelationID string
+	OpenedAt      time.Time
+	UpdatedAt     time.Time
+	OwnerQueueID  string
+	CurrentPlanID string
+	Attributes    map[string]any
+}
+
+type CaseRepository interface {
+	Save(ctx context.Context, c Case) error
+	GetByID(ctx context.Context, id string) (Case, bool, error)
+	FindByCorrelation(ctx context.Context, correlationID string) (Case, bool, error)
+	FindBySubjectRef(ctx context.Context, subjectRef string) (Case, bool, error)
+}
+
+type CaseResolver interface {
+	ResolveForCommand(ctx context.Context, cmd eventcore.Command) (Case, bool, error)
+}

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -2,11 +2,13 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 
+	"kalita/internal/caseruntime"
 	"kalita/internal/command"
 	"kalita/internal/eventcore"
 	"kalita/internal/runtime"
@@ -21,10 +23,18 @@ type actionRequest struct {
 }
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
-	return ActionHandlerWithCommandBus(storage, nil)
+	return ActionHandlerWithServices(storage, nil, nil)
 }
 
 func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.CommandBus) gin.HandlerFunc {
+	return ActionHandlerWithServices(storage, commandBus, nil)
+}
+
+type commandCaseResolver interface {
+	ResolveCommand(ctx context.Context, cmd eventcore.Command) (caseruntime.ResolutionResult, error)
+}
+
+func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		fqn, action, req, ok := parseActionRequest(c, storage)
 		if !ok {
@@ -33,13 +43,24 @@ func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.Co
 
 		if commandBus != nil {
 			cmd := buildWorkflowActionCommand(c, fqn, action, req)
-			if _, err := commandBus.Submit(c.Request.Context(), cmd); err != nil {
+			admitted, err := commandBus.Submit(c.Request.Context(), cmd)
+			if err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
 					Code:    validation.ErrTypeMismatch,
 					Field:   "action",
 					Message: err.Error(),
 				}}})
 				return
+			}
+			if caseService != nil {
+				if _, err := caseService.ResolveCommand(c.Request.Context(), admitted); err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+						Code:    validation.ErrTypeMismatch,
+						Field:   "action",
+						Message: err.Error(),
+					}}})
+					return
+				}
 			}
 		}
 

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"kalita/internal/caseruntime"
+	"kalita/internal/command"
 	"kalita/internal/eventcore"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
@@ -164,6 +166,24 @@ func TestExistingPatchCompatibilityStillWorks(t *testing.T) {
 	}
 }
 
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDGenerator struct {
+	ids []string
+	i   int
+}
+
+func (f *fakeIDGenerator) NewID() string {
+	if f.i >= len(f.ids) {
+		return ""
+	}
+	id := f.ids[f.i]
+	f.i++
+	return id
+}
+
 func testHTTPWorkflowStorage() (*runtime.Storage, *runtime.Record) {
 	entity := &schema.Entity{
 		Name:   "WorkflowTask",
@@ -195,10 +215,106 @@ func testHTTPWorkflowStorage() (*runtime.Storage, *runtime.Record) {
 	return st, rec
 }
 
+type staticCommandBus struct {
+	cmd eventcore.Command
+}
+
+func (b staticCommandBus) Submit(_ context.Context, _ eventcore.Command) (eventcore.Command, error) {
+	return b.cmd, nil
+}
+
+type failingCaseService struct {
+	err error
+}
+
+func (s failingCaseService) ResolveCommand(context.Context, eventcore.Command) (caseruntime.ResolutionResult, error) {
+	return caseruntime.ResolutionResult{}, s.err
+}
+
 type denyCommandBus struct{}
 
 func (denyCommandBus) Submit(_ context.Context, _ eventcore.Command) (eventcore.Command, error) {
 	return eventcore.Command{}, errors.New("command denied")
+}
+
+func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "followup-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	storedCase, err := caseService.ResolveCommand(context.Background(), eventcore.Command{
+		ID: "cmd-followup", CorrelationID: "corr-1", ExecutionID: "exec-followup", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID,
+	})
+	if err != nil {
+		t.Fatalf("followup ResolveCommand error = %v", err)
+	}
+	if !storedCase.Existed || storedCase.Case.ID != "case-1" {
+		t.Fatalf("followup result = %#v", storedCase)
+	}
+	caseByID, ok, err := caseRepo.GetByID(context.Background(), "case-1")
+	if err != nil {
+		t.Fatalf("GetByID error = %v", err)
+	}
+	if !ok || caseByID.SubjectRef != "test.WorkflowTask/"+rec.ID {
+		t.Fatalf("stored case = %#v ok=%v", caseByID, ok)
+	}
+	_, executionEvents, err := eventLog.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(executionEvents) < 2 {
+		t.Fatalf("execution events len = %d, want at least 2", len(executionEvents))
+	}
+	if executionEvents[0].Step != "command_admission" || executionEvents[0].Status != "admitted" {
+		t.Fatalf("first execution event = %#v", executionEvents[0])
+	}
+	if executionEvents[1].Step != "case_resolution" || executionEvents[1].Status != "opened_new" {
+		t.Fatalf("second execution event = %#v", executionEvents[1])
+	}
+}
+
+func TestActionHandlerReturnsValidationErrorWhenCaseResolutionFails(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
 }
 
 func TestActionHandlerReturnsValidationErrorWhenCommandAdmissionFails(t *testing.T) {

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -3,6 +3,7 @@ package http
 import (
 	"log"
 
+	"kalita/internal/caseruntime"
 	"kalita/internal/command"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
@@ -11,10 +12,14 @@ import (
 )
 
 func RunServer(addr string, storage *runtime.Storage) {
-	RunServerWithCommandBus(addr, storage, nil)
+	RunServerWithServices(addr, storage, nil, nil)
 }
 
 func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus command.CommandBus) {
+	RunServerWithServices(addr, storage, commandBus, nil)
+}
+
+func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -34,7 +39,7 @@ func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus c
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
-		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithCommandBus(storage, commandBus))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
 		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))


### PR DESCRIPTION
### Motivation

- Introduce a minimal, transport-free Case runtime so admitted commands/events can be attached to a `Case` before later queue/plan/policy slices. 
- Provide an in-memory, testable repository and deterministic resolution logic without adding queue planning, digital employee execution, or policy/approval behavior. 
- Keep the change incremental and preserve existing runtime/CRUD/legacy workflow behavior while exposing case runtime components via bootstrap.

### Description

- Added a new `internal/caseruntime` package with `types.go`, `repository.go`, `resolver.go`, `service.go` and tests to define the `Case` model, `CaseRepository`/`CaseResolver` interfaces, an in-memory thread-safe repository, a resolver that opens/resolves cases, and a service that normalizes commands and emits a `case_resolution` execution event. 
- Implemented repository semantics: thread-safe `Save`, `GetByID`, `FindByCorrelation`, and `FindBySubjectRef`, plus overwrite semantics that keep indexes in-sync. 
- Resolver behavior: prefer existing case by `CorrelationID`, then by `SubjectRef`, otherwise create a new `Case` with deterministic `ID`/timestamps/`Title` using injected `Clock` and `IDGenerator`. 
- Service behavior: given an admitted `Command`, set `Command.CaseID`, return the resolved/opened `Case`, and append a `case_resolution` `ExecutionEvent` with status `opened_new` or `resolved_existing` to the existing `EventLog`. 
- Bootstrapped and wired the new runtime: `Bootstrap` now constructs `CaseRepo`, `CaseResolver`, and `CaseService` and exposes them in `BootstrapResult`, and HTTP server wiring passes the `CaseService` into the workflow action compatibility seam. 
- Extended only the workflow action compatibility seam in `internal/http/actions.go` to call case resolution after command admission, returning the existing-style validation error on resolver failure and otherwise continuing the legacy workflow path unchanged.

### Testing

- Ran `go test -count=1 ./internal/caseruntime` and all caseruntime unit tests passed. 
- Ran `go test -vet=off -count=1 ./internal/http` and the HTTP compatibility/seam tests (including case resolution integration scenarios) passed. 
- Ran `go test -count=1 ./internal/app` and the bootstrap test confirming exposure of case runtime components passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04b360d888324a61597f614163253)