### PR TITLE
Slice 4: Add DailyPlan layer, in-memory PlanRepository and Planner (attach during intake)

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -27,7 +27,9 @@ type BootstrapResult struct {
 	CaseResolver     caseruntime.CaseResolver
 	CaseService      *caseruntime.Service
 	QueueRepo        workplan.QueueRepository
+	PlanRepo         workplan.PlanRepository
 	AssignmentRouter workplan.AssignmentRouter
+	Planner          workplan.Planner
 	WorkService      *workplan.Service
 	Config           config.Config
 }
@@ -88,6 +90,7 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	caseResolver := caseruntime.NewResolver(caseRepo, clock, ids)
 	caseService := caseruntime.NewService(caseResolver, eventLog, clock, ids)
 	queueRepo := workplan.NewInMemoryQueueRepository()
+	planRepo := workplan.NewInMemoryPlanRepository()
 	defaultQueue := workplan.WorkQueue{
 		ID:               "default-intake",
 		Name:             "Default Intake",
@@ -99,7 +102,8 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		return nil, fmt.Errorf("seed default queue: %w", err)
 	}
 	assignmentRouter := workplan.NewRouter(queueRepo, defaultQueue.ID)
-	workService := workplan.NewService(queueRepo, assignmentRouter, eventLog, clock, ids)
+	planner := workplan.NewPlanner(planRepo, eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, assignmentRouter, planner, eventLog, clock, ids)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
@@ -113,7 +117,9 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		CaseResolver:     caseResolver,
 		CaseService:      caseService,
 		QueueRepo:        queueRepo,
+		PlanRepo:         planRepo,
 		AssignmentRouter: assignmentRouter,
+		Planner:          planner,
 		WorkService:      workService,
 		Config:           cfg,
 	}, nil

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -50,8 +50,14 @@ func TestBootstrapProvidesEventCenterCaseRuntimeAndWorkplan(t *testing.T) {
 	if result.QueueRepo == nil {
 		t.Fatal("QueueRepo is nil")
 	}
+	if result.PlanRepo == nil {
+		t.Fatal("PlanRepo is nil")
+	}
 	if result.AssignmentRouter == nil {
 		t.Fatal("AssignmentRouter is nil")
+	}
+	if result.Planner == nil {
+		t.Fatal("Planner is nil")
 	}
 	if result.WorkService == nil {
 		t.Fatal("WorkService is nil")

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -246,6 +246,14 @@ func (s failingWorkService) IntakeCommand(context.Context, caseruntime.Resolutio
 	return workplan.IntakeResult{}, s.err
 }
 
+type failingPlanner struct {
+	err error
+}
+
+func (p failingPlanner) EnsurePlanForWorkItem(context.Context, workplan.WorkQueue, workplan.WorkItem, string) (workplan.DailyPlan, bool, error) {
+	return workplan.DailyPlan{}, false, p.err
+}
+
 func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -253,7 +261,7 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	storage, rec := testHTTPWorkflowStorage()
 	eventLog := eventcore.NewInMemoryEventLog()
 	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
-	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "followup-event-1"}}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "followup-event-1"}}
 	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
 	caseRepo := caseruntime.NewInMemoryCaseRepository()
 	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
@@ -261,7 +269,9 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
 		t.Fatalf("SaveQueue error = %v", err)
 	}
-	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), eventLog, clock, ids)
+	planRepo := workplan.NewInMemoryPlanRepository()
+	planner := workplan.NewPlanner(planRepo, eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, eventLog, clock, ids)
 
 	router := gin.New()
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
@@ -297,8 +307,8 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListByCorrelation error = %v", err)
 	}
