### PR TITLE
Add Slice 3 workplan intake layer

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService)
+	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService)
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -14,17 +15,21 @@ import (
 	"kalita/internal/postgres"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
+	"kalita/internal/workplan"
 )
 
 // BootstrapResult holds the initialized application components
 type BootstrapResult struct {
-	Storage      *runtime.Storage
-	EventLog     eventcore.EventLog
-	CommandBus   command.CommandBus
-	CaseRepo     caseruntime.CaseRepository
-	CaseResolver caseruntime.CaseResolver
-	CaseService  *caseruntime.Service
-	Config       config.Config
+	Storage          *runtime.Storage
+	EventLog         eventcore.EventLog
+	CommandBus       command.CommandBus
+	CaseRepo         caseruntime.CaseRepository
+	CaseResolver     caseruntime.CaseResolver
+	CaseService      *caseruntime.Service
+	QueueRepo        workplan.QueueRepository
+	AssignmentRouter workplan.AssignmentRouter
+	WorkService      *workplan.Service
+	Config           config.Config
 }
 
 // Bootstrap initializes the application with all required components
@@ -82,19 +87,35 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	caseRepo := caseruntime.NewInMemoryCaseRepository()
 	caseResolver := caseruntime.NewResolver(caseRepo, clock, ids)
 	caseService := caseruntime.NewService(caseResolver, eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	defaultQueue := workplan.WorkQueue{
+		ID:               "default-intake",
+		Name:             "Default Intake",
+		Department:       "operations",
+		Purpose:          "Default operational intake for resolved cases",
+		AllowedCaseKinds: []string{"workflow.action"},
+	}
+	if err := queueRepo.SaveQueue(context.Background(), defaultQueue); err != nil {
+		return nil, fmt.Errorf("seed default queue: %w", err)
+	}
+	assignmentRouter := workplan.NewRouter(queueRepo, defaultQueue.ID)
+	workService := workplan.NewService(queueRepo, assignmentRouter, eventLog, clock, ids)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
 	st.Blob = &blob.LocalBlobStore{Root: cfg.FilesRoot}
 
 	return &BootstrapResult{
-		Storage:      st,
-		EventLog:     eventLog,
-		CommandBus:   commandBus,
-		CaseRepo:     caseRepo,
-		CaseResolver: caseResolver,
-		CaseService:  caseService,
-		Config:       cfg,
+		Storage:          st,
+		EventLog:         eventLog,
+		CommandBus:       commandBus,
+		CaseRepo:         caseRepo,
+		CaseResolver:     caseResolver,
+		CaseService:      caseService,
+		QueueRepo:        queueRepo,
+		AssignmentRouter: assignmentRouter,
+		WorkService:      workService,
+		Config:           cfg,
 	}, nil
 }
 

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -1,12 +1,13 @@
 package app
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestBootstrapProvidesEventCenterAndCaseRuntime(t *testing.T) {
+func TestBootstrapProvidesEventCenterCaseRuntimeAndWorkplan(t *testing.T) {
 	cfg := `{
   "port": "8080",
   "dslDir": "../../dsl",
@@ -45,5 +46,21 @@ func TestBootstrapProvidesEventCenterAndCaseRuntime(t *testing.T) {
 	}
 	if result.CaseService == nil {
 		t.Fatal("CaseService is nil")
+	}
+	if result.QueueRepo == nil {
+		t.Fatal("QueueRepo is nil")
+	}
+	if result.AssignmentRouter == nil {
+		t.Fatal("AssignmentRouter is nil")
+	}
+	if result.WorkService == nil {
+		t.Fatal("WorkService is nil")
+	}
+	queues, err := result.QueueRepo.ListQueues(context.Background())
+	if err != nil {
+		t.Fatalf("ListQueues error = %v", err)
+	}
+	if len(queues) == 0 || queues[0].ID != "default-intake" {
+		t.Fatalf("queues = %#v", queues)
 	}
 }

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -13,6 +13,7 @@ import (
 	"kalita/internal/eventcore"
 	"kalita/internal/runtime"
 	"kalita/internal/validation"
+	"kalita/internal/workplan"
 
 	"github.com/gin-gonic/gin"
 )
@@ -23,18 +24,22 @@ type actionRequest struct {
 }
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, nil, nil)
+	return ActionHandlerWithServices(storage, nil, nil, nil)
 }
 
 func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.CommandBus) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, commandBus, nil)
+	return ActionHandlerWithServices(storage, commandBus, nil, nil)
 }
 
 type commandCaseResolver interface {
 	ResolveCommand(ctx context.Context, cmd eventcore.Command) (caseruntime.ResolutionResult, error)
 }
 
-func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver) gin.HandlerFunc {
+type workItemIntakeService interface {
+	IntakeCommand(ctx context.Context, resolved caseruntime.ResolutionResult) (workplan.IntakeResult, error)
+}
+
+func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		fqn, action, req, ok := parseActionRequest(c, storage)
 		if !ok {
@@ -53,13 +58,24 @@ func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.Comm
 				return
 			}
 			if caseService != nil {
-				if _, err := caseService.ResolveCommand(c.Request.Context(), admitted); err != nil {
+				resolved, err := caseService.ResolveCommand(c.Request.Context(), admitted)
+				if err != nil {
 					c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
 						Code:    validation.ErrTypeMismatch,
 						Field:   "action",
 						Message: err.Error(),
 					}}})
 					return
+				}
+				if workService != nil {
+					if _, err := workService.IntakeCommand(c.Request.Context(), resolved); err != nil {
+						c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+							Code:    validation.ErrTypeMismatch,
+							Field:   "action",
+							Message: err.Error(),
+						}}})
+						return
+					}
 				}
 			}
 		}

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -15,6 +15,7 @@ import (
 	"kalita/internal/eventcore"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
+	"kalita/internal/workplan"
 
 	"github.com/gin-gonic/gin"
 )
@@ -237,6 +238,14 @@ func (denyCommandBus) Submit(_ context.Context, _ eventcore.Command) (eventcore.
 	return eventcore.Command{}, errors.New("command denied")
 }
 
+type failingWorkService struct {
+	err error
+}
+
+func (s failingWorkService) IntakeCommand(context.Context, caseruntime.ResolutionResult) (workplan.IntakeResult, error) {
+	return workplan.IntakeResult{}, s.err
+}
+
 func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -248,9 +257,14 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
 	caseRepo := caseruntime.NewInMemoryCaseRepository()
 	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -283,14 +297,27 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListByCorrelation error = %v", err)
 	}
-	if len(executionEvents) < 2 {
-		t.Fatalf("execution events len = %d, want at least 2", len(executionEvents))
+	if len(executionEvents) < 3 {
+		t.Fatalf("execution events len = %d, want at least 3", len(executionEvents))
 	}
 	if executionEvents[0].Step != "command_admission" || executionEvents[0].Status != "admitted" {
 		t.Fatalf("first execution event = %#v", executionEvents[0])
 	}
 	if executionEvents[1].Step != "case_resolution" || executionEvents[1].Status != "opened_new" {
 		t.Fatalf("second execution event = %#v", executionEvents[1])
+	}
+	if executionEvents[2].Step != "work_item_intake" || executionEvents[2].Status != "created" {
+		t.Fatalf("third execution event = %#v", executionEvents[2])
+	}
+	workItems, err := queueRepo.ListWorkItemsByCase(context.Background(), "case-1")
+	if err != nil {
+		t.Fatalf("ListWorkItemsByCase error = %v", err)
+	}
+	if len(workItems) != 1 || workItems[0].QueueID != "default-intake" {
+		t.Fatalf("workItems = %#v", workItems)
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("legacy flow mutated status to %v", got)
 	}
 }
 
@@ -300,7 +327,36 @@ func TestActionHandlerReturnsValidationErrorWhenCaseResolutionFails(t *testing.T
 
 	storage, rec := testHTTPWorkflowStorage()
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
+}
+
+func TestActionHandlerReturnsValidationErrorWhenWorkItemIntakeFails(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -12,14 +12,14 @@ import (
 )
 
 func RunServer(addr string, storage *runtime.Storage) {
-	RunServerWithServices(addr, storage, nil, nil)
+	RunServerWithServices(addr, storage, nil, nil, nil)
 }
 
 func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus command.CommandBus) {
-	RunServerWithServices(addr, storage, commandBus, nil)
+	RunServerWithServices(addr, storage, commandBus, nil, nil)
 }
 
-func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service) {
+func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -39,7 +39,7 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
-		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
 		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))

--- a/internal/workplan/repository.go
+++ b/internal/workplan/repository.go
@@ -1,0 +1,145 @@
+package workplan
+
+import (
+	"context"
+	"sync"
+)
+
+type InMemoryQueueRepository struct {
+	mu             sync.RWMutex
+	queuesByID     map[string]WorkQueue
+	queueOrder     []string
+	workItemsByID  map[string]WorkItem
+	workItemOrder  []string
+	workIDsByCase  map[string][]string
+	workIDsByQueue map[string][]string
+}
+
+func NewInMemoryQueueRepository() *InMemoryQueueRepository {
+	return &InMemoryQueueRepository{
+		queuesByID:     make(map[string]WorkQueue),
+		workItemsByID:  make(map[string]WorkItem),
+		workIDsByCase:  make(map[string][]string),
+		workIDsByQueue: make(map[string][]string),
+	}
+}
+
+func (r *InMemoryQueueRepository) SaveQueue(_ context.Context, q WorkQueue) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.queuesByID[q.ID]; !exists {
+		r.queueOrder = append(r.queueOrder, q.ID)
+	}
+	r.queuesByID[q.ID] = cloneQueue(q)
+	return nil
+}
+
+func (r *InMemoryQueueRepository) GetQueue(_ context.Context, id string) (WorkQueue, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	q, ok := r.queuesByID[id]
+	if !ok {
+		return WorkQueue{}, false, nil
+	}
+	return cloneQueue(q), true, nil
+}
+
+func (r *InMemoryQueueRepository) ListQueues(_ context.Context) ([]WorkQueue, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]WorkQueue, 0, len(r.queueOrder))
+	for _, id := range r.queueOrder {
+		out = append(out, cloneQueue(r.queuesByID[id]))
+	}
+	return out, nil
+}
+
+func (r *InMemoryQueueRepository) SaveWorkItem(_ context.Context, wi WorkItem) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, exists := r.workItemsByID[wi.ID]; exists {
+		if existing.CaseID != wi.CaseID {
+			r.workIDsByCase[existing.CaseID] = removeID(r.workIDsByCase[existing.CaseID], wi.ID)
+		}
+		if existing.QueueID != wi.QueueID {
+			r.workIDsByQueue[existing.QueueID] = removeID(r.workIDsByQueue[existing.QueueID], wi.ID)
+		}
+	} else {
+		r.workItemOrder = append(r.workItemOrder, wi.ID)
+	}
+	if !containsID(r.workIDsByCase[wi.CaseID], wi.ID) {
+		r.workIDsByCase[wi.CaseID] = append(r.workIDsByCase[wi.CaseID], wi.ID)
+	}
+	if !containsID(r.workIDsByQueue[wi.QueueID], wi.ID) {
+		r.workIDsByQueue[wi.QueueID] = append(r.workIDsByQueue[wi.QueueID], wi.ID)
+	}
+	r.workItemsByID[wi.ID] = cloneWorkItem(wi)
+	return nil
+}
+
+func (r *InMemoryQueueRepository) GetWorkItem(_ context.Context, id string) (WorkItem, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	wi, ok := r.workItemsByID[id]
+	if !ok {
+		return WorkItem{}, false, nil
+	}
+	return cloneWorkItem(wi), true, nil
+}
+
+func (r *InMemoryQueueRepository) ListWorkItemsByCase(_ context.Context, caseID string) ([]WorkItem, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.workIDsByCase[caseID]
+	out := make([]WorkItem, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, cloneWorkItem(r.workItemsByID[id]))
+	}
+	return out, nil
+}
+
+func (r *InMemoryQueueRepository) ListWorkItemsByQueue(_ context.Context, queueID string) ([]WorkItem, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.workIDsByQueue[queueID]
+	out := make([]WorkItem, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, cloneWorkItem(r.workItemsByID[id]))
+	}
+	return out, nil
+}
+
+func cloneQueue(q WorkQueue) WorkQueue {
+	out := q
+	out.AllowedCaseKinds = append([]string(nil), q.AllowedCaseKinds...)
+	out.DefaultEmployeeIDs = append([]string(nil), q.DefaultEmployeeIDs...)
+	return out
+}
+
+func cloneWorkItem(wi WorkItem) WorkItem {
+	out := wi
+	if wi.DueAt != nil {
+		due := *wi.DueAt
+		out.DueAt = &due
+	}
+	return out
+}
+
+func containsID(ids []string, target string) bool {
+	for _, id := range ids {
+		if id == target {
+			return true
+		}
+	}
+	return false
+}
+
+func removeID(ids []string, target string) []string {
+	out := ids[:0]
+	for _, id := range ids {
+		if id != target {
+			out = append(out, id)
+		}
+	}
+	return out
+}

--- a/internal/workplan/repository_test.go
+++ b/internal/workplan/repository_test.go
@@ -1,0 +1,60 @@
+package workplan
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInMemoryQueueRepositorySaveGetListQueue(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryQueueRepository()
+	queue := WorkQueue{ID: "queue-1", Name: "Operations", AllowedCaseKinds: []string{"workflow.action"}}
+	if err := repo.SaveQueue(context.Background(), queue); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	got, ok, err := repo.GetQueue(context.Background(), "queue-1")
+	if err != nil || !ok {
+		t.Fatalf("GetQueue = %#v ok=%v err=%v", got, ok, err)
+	}
+	got.AllowedCaseKinds[0] = "mutated"
+	reloaded, _, _ := repo.GetQueue(context.Background(), "queue-1")
+	if reloaded.AllowedCaseKinds[0] != "workflow.action" {
+		t.Fatalf("queue clone failed: %#v", reloaded)
+	}
+	queues, err := repo.ListQueues(context.Background())
+	if err != nil {
+		t.Fatalf("ListQueues error = %v", err)
+	}
+	if len(queues) != 1 || queues[0].ID != "queue-1" {
+		t.Fatalf("queues = %#v", queues)
+	}
+}
+
+func TestInMemoryQueueRepositorySaveGetListWorkItemsByCaseAndQueue(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryQueueRepository()
+	items := []WorkItem{{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1", Type: "workflow.action"}, {ID: "wi-2", CaseID: "case-1", QueueID: "queue-2", Type: "followup"}, {ID: "wi-3", CaseID: "case-2", QueueID: "queue-1", Type: "other"}}
+	for _, item := range items {
+		if err := repo.SaveWorkItem(context.Background(), item); err != nil {
+			t.Fatalf("SaveWorkItem(%s) error = %v", item.ID, err)
+		}
+	}
+	got, ok, err := repo.GetWorkItem(context.Background(), "wi-1")
+	if err != nil || !ok {
+		t.Fatalf("GetWorkItem = %#v ok=%v err=%v", got, ok, err)
+	}
+	byCase, err := repo.ListWorkItemsByCase(context.Background(), "case-1")
+	if err != nil {
+		t.Fatalf("ListWorkItemsByCase error = %v", err)
+	}
+	if len(byCase) != 2 || byCase[0].ID != "wi-1" || byCase[1].ID != "wi-2" {
+		t.Fatalf("byCase = %#v", byCase)
+	}
+	byQueue, err := repo.ListWorkItemsByQueue(context.Background(), "queue-1")
+	if err != nil {
+		t.Fatalf("ListWorkItemsByQueue error = %v", err)
+	}
+	if len(byQueue) != 2 || byQueue[0].ID != "wi-1" || byQueue[1].ID != "wi-3" {
+		t.Fatalf("byQueue = %#v", byQueue)
+	}
+}

--- a/internal/workplan/router.go
+++ b/internal/workplan/router.go
@@ -1,0 +1,42 @@
+package workplan
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/caseruntime"
+)
+
+type Router struct {
+	repo           QueueRepository
+	defaultQueueID string
+}
+
+func NewRouter(repo QueueRepository, defaultQueueID string) *Router {
+	return &Router{repo: repo, defaultQueueID: defaultQueueID}
+}
+
+func (r *Router) RouteCase(ctx context.Context, c caseruntime.Case) (WorkQueue, error) {
+	if r.repo == nil {
+		return WorkQueue{}, fmt.Errorf("queue repository is nil")
+	}
+	queues, err := r.repo.ListQueues(ctx)
+	if err != nil {
+		return WorkQueue{}, err
+	}
+	for _, q := range queues {
+		for _, allowed := range q.AllowedCaseKinds {
+			if allowed == c.Kind {
+				return q, nil
+			}
+		}
+	}
+	if r.defaultQueueID != "" {
+		if q, ok, err := r.repo.GetQueue(ctx, r.defaultQueueID); err != nil {
+			return WorkQueue{}, err
+		} else if ok {
+			return q, nil
+		}
+	}
+	return WorkQueue{}, fmt.Errorf("no queue available for case kind %q", c.Kind)
+}

--- a/internal/workplan/router_test.go
+++ b/internal/workplan/router_test.go
@@ -1,0 +1,46 @@
+package workplan
+
+import (
+	"context"
+	"testing"
+
+	"kalita/internal/caseruntime"
+)
+
+func TestRouterRoutesByCaseKind(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryQueueRepository()
+	_ = repo.SaveQueue(context.Background(), WorkQueue{ID: "queue-1", AllowedCaseKinds: []string{"workflow.action"}})
+	_ = repo.SaveQueue(context.Background(), WorkQueue{ID: "queue-2", AllowedCaseKinds: []string{"other"}})
+	router := NewRouter(repo, "")
+	queue, err := router.RouteCase(context.Background(), caseruntime.Case{Kind: "workflow.action"})
+	if err != nil {
+		t.Fatalf("RouteCase error = %v", err)
+	}
+	if queue.ID != "queue-1" {
+		t.Fatalf("queue = %#v", queue)
+	}
+}
+
+func TestRouterFallsBackToDefaultQueue(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryQueueRepository()
+	_ = repo.SaveQueue(context.Background(), WorkQueue{ID: "default-queue", Name: "Default"})
+	router := NewRouter(repo, "default-queue")
+	queue, err := router.RouteCase(context.Background(), caseruntime.Case{Kind: "missing"})
+	if err != nil {
+		t.Fatalf("RouteCase error = %v", err)
+	}
+	if queue.ID != "default-queue" {
+		t.Fatalf("queue = %#v", queue)
+	}
+}
+
+func TestRouterReturnsErrorWhenNoRouteExists(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryQueueRepository()
+	router := NewRouter(repo, "")
+	if _, err := router.RouteCase(context.Background(), caseruntime.Case{Kind: "missing"}); err == nil {
+		t.Fatal("RouteCase error = nil, want non-nil")
+	}
+}

--- a/internal/workplan/service.go
+++ b/internal/workplan/service.go
@@ -1,0 +1,98 @@
+package workplan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"kalita/internal/caseruntime"
+	"kalita/internal/eventcore"
+)
+
+type Service struct {
+	repo   QueueRepository
+	router AssignmentRouter
+	log    eventcore.EventLog
+	clock  eventcore.Clock
+	ids    eventcore.IDGenerator
+}
+
+type IntakeResult struct {
+	Command   eventcore.Command
+	Case      caseruntime.Case
+	Queue     WorkQueue
+	WorkItem  WorkItem
+	ExecEvent eventcore.ExecutionEvent
+}
+
+func NewService(repo QueueRepository, router AssignmentRouter, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *Service {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &Service{repo: repo, router: router, log: log, clock: clock, ids: ids}
+}
+
+func (s *Service) IntakeCommand(ctx context.Context, resolved caseruntime.ResolutionResult) (IntakeResult, error) {
+	if s.repo == nil {
+		return IntakeResult{}, fmt.Errorf("queue repository is nil")
+	}
+	if s.router == nil {
+		return IntakeResult{}, fmt.Errorf("assignment router is nil")
+	}
+	queue, err := s.router.RouteCase(ctx, resolved.Case)
+	if err != nil {
+		return IntakeResult{}, err
+	}
+	now := s.clock.Now()
+	workItem := WorkItem{
+		ID:        s.ids.NewID(),
+		CaseID:    resolved.Case.ID,
+		QueueID:   queue.ID,
+		Type:      workItemTypeForCommand(resolved.Command),
+		Status:    string(WorkItemOpen),
+		Reason:    workItemReason(resolved.Case, resolved.Command),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.repo.SaveWorkItem(ctx, workItem); err != nil {
+		return IntakeResult{}, err
+	}
+	execEvent := eventcore.ExecutionEvent{
+		ID:            s.ids.NewID(),
+		ExecutionID:   resolved.Command.ExecutionID,
+		CaseID:        resolved.Case.ID,
+		Step:          "work_item_intake",
+		Status:        "created",
+		OccurredAt:    now,
+		CorrelationID: resolved.Command.CorrelationID,
+		CausationID:   resolved.Command.ID,
+		Payload: map[string]any{
+			"case_id":      resolved.Case.ID,
+			"queue_id":     queue.ID,
+			"work_item_id": workItem.ID,
+		},
+	}
+	if s.log != nil {
+		if err := s.log.AppendExecutionEvent(ctx, execEvent); err != nil {
+			return IntakeResult{}, err
+		}
+	}
+	return IntakeResult{Command: resolved.Command, Case: resolved.Case, Queue: queue, WorkItem: workItem, ExecEvent: execEvent}, nil
+}
+
+func workItemTypeForCommand(cmd eventcore.Command) string {
+	if strings.TrimSpace(cmd.Type) != "" {
+		return cmd.Type
+	}
+	return "generic"
+}
+
+func workItemReason(c caseruntime.Case, cmd eventcore.Command) string {
+	if cmd.TargetRef != "" {
+		return fmt.Sprintf("intake %s for %s", c.Kind, cmd.TargetRef)
+	}
+	return fmt.Sprintf("intake %s", c.Kind)
+}

--- a/internal/workplan/service_test.go
+++ b/internal/workplan/service_test.go
@@ -1,0 +1,64 @@
+package workplan
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/caseruntime"
+	"kalita/internal/eventcore"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDGenerator struct {
+	ids []string
+	i   int
+}
+
+func (f *fakeIDGenerator) NewID() string { id := f.ids[f.i]; f.i++; return id }
+
+func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryQueueRepository()
+	if err := repo.SaveQueue(context.Background(), WorkQueue{ID: "queue-1", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 15, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"work-1", "event-1"}}
+	service := NewService(repo, NewRouter(repo, ""), log, clock, ids)
+	resolved := caseruntime.ResolutionResult{Command: eventcore.Command{ID: "cmd-1", Type: "workflow.action", CorrelationID: "corr-1", ExecutionID: "exec-1", TargetRef: "test.WorkflowTask/rec-1"}, Case: caseruntime.Case{ID: "case-1", Kind: "workflow.action"}}
+
+	result, err := service.IntakeCommand(context.Background(), resolved)
+	if err != nil {
+		t.Fatalf("IntakeCommand error = %v", err)
+	}
+	if result.WorkItem.ID != "work-1" || result.WorkItem.CaseID != "case-1" || result.WorkItem.QueueID != "queue-1" {
+		t.Fatalf("work item = %#v", result.WorkItem)
+	}
+	if result.WorkItem.Type != "workflow.action" || result.WorkItem.Status != string(WorkItemOpen) {
+		t.Fatalf("work item = %#v", result.WorkItem)
+	}
+	if result.WorkItem.Reason != "intake workflow.action for test.WorkflowTask/rec-1" {
+		t.Fatalf("reason = %q", result.WorkItem.Reason)
+	}
+	if !result.WorkItem.CreatedAt.Equal(clock.now) || !result.WorkItem.UpdatedAt.Equal(clock.now) {
+		t.Fatalf("timestamps = %#v", result.WorkItem)
+	}
+	_, executionEvents, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(executionEvents) != 1 {
+		t.Fatalf("executionEvents len = %d", len(executionEvents))
+	}
+	if executionEvents[0].Step != "work_item_intake" || executionEvents[0].Status != "created" {
+		t.Fatalf("execution event = %#v", executionEvents[0])
+	}
+	if executionEvents[0].Payload["case_id"] != "case-1" || executionEvents[0].Payload["queue_id"] != "queue-1" || executionEvents[0].Payload["work_item_id"] != "work-1" {
+		t.Fatalf("execution event payload = %#v", executionEvents[0].Payload)
+	}
+}

--- a/internal/workplan/types.go
+++ b/internal/workplan/types.go
@@ -1,0 +1,55 @@
+package workplan
+
+import (
+	"context"
+	"time"
+
+	"kalita/internal/caseruntime"
+)
+
+type WorkItemStatus string
+
+const (
+	WorkItemOpen WorkItemStatus = "open"
+	WorkItemDone WorkItemStatus = "done"
+)
+
+type WorkItem struct {
+	ID                 string
+	CaseID             string
+	QueueID            string
+	Type               string
+	Status             string
+	Priority           string
+	Reason             string
+	AssignedEmployeeID string
+	PlanID             string
+	DueAt              *time.Time
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+type WorkQueue struct {
+	ID                 string
+	Name               string
+	Department         string
+	Purpose            string
+	AllowedCaseKinds   []string
+	DefaultEmployeeIDs []string
+	PolicyRef          string
+}
+
+type QueueRepository interface {
+	SaveQueue(ctx context.Context, q WorkQueue) error
+	GetQueue(ctx context.Context, id string) (WorkQueue, bool, error)
+	ListQueues(ctx context.Context) ([]WorkQueue, error)
+
+	SaveWorkItem(ctx context.Context, wi WorkItem) error
+	GetWorkItem(ctx context.Context, id string) (WorkItem, bool, error)
+	ListWorkItemsByCase(ctx context.Context, caseID string) ([]WorkItem, error)
+	ListWorkItemsByQueue(ctx context.Context, queueID string) ([]WorkItem, error)
+}
+
+type AssignmentRouter interface {
+	RouteCase(ctx context.Context, c caseruntime.Case) (WorkQueue, error)
+}


### PR DESCRIPTION
### Motivation
- Introduce the minimal operational intake layer between Case resolution and future planning/execution by adding `WorkItem`/`WorkQueue`, a queue repository, a case-to-queue router and a deterministic intake service. 
- Keep the change small, transport-free and in-memory so it can be incrementally extended in later slices without touching planning/approval/employee concerns.

### Description
- Added a new transport-free package `internal/workplan` containing `types.go`, `repository.go`, `router.go`, `service.go` and tests; it implements `WorkItem`, `WorkQueue`, a thread-safe in-memory `QueueRepository`, an `AssignmentRouter` and a work intake `Service` that emits `work_item_intake` execution events. 
- Wired bootstrap to construct and expose `QueueRepository`, `AssignmentRouter` and `WorkService` and to seed a minimal `default-intake` queue (`default-intake`) so existing workflow-action compatibility paths can route to a queue. 
- Extended the existing workflow-action compatibility seam so that after command admission and case resolution the code invokes the new work intake service (one `WorkItem` is created), while keeping legacy `runtime.ExecuteWorkflowAction` untouched and surfacing intake failures as the existing validation-style bad-request response. 
- Kept persistence in-memory and deterministic (fake clock / ID generator support in tests); no DailyPlan, DigitalEmployee, policy/approval, employee selection or runtime execution replacement was introduced.

### Testing
- Unit tests for the new package: ran `go test ./internal/workplan` including `TestInMemoryQueueRepositorySaveGetListQueue`, `TestInMemoryQueueRepositorySaveGetListWorkItemsByCaseAndQueue`, `TestRouterRoutesByCaseKind` and `TestServiceCreatesWorkItemAndExecutionEventDeterministically`, and they passed. 
- Integration/compatibility tests: ran `go test ./internal/http ./internal/app` which exercise the adapted workflow action seam including intake success and intake-failure handling, and they passed. 
- End-to-end targeted command: `go test ./internal/workplan ./internal/http ./internal/app` succeeded (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04e4a937c83249c91409323679c4b)