-	if len(executionEvents) < 3 {
-		t.Fatalf("execution events len = %d, want at least 3", len(executionEvents))
+	if len(executionEvents) < 4 {
+		t.Fatalf("execution events len = %d, want at least 4", len(executionEvents))
 	}
 	if executionEvents[0].Step != "command_admission" || executionEvents[0].Status != "admitted" {
 		t.Fatalf("first execution event = %#v", executionEvents[0])
@@ -309,12 +319,22 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	if executionEvents[2].Step != "work_item_intake" || executionEvents[2].Status != "created" {
 		t.Fatalf("third execution event = %#v", executionEvents[2])
 	}
+	if executionEvents[3].Step != "daily_plan_intake" || executionEvents[3].Status != "attached" {
+		t.Fatalf("fourth execution event = %#v", executionEvents[3])
+	}
 	workItems, err := queueRepo.ListWorkItemsByCase(context.Background(), "case-1")
 	if err != nil {
 		t.Fatalf("ListWorkItemsByCase error = %v", err)
 	}
-	if len(workItems) != 1 || workItems[0].QueueID != "default-intake" {
+	if len(workItems) != 1 || workItems[0].QueueID != "default-intake" || workItems[0].PlanID != "plan-1" {
 		t.Fatalf("workItems = %#v", workItems)
+	}
+	plan, ok, err := planRepo.GetPlan(context.Background(), "plan-1")
+	if err != nil {
+		t.Fatalf("GetPlan error = %v", err)
+	}
+	if !ok || len(plan.WorkItemIDs) != 1 || plan.WorkItemIDs[0] != "work-1" {
+		t.Fatalf("plan = %#v ok=%v", plan, ok)
 	}
 	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
 		t.Fatalf("legacy flow mutated status to %v", got)
@@ -483,5 +503,40 @@ func TestCreateActionRequestReusesValidationAndProposalEndpointStaysCompatible(t
 	}
 	if len(storage.ActionRequests) != 0 {
 		t.Fatalf("proposal endpoint created request unexpectedly: %#v", storage.ActionRequests)
+	}
+}
+
+func TestActionHandlerReturnsValidationErrorWhenDailyPlanAttachmentFails(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), failingPlanner{err: errors.New("daily plan failed")}, eventLog, clock, ids)
+
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
 	}
 }

--- a/internal/workplan/daily_plan.go
+++ b/internal/workplan/daily_plan.go
@@ -1,0 +1,116 @@
+package workplan
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type DailyPlan struct {
+	ID          string
+	QueueID     string
+	PlanDate    string
+	Status      string
+	WorkItemIDs []string
+	Assignments map[string][]string
+	CreatedAt   time.Time
+	ApprovedAt  *time.Time
+}
+
+type DailyPlanStatus string
+
+const (
+	DailyPlanDraft DailyPlanStatus = "draft"
+	DailyPlanReady DailyPlanStatus = "ready"
+)
+
+type PlanRepository interface {
+	SavePlan(ctx context.Context, p DailyPlan) error
+	GetPlan(ctx context.Context, id string) (DailyPlan, bool, error)
+	FindPlanByQueueAndDate(ctx context.Context, queueID, planDate string) (DailyPlan, bool, error)
+	ListPlansByQueue(ctx context.Context, queueID string) ([]DailyPlan, error)
+}
+
+type InMemoryPlanRepository struct {
+	mu               sync.RWMutex
+	plansByID        map[string]DailyPlan
+	planOrder        []string
+	planIDByQueueDay map[string]string
+	planIDsByQueue   map[string][]string
+}
+
+func NewInMemoryPlanRepository() *InMemoryPlanRepository {
+	return &InMemoryPlanRepository{
+		plansByID:        make(map[string]DailyPlan),
+		planIDByQueueDay: make(map[string]string),
+		planIDsByQueue:   make(map[string][]string),
+	}
+}
+
+func (r *InMemoryPlanRepository) SavePlan(_ context.Context, p DailyPlan) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.plansByID[p.ID]; !exists {
+		r.planOrder = append(r.planOrder, p.ID)
+	}
+	if existing, exists := r.plansByID[p.ID]; exists && existing.QueueID != p.QueueID {
+		r.planIDsByQueue[existing.QueueID] = removeID(r.planIDsByQueue[existing.QueueID], p.ID)
+	}
+	if !containsID(r.planIDsByQueue[p.QueueID], p.ID) {
+		r.planIDsByQueue[p.QueueID] = append(r.planIDsByQueue[p.QueueID], p.ID)
+	}
+	r.planIDByQueueDay[planQueueDateKey(p.QueueID, p.PlanDate)] = p.ID
+	r.plansByID[p.ID] = cloneDailyPlan(p)
+	return nil
+}
+
+func (r *InMemoryPlanRepository) GetPlan(_ context.Context, id string) (DailyPlan, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.plansByID[id]
+	if !ok {
+		return DailyPlan{}, false, nil
+	}
+	return cloneDailyPlan(p), true, nil
+}
+
+func (r *InMemoryPlanRepository) FindPlanByQueueAndDate(_ context.Context, queueID, planDate string) (DailyPlan, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	id, ok := r.planIDByQueueDay[planQueueDateKey(queueID, planDate)]
+	if !ok {
+		return DailyPlan{}, false, nil
+	}
+	return cloneDailyPlan(r.plansByID[id]), true, nil
+}
+
+func (r *InMemoryPlanRepository) ListPlansByQueue(_ context.Context, queueID string) ([]DailyPlan, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.planIDsByQueue[queueID]
+	out := make([]DailyPlan, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, cloneDailyPlan(r.plansByID[id]))
+	}
+	return out, nil
+}
+
+func cloneDailyPlan(p DailyPlan) DailyPlan {
+	out := p
+	out.WorkItemIDs = append([]string(nil), p.WorkItemIDs...)
+	if p.Assignments != nil {
+		out.Assignments = make(map[string][]string, len(p.Assignments))
+		for key, ids := range p.Assignments {
+			out.Assignments[key] = append([]string(nil), ids...)
+		}
+	}
+	if p.ApprovedAt != nil {
+		approvedAt := *p.ApprovedAt
+		out.ApprovedAt = &approvedAt
+	}
+	return out
+}
+
+func planQueueDateKey(queueID, planDate string) string {
+	return queueID + "::" + planDate
+}

--- a/internal/workplan/planner.go
+++ b/internal/workplan/planner.go
@@ -1,0 +1,102 @@
+package workplan
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"kalita/internal/eventcore"
+)
+
+type Planner interface {
+	EnsurePlanForWorkItem(ctx context.Context, queue WorkQueue, wi WorkItem, planDate string) (DailyPlan, bool, error)
+}
+
+type planningExecutionContextKey struct{}
+
+type PlanningExecutionContext struct {
+	ExecutionID   string
+	CorrelationID string
+	CausationID   string
+}
+
+func ContextWithPlanningExecution(ctx context.Context, meta PlanningExecutionContext) context.Context {
+	return context.WithValue(ctx, planningExecutionContextKey{}, meta)
+}
+
+func planningExecutionFromContext(ctx context.Context) PlanningExecutionContext {
+	meta, _ := ctx.Value(planningExecutionContextKey{}).(PlanningExecutionContext)
+	return meta
+}
+
+type DefaultPlanner struct {
+	repo  PlanRepository
+	log   eventcore.EventLog
+	clock eventcore.Clock
+	ids   eventcore.IDGenerator
+}
+
+func NewPlanner(repo PlanRepository, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *DefaultPlanner {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &DefaultPlanner{repo: repo, log: log, clock: clock, ids: ids}
+}
+
+func (p *DefaultPlanner) EnsurePlanForWorkItem(ctx context.Context, queue WorkQueue, wi WorkItem, planDate string) (DailyPlan, bool, error) {
+	if p.repo == nil {
+		return DailyPlan{}, false, fmt.Errorf("plan repository is nil")
+	}
+	plan, reused, err := p.repo.FindPlanByQueueAndDate(ctx, queue.ID, planDate)
+	if err != nil {
+		return DailyPlan{}, false, err
+	}
+	now := p.clock.Now()
+	if !reused {
+		plan = DailyPlan{
+			ID:          p.ids.NewID(),
+			QueueID:     queue.ID,
+			PlanDate:    planDate,
+			Status:      string(DailyPlanDraft),
+			WorkItemIDs: []string{},
+			Assignments: map[string][]string{},
+			CreatedAt:   now,
+		}
+	}
+	if !containsID(plan.WorkItemIDs, wi.ID) {
+		plan.WorkItemIDs = append(plan.WorkItemIDs, wi.ID)
+	}
+	if err := p.repo.SavePlan(ctx, plan); err != nil {
+		return DailyPlan{}, false, err
+	}
+	if p.log != nil {
+		meta := planningExecutionFromContext(ctx)
+		if err := p.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{
+			ID:            p.ids.NewID(),
+			ExecutionID:   meta.ExecutionID,
+			CaseID:        wi.CaseID,
+			Step:          "daily_plan_intake",
+			Status:        "attached",
+			OccurredAt:    now,
+			CorrelationID: meta.CorrelationID,
+			CausationID:   meta.CausationID,
+			Payload: map[string]any{
+				"case_id":       wi.CaseID,
+				"queue_id":      queue.ID,
+				"work_item_id":  wi.ID,
+				"daily_plan_id": plan.ID,
+				"plan_date":     planDate,
+			},
+		}); err != nil {
+			return DailyPlan{}, false, err
+		}
+	}
+	return plan, reused, nil
+}
+
+func PlanDateFromTime(now time.Time) string {
+	return now.UTC().Format("2006-01-02")
+}

--- a/internal/workplan/planner_test.go
+++ b/internal/workplan/planner_test.go
@@ -1,0 +1,212 @@
+package workplan
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"kalita/internal/eventcore"
+)
+
+func TestInMemoryPlanRepositorySaveGetPlan(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryPlanRepository()
+	approvedAt := time.Date(2026, 3, 23, 8, 0, 0, 0, time.UTC)
+	plan := DailyPlan{
+		ID:          "plan-1",
+		QueueID:     "queue-1",
+		PlanDate:    "2026-03-22",
+		Status:      string(DailyPlanReady),
+		WorkItemIDs: []string{"wi-1"},
+		Assignments: map[string][]string{"emp-1": {"wi-1"}},
+		CreatedAt:   time.Date(2026, 3, 22, 7, 0, 0, 0, time.UTC),
+		ApprovedAt:  &approvedAt,
+	}
+	if err := repo.SavePlan(context.Background(), plan); err != nil {
+		t.Fatalf("SavePlan error = %v", err)
+	}
+
+	got, ok, err := repo.GetPlan(context.Background(), "plan-1")
+	if err != nil || !ok {
+		t.Fatalf("GetPlan = %#v ok=%v err=%v", got, ok, err)
+	}
+	got.WorkItemIDs[0] = "mutated"
+	got.Assignments["emp-1"][0] = "mutated"
+
+	reloaded, ok, err := repo.GetPlan(context.Background(), "plan-1")
+	if err != nil || !ok {
+		t.Fatalf("GetPlan(reload) = %#v ok=%v err=%v", reloaded, ok, err)
+	}
+	if reloaded.WorkItemIDs[0] != "wi-1" || reloaded.Assignments["emp-1"][0] != "wi-1" {
+		t.Fatalf("plan clone failed: %#v", reloaded)
+	}
+}
+
+func TestInMemoryPlanRepositoryFindByQueueAndDate(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryPlanRepository()
+	plan := DailyPlan{ID: "plan-1", QueueID: "queue-1", PlanDate: "2026-03-22", Status: string(DailyPlanDraft)}
+	if err := repo.SavePlan(context.Background(), plan); err != nil {
+		t.Fatalf("SavePlan error = %v", err)
+	}
+
+	got, ok, err := repo.FindPlanByQueueAndDate(context.Background(), "queue-1", "2026-03-22")
+	if err != nil || !ok {
+		t.Fatalf("FindPlanByQueueAndDate = %#v ok=%v err=%v", got, ok, err)
+	}
+	if got.ID != "plan-1" {
+		t.Fatalf("plan = %#v", got)
+	}
+}
+
+func TestInMemoryPlanRepositoryListPlansByQueue(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryPlanRepository()
+	plans := []DailyPlan{
+		{ID: "plan-1", QueueID: "queue-1", PlanDate: "2026-03-22", Status: string(DailyPlanDraft)},
+		{ID: "plan-2", QueueID: "queue-1", PlanDate: "2026-03-23", Status: string(DailyPlanDraft)},
+		{ID: "plan-3", QueueID: "queue-2", PlanDate: "2026-03-22", Status: string(DailyPlanDraft)},
+	}
+	for _, plan := range plans {
+		if err := repo.SavePlan(context.Background(), plan); err != nil {
+			t.Fatalf("SavePlan(%s) error = %v", plan.ID, err)
+		}
+	}
+
+	got, err := repo.ListPlansByQueue(context.Background(), "queue-1")
+	if err != nil {
+		t.Fatalf("ListPlansByQueue error = %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "plan-1" || got[1].ID != "plan-2" {
+		t.Fatalf("plans = %#v", got)
+	}
+}
+
+func TestPlannerCreatesNewPlanWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryPlanRepository()
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"plan-1", "plan-event-1"}}
+	planner := NewPlanner(repo, log, clock, ids)
+	ctx := ContextWithPlanningExecution(context.Background(), PlanningExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
+
+	plan, reused, err := planner.EnsurePlanForWorkItem(ctx, WorkQueue{ID: "queue-1"}, WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1"}, "2026-03-22")
+	if err != nil {
+		t.Fatalf("EnsurePlanForWorkItem error = %v", err)
+	}
+	if reused {
+		t.Fatal("reused = true, want false")
+	}
+	if plan.ID != "plan-1" || plan.Status != string(DailyPlanDraft) || plan.QueueID != "queue-1" || plan.PlanDate != "2026-03-22" {
+		t.Fatalf("plan = %#v", plan)
+	}
+	if !plan.CreatedAt.Equal(clock.now) || len(plan.WorkItemIDs) != 1 || plan.WorkItemIDs[0] != "wi-1" {
+		t.Fatalf("plan = %#v", plan)
+	}
+	if plan.ApprovedAt != nil || len(plan.Assignments) != 0 {
+		t.Fatalf("plan = %#v", plan)
+	}
+}
+
+func TestPlannerReusesExistingPlanWhenQueueAndDateMatch(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryPlanRepository()
+	createdAt := time.Date(2026, 3, 22, 9, 0, 0, 0, time.UTC)
+	if err := repo.SavePlan(context.Background(), DailyPlan{ID: "plan-1", QueueID: "queue-1", PlanDate: "2026-03-22", Status: string(DailyPlanDraft), WorkItemIDs: []string{"wi-1"}, Assignments: map[string][]string{}, CreatedAt: createdAt}); err != nil {
+		t.Fatalf("SavePlan error = %v", err)
+	}
+	planner := NewPlanner(repo, nil, fakeClock{now: time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"unused"}})
+
+	plan, reused, err := planner.EnsurePlanForWorkItem(context.Background(), WorkQueue{ID: "queue-1"}, WorkItem{ID: "wi-2", CaseID: "case-1", QueueID: "queue-1"}, "2026-03-22")
+	if err != nil {
+		t.Fatalf("EnsurePlanForWorkItem error = %v", err)
+	}
+	if !reused {
+		t.Fatal("reused = false, want true")
+	}
+	if plan.ID != "plan-1" || len(plan.WorkItemIDs) != 2 || plan.WorkItemIDs[1] != "wi-2" || !plan.CreatedAt.Equal(createdAt) {
+		t.Fatalf("plan = %#v", plan)
+	}
+}
+
+func TestPlannerDoesNotDuplicateWorkItemID(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryPlanRepository()
+	planner := NewPlanner(repo, nil, fakeClock{now: time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"plan-1"}})
+
+	if _, _, err := planner.EnsurePlanForWorkItem(context.Background(), WorkQueue{ID: "queue-1"}, WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1"}, "2026-03-22"); err != nil {
+		t.Fatalf("first EnsurePlanForWorkItem error = %v", err)
+	}
+	plan, reused, err := planner.EnsurePlanForWorkItem(context.Background(), WorkQueue{ID: "queue-1"}, WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1"}, "2026-03-22")
+	if err != nil {
+		t.Fatalf("second EnsurePlanForWorkItem error = %v", err)
+	}
+	if !reused || len(plan.WorkItemIDs) != 1 {
+		t.Fatalf("plan = %#v reused=%v", plan, reused)
+	}
+}
+
+func TestPlannerAppendsExecutionEventDeterministically(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryPlanRepository()
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 10, 30, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"plan-1", "plan-event-1"}}
+	planner := NewPlanner(repo, log, clock, ids)
+	ctx := ContextWithPlanningExecution(context.Background(), PlanningExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
+
+	plan, _, err := planner.EnsurePlanForWorkItem(ctx, WorkQueue{ID: "queue-1"}, WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1"}, "2026-03-22")
+	if err != nil {
+		t.Fatalf("EnsurePlanForWorkItem error = %v", err)
+	}
+	_, executionEvents, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(executionEvents) != 1 {
+		t.Fatalf("executionEvents len = %d", len(executionEvents))
+	}
+	got := executionEvents[0]
+	if got.ID != "plan-event-1" || got.ExecutionID != "exec-1" || got.CaseID != "case-1" || got.Step != "daily_plan_intake" || got.Status != "attached" || !got.OccurredAt.Equal(clock.now) {
+		t.Fatalf("execution event = %#v", got)
+	}
+	if got.Payload["daily_plan_id"] != plan.ID || got.Payload["plan_date"] != "2026-03-22" || got.Payload["work_item_id"] != "wi-1" || got.Payload["queue_id"] != "queue-1" || got.Payload["case_id"] != "case-1" {
+		t.Fatalf("execution event payload = %#v", got.Payload)
+	}
+}
+
+type failingPlanRepository struct{ err error }
+
+func (f failingPlanRepository) SavePlan(context.Context, DailyPlan) error {
+	return f.err
+}
+
+func (f failingPlanRepository) GetPlan(context.Context, string) (DailyPlan, bool, error) {
+	return DailyPlan{}, false, f.err
+}
+
+func (f failingPlanRepository) FindPlanByQueueAndDate(context.Context, string, string) (DailyPlan, bool, error) {
+	return DailyPlan{}, false, f.err
+}
+
+func (f failingPlanRepository) ListPlansByQueue(context.Context, string) ([]DailyPlan, error) {
+	return nil, f.err
+}
+
+func TestPlannerReturnsRepositoryError(t *testing.T) {
+	t.Parallel()
+
+	planner := NewPlanner(failingPlanRepository{err: errors.New("plan repo failed")}, nil, fakeClock{now: time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"unused"}})
+	if _, _, err := planner.EnsurePlanForWorkItem(context.Background(), WorkQueue{ID: "queue-1"}, WorkItem{ID: "wi-1", CaseID: "case-1"}, "2026-03-22"); err == nil {
+		t.Fatal("EnsurePlanForWorkItem error = nil, want non-nil")
+	}
+}

--- a/internal/workplan/service.go
+++ b/internal/workplan/service.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"kalita/internal/caseruntime"
 	"kalita/internal/eventcore"
 )
 
 type Service struct {
-	repo   QueueRepository
-	router AssignmentRouter
-	log    eventcore.EventLog
-	clock  eventcore.Clock
-	ids    eventcore.IDGenerator
+	repo     QueueRepository
+	router   AssignmentRouter
+	planner  Planner
+	log      eventcore.EventLog
+	clock    eventcore.Clock
+	ids      eventcore.IDGenerator
+	planDate func(time.Time) string
 }
 
 type IntakeResult struct {
@@ -25,14 +28,14 @@ type IntakeResult struct {
 	ExecEvent eventcore.ExecutionEvent
 }
 
-func NewService(repo QueueRepository, router AssignmentRouter, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *Service {
+func NewService(repo QueueRepository, router AssignmentRouter, planner Planner, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *Service {
 	if clock == nil {
 		clock = eventcore.RealClock{}
 	}
 	if ids == nil {
 		ids = eventcore.NewULIDGenerator()
 	}
-	return &Service{repo: repo, router: router, log: log, clock: clock, ids: ids}
+	return &Service{repo: repo, router: router, planner: planner, log: log, clock: clock, ids: ids, planDate: PlanDateFromTime}
 }
 
 func (s *Service) IntakeCommand(ctx context.Context, resolved caseruntime.ResolutionResult) (IntakeResult, error) {
@@ -41,6 +44,9 @@ func (s *Service) IntakeCommand(ctx context.Context, resolved caseruntime.Resolu
 	}
 	if s.router == nil {
 		return IntakeResult{}, fmt.Errorf("assignment router is nil")
+	}
+	if s.planner == nil {
+		return IntakeResult{}, fmt.Errorf("planner is nil")
 	}
 	queue, err := s.router.RouteCase(ctx, resolved.Case)
 	if err != nil {
@@ -79,6 +85,21 @@ func (s *Service) IntakeCommand(ctx context.Context, resolved caseruntime.Resolu
 		if err := s.log.AppendExecutionEvent(ctx, execEvent); err != nil {
 			return IntakeResult{}, err
 		}
+	}
+	planDate := s.planDate(now)
+	planningCtx := ContextWithPlanningExecution(ctx, PlanningExecutionContext{
+		ExecutionID:   resolved.Command.ExecutionID,
+		CorrelationID: resolved.Command.CorrelationID,
+		CausationID:   resolved.Command.ID,
+	})
+	plan, _, err := s.planner.EnsurePlanForWorkItem(planningCtx, queue, workItem, planDate)
+	if err != nil {
+		return IntakeResult{}, err
+	}
+	workItem.PlanID = plan.ID
+	workItem.UpdatedAt = now
+	if err := s.repo.SaveWorkItem(ctx, workItem); err != nil {
+		return IntakeResult{}, err
 	}
 	return IntakeResult{Command: resolved.Command, Case: resolved.Case, Queue: queue, WorkItem: workItem, ExecEvent: execEvent}, nil
 }

--- a/internal/workplan/service_test.go
+++ b/internal/workplan/service_test.go
@@ -2,6 +2,7 @@ package workplan
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -28,8 +29,10 @@ func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) 
 	}
 	log := eventcore.NewInMemoryEventLog()
 	clock := fakeClock{now: time.Date(2026, 3, 22, 15, 0, 0, 0, time.UTC)}
-	ids := &fakeIDGenerator{ids: []string{"work-1", "event-1"}}
-	service := NewService(repo, NewRouter(repo, ""), log, clock, ids)
+	ids := &fakeIDGenerator{ids: []string{"work-1", "work-event-1", "plan-1", "plan-event-1"}}
+	planRepo := NewInMemoryPlanRepository()
+	planner := NewPlanner(planRepo, log, clock, ids)
+	service := NewService(repo, NewRouter(repo, ""), planner, log, clock, ids)
 	resolved := caseruntime.ResolutionResult{Command: eventcore.Command{ID: "cmd-1", Type: "workflow.action", CorrelationID: "corr-1", ExecutionID: "exec-1", TargetRef: "test.WorkflowTask/rec-1"}, Case: caseruntime.Case{ID: "case-1", Kind: "workflow.action"}}
 
 	result, err := service.IntakeCommand(context.Background(), resolved)
@@ -45,6 +48,9 @@ func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) 
 	if result.WorkItem.Reason != "intake workflow.action for test.WorkflowTask/rec-1" {
 		t.Fatalf("reason = %q", result.WorkItem.Reason)
 	}
+	if result.WorkItem.PlanID != "plan-1" {
+		t.Fatalf("plan id = %q", result.WorkItem.PlanID)
+	}
 	if !result.WorkItem.CreatedAt.Equal(clock.now) || !result.WorkItem.UpdatedAt.Equal(clock.now) {
 		t.Fatalf("timestamps = %#v", result.WorkItem)
 	}
@@ -52,13 +58,36 @@ func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) 
 	if err != nil {
 		t.Fatalf("ListByCorrelation error = %v", err)
 	}
-	if len(executionEvents) != 1 {
+	if len(executionEvents) != 2 {
 		t.Fatalf("executionEvents len = %d", len(executionEvents))
 	}
 	if executionEvents[0].Step != "work_item_intake" || executionEvents[0].Status != "created" {
-		t.Fatalf("execution event = %#v", executionEvents[0])
+		t.Fatalf("first execution event = %#v", executionEvents[0])
 	}
-	if executionEvents[0].Payload["case_id"] != "case-1" || executionEvents[0].Payload["queue_id"] != "queue-1" || executionEvents[0].Payload["work_item_id"] != "work-1" {
-		t.Fatalf("execution event payload = %#v", executionEvents[0].Payload)
+	if executionEvents[1].Step != "daily_plan_intake" || executionEvents[1].Status != "attached" {
+		t.Fatalf("second execution event = %#v", executionEvents[1])
+	}
+	if executionEvents[1].Payload["case_id"] != "case-1" || executionEvents[1].Payload["queue_id"] != "queue-1" || executionEvents[1].Payload["work_item_id"] != "work-1" || executionEvents[1].Payload["daily_plan_id"] != "plan-1" || executionEvents[1].Payload["plan_date"] != "2026-03-22" {
+		t.Fatalf("execution event payload = %#v", executionEvents[1].Payload)
+	}
+}
+
+type errPlanner struct{ err error }
+
+func (p errPlanner) EnsurePlanForWorkItem(context.Context, WorkQueue, WorkItem, string) (DailyPlan, bool, error) {
+	return DailyPlan{}, false, p.err
+}
+
+func TestServiceReturnsErrorWhenPlanAttachmentFails(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryQueueRepository()
+	if err := repo.SaveQueue(context.Background(), WorkQueue{ID: "queue-1", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	service := NewService(repo, NewRouter(repo, ""), errPlanner{err: fmt.Errorf("plan attach failed")}, eventcore.NewInMemoryEventLog(), fakeClock{now: time.Date(2026, 3, 22, 15, 0, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"work-1", "work-event-1"}})
+	resolved := caseruntime.ResolutionResult{Command: eventcore.Command{ID: "cmd-1", Type: "workflow.action", CorrelationID: "corr-1", ExecutionID: "exec-1", TargetRef: "test.WorkflowTask/rec-1"}, Case: caseruntime.Case{ID: "case-1", Kind: "workflow.action"}}
+
+	if _, err := service.IntakeCommand(context.Background(), resolved); err == nil {
+		t.Fatal("IntakeCommand error = nil, want non-nil")
 	}
 }


### PR DESCRIPTION
### Motivation
- Introduce a minimal, transport-free DailyPlan layer so queued `WorkItem`s become planned work without adding employee execution, policy, or approval logic. 
- Keep persistence in-memory and changes incremental so Slice 5 can build controlled execution on top of an explicit planning object. 

### Description
- Add `DailyPlan` model, `PlanRepository` interface and a thread-safe in-memory implementation in `internal/workplan` (`daily_plan.go`).
- Implement a deterministic `Planner` (`NewPlanner`, `DefaultPlanner`) that finds-or-creates per-queue/per-date plans, appends non-duplicated `WorkItem` IDs, saves plans and emits a `daily_plan_intake` execution event (`planner.go`).
- Wire planner into the intake compatibility seam: `workplan.Service` now requires a `Planner`, attaches a work item to the plan (sets `WorkItem.PlanID`) after `work_item_intake`, and preserves legacy flow otherwise (`service.go`).
- Expose `PlanRepo` and `Planner` from bootstrap and update tests to verify plan attachment and the validation-style error path when plan attachment fails (`internal/app/bootstrap.go`, `internal/http/actions_test.go`).

### Testing
- Ran the package test suite with `go test ./internal/workplan ./internal/http ./internal/app` and all automated tests passed.
- Added unit tests covering `InMemoryPlanRepository` (save/get/find/list), planner behavior (create/reuse/no-duplicate/work-item event emission), service-level plan failure handling, and bootstrap exposure (`internal/workplan/planner_test.go`, updated `service_test.go`, `actions_test.go`, `bootstrap_test.go`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0514916b08324ac8bbd2d3a0f2ec9)