### PR TITLE
Add coordination layer and in-memory CoordinationDecision repo for work intake (Slice 4)

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -28,8 +28,10 @@ type BootstrapResult struct {
 	CaseService      *caseruntime.Service
 	QueueRepo        workplan.QueueRepository
 	PlanRepo         workplan.PlanRepository
+	CoordinationRepo workplan.CoordinationRepository
 	AssignmentRouter workplan.AssignmentRouter
 	Planner          workplan.Planner
+	Coordinator      workplan.Coordinator
 	WorkService      *workplan.Service
 	Config           config.Config
 }
@@ -103,7 +105,9 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	}
 	assignmentRouter := workplan.NewRouter(queueRepo, defaultQueue.ID)
 	planner := workplan.NewPlanner(planRepo, eventLog, clock, ids)
-	workService := workplan.NewService(queueRepo, assignmentRouter, planner, eventLog, clock, ids)
+	coordinationRepo := workplan.NewInMemoryCoordinationRepository()
+	coordinator := workplan.NewCoordinator(coordinationRepo, eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, assignmentRouter, planner, coordinator, eventLog, clock, ids)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
@@ -118,8 +122,10 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		CaseService:      caseService,
 		QueueRepo:        queueRepo,
 		PlanRepo:         planRepo,
+		CoordinationRepo: coordinationRepo,
 		AssignmentRouter: assignmentRouter,
 		Planner:          planner,
+		Coordinator:      coordinator,
 		WorkService:      workService,
 		Config:           cfg,
 	}, nil

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -53,11 +53,17 @@ func TestBootstrapProvidesEventCenterCaseRuntimeAndWorkplan(t *testing.T) {
 	if result.PlanRepo == nil {
 		t.Fatal("PlanRepo is nil")
 	}
+	if result.CoordinationRepo == nil {
+		t.Fatal("CoordinationRepo is nil")
+	}
 	if result.AssignmentRouter == nil {
 		t.Fatal("AssignmentRouter is nil")
 	}
 	if result.Planner == nil {
 		t.Fatal("Planner is nil")
+	}
+	if result.Coordinator == nil {
+		t.Fatal("Coordinator is nil")
 	}
 	if result.WorkService == nil {
 		t.Fatal("WorkService is nil")

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -254,6 +254,12 @@ func (p failingPlanner) EnsurePlanForWorkItem(context.Context, workplan.WorkQueu
 	return workplan.DailyPlan{}, false, p.err
 }
 
+type failingCoordinator struct{ err error }
+
+func (f failingCoordinator) CoordinateWorkItem(context.Context, workplan.WorkItem) (workplan.CoordinationDecision, error) {
+	return workplan.CoordinationDecision{}, f.err
+}
+
 func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -271,7 +277,9 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	}
 	planRepo := workplan.NewInMemoryPlanRepository()
 	planner := workplan.NewPlanner(planRepo, eventLog, clock, ids)
-	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, eventLog, clock, ids)
+	coordinationRepo := workplan.NewInMemoryCoordinationRepository()
+	coordinator := workplan.NewCoordinator(coordinationRepo, eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, coordinator, eventLog, clock, ids)
 
 	router := gin.New()
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
@@ -307,8 +315,8 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListByCorrelation error = %v", err)
 	}
-	if len(executionEvents) < 4 {
-		t.Fatalf("execution events len = %d, want at least 4", len(executionEvents))
+	if len(executionEvents) < 5 {
+		t.Fatalf("execution events len = %d, want at least 5", len(executionEvents))
 	}
 	if executionEvents[0].Step != "command_admission" || executionEvents[0].Status != "admitted" {
 		t.Fatalf("first execution event = %#v", executionEvents[0])
@@ -321,6 +329,9 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	}
 	if executionEvents[3].Step != "daily_plan_intake" || executionEvents[3].Status != "attached" {
 		t.Fatalf("fourth execution event = %#v", executionEvents[3])
+	}
+	if executionEvents[4].Step != "coordination_decision" || executionEvents[4].Status != "selected" {
+		t.Fatalf("fifth execution event = %#v", executionEvents[4])
 	}
 	workItems, err := queueRepo.ListWorkItemsByCase(context.Background(), "case-1")
 	if err != nil {
@@ -335,6 +346,13 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	}
 	if !ok || len(plan.WorkItemIDs) != 1 || plan.WorkItemIDs[0] != "work-1" {
 		t.Fatalf("plan = %#v ok=%v", plan, ok)
+	}
+	decisions, err := coordinationRepo.ListByWorkItem(context.Background(), "work-1")
+	if err != nil {
+		t.Fatalf("ListByWorkItem error = %v", err)
+	}
+	if len(decisions) != 1 || decisions[0].Outcome != workplan.CoordinationSelected {
+		t.Fatalf("coordination decisions = %#v", decisions)
 	}
 	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
 		t.Fatalf("legacy flow mutated status to %v", got)
@@ -377,6 +395,42 @@ func TestActionHandlerReturnsValidationErrorWhenWorkItemIntakeFails(t *testing.T
 	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
 	router := gin.New()
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
+}
+
+func TestActionHandlerReturnsValidationErrorWhenCoordinationFails(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, failingCoordinator{err: errors.New("coordination failed")}, eventLog, clock, ids)
+
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -521,7 +575,7 @@ func TestActionHandlerReturnsValidationErrorWhenDailyPlanAttachmentFails(t *test
 	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
 		t.Fatalf("SaveQueue error = %v", err)
 	}
-	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), failingPlanner{err: errors.New("daily plan failed")}, eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), failingPlanner{err: errors.New("daily plan failed")}, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))

--- a/internal/workplan/coordination.go
+++ b/internal/workplan/coordination.go
@@ -1,0 +1,39 @@
+package workplan
+
+import (
+	"context"
+	"time"
+)
+
+type CoordinationOutcome string
+
+const (
+	CoordinationSelected  CoordinationOutcome = "selected"
+	CoordinationDeferred  CoordinationOutcome = "deferred"
+	CoordinationBlocked   CoordinationOutcome = "blocked"
+	CoordinationEscalated CoordinationOutcome = "escalated"
+)
+
+type CoordinationDecision struct {
+	ID         string
+	CaseID     string
+	WorkItemID string
+	QueueID    string
+	Strategy   string
+	SelectedBy string
+	Outcome    CoordinationOutcome
+	Reason     string
+	CreatedAt  time.Time
+}
+
+type CoordinationRepository interface {
+	SaveDecision(ctx context.Context, d CoordinationDecision) error
+	GetDecision(ctx context.Context, id string) (CoordinationDecision, bool, error)
+	ListByWorkItem(ctx context.Context, workItemID string) ([]CoordinationDecision, error)
+	ListByCase(ctx context.Context, caseID string) ([]CoordinationDecision, error)
+	ListByQueue(ctx context.Context, queueID string) ([]CoordinationDecision, error)
+}
+
+type Coordinator interface {
+	CoordinateWorkItem(ctx context.Context, wi WorkItem) (CoordinationDecision, error)
+}

--- a/internal/workplan/coordination_repository.go
+++ b/internal/workplan/coordination_repository.go
@@ -1,0 +1,89 @@
+package workplan
+
+import (
+	"context"
+	"sync"
+)
+
+type InMemoryCoordinationRepository struct {
+	mu            sync.RWMutex
+	decisionsByID map[string]CoordinationDecision
+	decisionOrder []string
+	idsByWorkItem map[string][]string
+	idsByCase     map[string][]string
+	idsByQueue    map[string][]string
+}
+
+func NewInMemoryCoordinationRepository() *InMemoryCoordinationRepository {
+	return &InMemoryCoordinationRepository{
+		decisionsByID: make(map[string]CoordinationDecision),
+		idsByWorkItem: make(map[string][]string),
+		idsByCase:     make(map[string][]string),
+		idsByQueue:    make(map[string][]string),
+	}
+}
+
+func (r *InMemoryCoordinationRepository) SaveDecision(_ context.Context, d CoordinationDecision) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.decisionsByID[d.ID]; ok {
+		if existing.WorkItemID != d.WorkItemID {
+			r.idsByWorkItem[existing.WorkItemID] = removeID(r.idsByWorkItem[existing.WorkItemID], d.ID)
+		}
+		if existing.CaseID != d.CaseID {
+			r.idsByCase[existing.CaseID] = removeID(r.idsByCase[existing.CaseID], d.ID)
+		}
+		if existing.QueueID != d.QueueID {
+			r.idsByQueue[existing.QueueID] = removeID(r.idsByQueue[existing.QueueID], d.ID)
+		}
+	} else {
+		r.decisionOrder = append(r.decisionOrder, d.ID)
+	}
+	if !containsID(r.idsByWorkItem[d.WorkItemID], d.ID) {
+		r.idsByWorkItem[d.WorkItemID] = append(r.idsByWorkItem[d.WorkItemID], d.ID)
+	}
+	if !containsID(r.idsByCase[d.CaseID], d.ID) {
+		r.idsByCase[d.CaseID] = append(r.idsByCase[d.CaseID], d.ID)
+	}
+	if !containsID(r.idsByQueue[d.QueueID], d.ID) {
+		r.idsByQueue[d.QueueID] = append(r.idsByQueue[d.QueueID], d.ID)
+	}
+	r.decisionsByID[d.ID] = d
+	return nil
+}
+
+func (r *InMemoryCoordinationRepository) GetDecision(_ context.Context, id string) (CoordinationDecision, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	d, ok := r.decisionsByID[id]
+	if !ok {
+		return CoordinationDecision{}, false, nil
+	}
+	return d, true, nil
+}
+
+func (r *InMemoryCoordinationRepository) ListByWorkItem(_ context.Context, workItemID string) ([]CoordinationDecision, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.listByIDs(r.idsByWorkItem[workItemID]), nil
+}
+
+func (r *InMemoryCoordinationRepository) ListByCase(_ context.Context, caseID string) ([]CoordinationDecision, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.listByIDs(r.idsByCase[caseID]), nil
+}
+
+func (r *InMemoryCoordinationRepository) ListByQueue(_ context.Context, queueID string) ([]CoordinationDecision, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.listByIDs(r.idsByQueue[queueID]), nil
+}
+
+func (r *InMemoryCoordinationRepository) listByIDs(ids []string) []CoordinationDecision {
+	out := make([]CoordinationDecision, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, r.decisionsByID[id])
+	}
+	return out
+}

--- a/internal/workplan/coordination_repository_test.go
+++ b/internal/workplan/coordination_repository_test.go
@@ -1,0 +1,71 @@
+package workplan
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryCoordinationRepositorySaveAndGetDecision(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryCoordinationRepository()
+	decision := CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", Strategy: DefaultCoordinationStrategy, SelectedBy: "system", Outcome: CoordinationSelected, Reason: "selected", CreatedAt: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}
+	if err := repo.SaveDecision(context.Background(), decision); err != nil {
+		t.Fatalf("SaveDecision error = %v", err)
+	}
+	got, ok, err := repo.GetDecision(context.Background(), "coord-1")
+	if err != nil || !ok {
+		t.Fatalf("GetDecision = %#v ok=%v err=%v", got, ok, err)
+	}
+	if got != decision {
+		t.Fatalf("decision = %#v, want %#v", got, decision)
+	}
+}
+
+func TestInMemoryCoordinationRepositoryListByWorkItem(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryCoordinationRepository()
+	seedCoordinationDecisions(t, repo)
+	got, err := repo.ListByWorkItem(context.Background(), "wi-1")
+	if err != nil {
+		t.Fatalf("ListByWorkItem error = %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "coord-1" || got[1].ID != "coord-2" {
+		t.Fatalf("decisions = %#v", got)
+	}
+}
+
+func TestInMemoryCoordinationRepositoryListByCase(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryCoordinationRepository()
+	seedCoordinationDecisions(t, repo)
+	got, err := repo.ListByCase(context.Background(), "case-1")
+	if err != nil {
+		t.Fatalf("ListByCase error = %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "coord-1" || got[1].ID != "coord-2" {
+		t.Fatalf("decisions = %#v", got)
+	}
+}
+
+func TestInMemoryCoordinationRepositoryListByQueue(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryCoordinationRepository()
+	seedCoordinationDecisions(t, repo)
+	got, err := repo.ListByQueue(context.Background(), "queue-1")
+	if err != nil {
+		t.Fatalf("ListByQueue error = %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "coord-1" || got[1].ID != "coord-3" {
+		t.Fatalf("decisions = %#v", got)
+	}
+}
+
+func seedCoordinationDecisions(t *testing.T, repo *InMemoryCoordinationRepository) {
+	t.Helper()
+	for _, d := range []CoordinationDecision{{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1"}, {ID: "coord-2", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-2"}, {ID: "coord-3", CaseID: "case-2", WorkItemID: "wi-2", QueueID: "queue-1"}} {
+		if err := repo.SaveDecision(context.Background(), d); err != nil {
+			t.Fatalf("SaveDecision(%s) error = %v", d.ID, err)
+		}
+	}
+}

--- a/internal/workplan/coordination_service.go
+++ b/internal/workplan/coordination_service.go
@@ -1,0 +1,71 @@
+package workplan
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/eventcore"
+)
+
+const DefaultCoordinationStrategy = "default_queue_selection"
+
+type CoordinationService struct {
+	repo  CoordinationRepository
+	log   eventcore.EventLog
+	clock eventcore.Clock
+	ids   eventcore.IDGenerator
+}
+
+func NewCoordinator(repo CoordinationRepository, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *CoordinationService {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &CoordinationService{repo: repo, log: log, clock: clock, ids: ids}
+}
+
+func (s *CoordinationService) CoordinateWorkItem(ctx context.Context, wi WorkItem) (CoordinationDecision, error) {
+	if s.repo == nil {
+		return CoordinationDecision{}, fmt.Errorf("coordination repository is nil")
+	}
+	now := s.clock.Now()
+	decision := CoordinationDecision{
+		ID:         s.ids.NewID(),
+		CaseID:     wi.CaseID,
+		WorkItemID: wi.ID,
+		QueueID:    wi.QueueID,
+		Strategy:   DefaultCoordinationStrategy,
+		SelectedBy: "system",
+		Outcome:    CoordinationSelected,
+		Reason:     fmt.Sprintf("strategy %s selected work item %s from queue %s", DefaultCoordinationStrategy, wi.ID, wi.QueueID),
+		CreatedAt:  now,
+	}
+	if err := s.repo.SaveDecision(ctx, decision); err != nil {
+		return CoordinationDecision{}, err
+	}
+	if s.log != nil {
+		meta := planningExecutionFromContext(ctx)
+		if err := s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{
+			ID:            s.ids.NewID(),
+			ExecutionID:   meta.ExecutionID,
+			CaseID:        wi.CaseID,
+			Step:          "coordination_decision",
+			Status:        string(decision.Outcome),
+			OccurredAt:    now,
+			CorrelationID: meta.CorrelationID,
+			CausationID:   meta.CausationID,
+			Payload: map[string]any{
+				"case_id":                  wi.CaseID,
+				"queue_id":                 wi.QueueID,
+				"work_item_id":             wi.ID,
+				"coordination_decision_id": decision.ID,
+				"strategy":                 decision.Strategy,
+			},
+		}); err != nil {
+			return CoordinationDecision{}, err
+		}
+	}
+	return decision, nil
+}

--- a/internal/workplan/coordination_service_test.go
+++ b/internal/workplan/coordination_service_test.go
@@ -1,0 +1,52 @@
+package workplan
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/eventcore"
+)
+
+func TestCoordinatorCreatesSelectedDecisionAndExecutionEventDeterministically(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryCoordinationRepository()
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 16, 30, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"coord-1", "coord-event-1"}}
+	coordinator := NewCoordinator(repo, log, clock, ids)
+	wi := WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1"}
+	ctx := ContextWithPlanningExecution(context.Background(), PlanningExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
+
+	decision, err := coordinator.CoordinateWorkItem(ctx, wi)
+	if err != nil {
+		t.Fatalf("CoordinateWorkItem error = %v", err)
+	}
+	if decision.ID != "coord-1" || decision.Strategy != DefaultCoordinationStrategy || decision.SelectedBy != "system" || decision.Outcome != CoordinationSelected {
+		t.Fatalf("decision = %#v", decision)
+	}
+	if decision.Reason == "" || !decision.CreatedAt.Equal(clock.now) {
+		t.Fatalf("decision = %#v", decision)
+	}
+	stored, ok, err := repo.GetDecision(context.Background(), "coord-1")
+	if err != nil || !ok {
+		t.Fatalf("GetDecision = %#v ok=%v err=%v", stored, ok, err)
+	}
+	if stored != decision {
+		t.Fatalf("stored = %#v, want %#v", stored, decision)
+	}
+	_, executionEvents, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(executionEvents) != 1 {
+		t.Fatalf("execution events len = %d", len(executionEvents))
+	}
+	got := executionEvents[0]
+	if got.ID != "coord-event-1" || got.Step != "coordination_decision" || got.Status != "selected" || got.ExecutionID != "exec-1" || got.CausationID != "cmd-1" {
+		t.Fatalf("execution event = %#v", got)
+	}
+	if got.Payload["coordination_decision_id"] != "coord-1" || got.Payload["strategy"] != DefaultCoordinationStrategy {
+		t.Fatalf("payload = %#v", got.Payload)
+	}
+}

--- a/internal/workplan/service.go
+++ b/internal/workplan/service.go
@@ -11,31 +11,33 @@ import (
 )
 
 type Service struct {
-	repo     QueueRepository
-	router   AssignmentRouter
-	planner  Planner
-	log      eventcore.EventLog
-	clock    eventcore.Clock
-	ids      eventcore.IDGenerator
-	planDate func(time.Time) string
+	repo        QueueRepository
+	router      AssignmentRouter
+	planner     Planner
+	coordinator Coordinator
+	log         eventcore.EventLog
+	clock       eventcore.Clock
+	ids         eventcore.IDGenerator
+	planDate    func(time.Time) string
 }
 
 type IntakeResult struct {
-	Command   eventcore.Command
-	Case      caseruntime.Case
-	Queue     WorkQueue
-	WorkItem  WorkItem
-	ExecEvent eventcore.ExecutionEvent
+	Command              eventcore.Command
+	Case                 caseruntime.Case
+	Queue                WorkQueue
+	WorkItem             WorkItem
+	CoordinationDecision CoordinationDecision
+	ExecEvent            eventcore.ExecutionEvent
 }
 
-func NewService(repo QueueRepository, router AssignmentRouter, planner Planner, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *Service {
+func NewService(repo QueueRepository, router AssignmentRouter, planner Planner, coordinator Coordinator, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *Service {
 	if clock == nil {
 		clock = eventcore.RealClock{}
 	}
 	if ids == nil {
 		ids = eventcore.NewULIDGenerator()
 	}
-	return &Service{repo: repo, router: router, planner: planner, log: log, clock: clock, ids: ids, planDate: PlanDateFromTime}
+	return &Service{repo: repo, router: router, planner: planner, coordinator: coordinator, log: log, clock: clock, ids: ids, planDate: PlanDateFromTime}
 }
 
 func (s *Service) IntakeCommand(ctx context.Context, resolved caseruntime.ResolutionResult) (IntakeResult, error) {
@@ -47,6 +49,9 @@ func (s *Service) IntakeCommand(ctx context.Context, resolved caseruntime.Resolu
 	}
 	if s.planner == nil {
 		return IntakeResult{}, fmt.Errorf("planner is nil")
+	}
+	if s.coordinator == nil {
+		return IntakeResult{}, fmt.Errorf("coordinator is nil")
 	}
 	queue, err := s.router.RouteCase(ctx, resolved.Case)
 	if err != nil {
@@ -101,7 +106,16 @@ func (s *Service) IntakeCommand(ctx context.Context, resolved caseruntime.Resolu
 	if err := s.repo.SaveWorkItem(ctx, workItem); err != nil {
 		return IntakeResult{}, err
 	}
-	return IntakeResult{Command: resolved.Command, Case: resolved.Case, Queue: queue, WorkItem: workItem, ExecEvent: execEvent}, nil
+	coordinationCtx := ContextWithPlanningExecution(ctx, PlanningExecutionContext{
+		ExecutionID:   resolved.Command.ExecutionID,
+		CorrelationID: resolved.Command.CorrelationID,
+		CausationID:   resolved.Command.ID,
+	})
+	decision, err := s.coordinator.CoordinateWorkItem(coordinationCtx, workItem)
+	if err != nil {
+		return IntakeResult{}, err
+	}
+	return IntakeResult{Command: resolved.Command, Case: resolved.Case, Queue: queue, WorkItem: workItem, CoordinationDecision: decision, ExecEvent: execEvent}, nil
 }
 
 func workItemTypeForCommand(cmd eventcore.Command) string {

--- a/internal/workplan/service_test.go
+++ b/internal/workplan/service_test.go
@@ -29,10 +29,11 @@ func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) 
 	}
 	log := eventcore.NewInMemoryEventLog()
 	clock := fakeClock{now: time.Date(2026, 3, 22, 15, 0, 0, 0, time.UTC)}
-	ids := &fakeIDGenerator{ids: []string{"work-1", "work-event-1", "plan-1", "plan-event-1"}}
+	ids := &fakeIDGenerator{ids: []string{"work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
 	planRepo := NewInMemoryPlanRepository()
 	planner := NewPlanner(planRepo, log, clock, ids)
-	service := NewService(repo, NewRouter(repo, ""), planner, log, clock, ids)
+	coordinator := NewCoordinator(NewInMemoryCoordinationRepository(), log, clock, ids)
+	service := NewService(repo, NewRouter(repo, ""), planner, coordinator, log, clock, ids)
 	resolved := caseruntime.ResolutionResult{Command: eventcore.Command{ID: "cmd-1", Type: "workflow.action", CorrelationID: "corr-1", ExecutionID: "exec-1", TargetRef: "test.WorkflowTask/rec-1"}, Case: caseruntime.Case{ID: "case-1", Kind: "workflow.action"}}
 
 	result, err := service.IntakeCommand(context.Background(), resolved)
@@ -51,6 +52,9 @@ func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) 
 	if result.WorkItem.PlanID != "plan-1" {
 		t.Fatalf("plan id = %q", result.WorkItem.PlanID)
 	}
+	if result.CoordinationDecision.ID != "coord-1" || result.CoordinationDecision.Outcome != CoordinationSelected {
+		t.Fatalf("coordination decision = %#v", result.CoordinationDecision)
+	}
 	if !result.WorkItem.CreatedAt.Equal(clock.now) || !result.WorkItem.UpdatedAt.Equal(clock.now) {
 		t.Fatalf("timestamps = %#v", result.WorkItem)
 	}
@@ -58,7 +62,7 @@ func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) 
 	if err != nil {
 		t.Fatalf("ListByCorrelation error = %v", err)
 	}
-	if len(executionEvents) != 2 {
+	if len(executionEvents) != 3 {
 		t.Fatalf("executionEvents len = %d", len(executionEvents))
 	}
 	if executionEvents[0].Step != "work_item_intake" || executionEvents[0].Status != "created" {
@@ -67,8 +71,11 @@ func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) 
 	if executionEvents[1].Step != "daily_plan_intake" || executionEvents[1].Status != "attached" {
 		t.Fatalf("second execution event = %#v", executionEvents[1])
 	}
-	if executionEvents[1].Payload["case_id"] != "case-1" || executionEvents[1].Payload["queue_id"] != "queue-1" || executionEvents[1].Payload["work_item_id"] != "work-1" || executionEvents[1].Payload["daily_plan_id"] != "plan-1" || executionEvents[1].Payload["plan_date"] != "2026-03-22" {
-		t.Fatalf("execution event payload = %#v", executionEvents[1].Payload)
+	if executionEvents[2].Step != "coordination_decision" || executionEvents[2].Status != "selected" {
+		t.Fatalf("third execution event = %#v", executionEvents[2])
+	}
+	if executionEvents[2].Payload["case_id"] != "case-1" || executionEvents[2].Payload["queue_id"] != "queue-1" || executionEvents[2].Payload["work_item_id"] != "work-1" || executionEvents[2].Payload["coordination_decision_id"] != "coord-1" || executionEvents[2].Payload["strategy"] != DefaultCoordinationStrategy {
+		t.Fatalf("execution event payload = %#v", executionEvents[2].Payload)
 	}
 }
 
@@ -84,7 +91,7 @@ func TestServiceReturnsErrorWhenPlanAttachmentFails(t *testing.T) {
 	if err := repo.SaveQueue(context.Background(), WorkQueue{ID: "queue-1", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
 		t.Fatalf("SaveQueue error = %v", err)
 	}
-	service := NewService(repo, NewRouter(repo, ""), errPlanner{err: fmt.Errorf("plan attach failed")}, eventcore.NewInMemoryEventLog(), fakeClock{now: time.Date(2026, 3, 22, 15, 0, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"work-1", "work-event-1"}})
+	service := NewService(repo, NewRouter(repo, ""), errPlanner{err: fmt.Errorf("plan attach failed")}, NewCoordinator(NewInMemoryCoordinationRepository(), eventcore.NewInMemoryEventLog(), fakeClock{now: time.Date(2026, 3, 22, 15, 0, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"coord-unused", "coord-event-unused"}}), eventcore.NewInMemoryEventLog(), fakeClock{now: time.Date(2026, 3, 22, 15, 0, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"work-1", "work-event-1"}})
 	resolved := caseruntime.ResolutionResult{Command: eventcore.Command{ID: "cmd-1", Type: "workflow.action", CorrelationID: "corr-1", ExecutionID: "exec-1", TargetRef: "test.WorkflowTask/rec-1"}, Case: caseruntime.Case{ID: "case-1", Kind: "workflow.action"}}
 
 	if _, err := service.IntakeCommand(context.Background(), resolved); err == nil {


### PR DESCRIPTION
### Motivation
- Introduce a minimal, transport-free coordination seam between `WorkItem` backlog and execution readiness without promoting `DailyPlan` to a mandatory runtime abstraction. 
- Provide a simple deterministic default strategy for this slice so downstream execution can be gated by an explicit `CoordinationDecision` record.

### Description
- Added a new coordination model and interfaces in `internal/workplan/coordination.go`, including `CoordinationDecision`, `CoordinationOutcome`, `CoordinationRepository`, and `Coordinator`.
- Implemented an in-memory, thread-safe repository `InMemoryCoordinationRepository` in `internal/workplan/coordination_repository.go` with list-by-work-item/case/queue support.
- Implemented a deterministic default coordinator `CoordinationService` in `internal/workplan/coordination_service.go` that writes one `selected` decision (strategy `default_queue_selection`), stamps ID/time from injected `IDGenerator`/`Clock`, and appends an `ExecutionEvent` step `coordination_decision` with the required payload.
- Wire coordination into intake: `internal/workplan/service.go` now depends on a `Coordinator`, invokes `CoordinateWorkItem` after plan attachment, and returns the created `CoordinationDecision` in `IntakeResult` while preserving the legacy execution path.
- Bootstrap now constructs and exposes `CoordinationRepo` and `Coordinator` in `internal/app/bootstrap.go` and checks them in `internal/app/bootstrap_test.go`.
- Added tests: repository tests (`internal/workplan/coordination_repository_test.go`), service tests (`internal/workplan/coordination_service_test.go`), intake/service tests updated to assert coordination (`internal/workplan/service_test.go`), and HTTP compatibility tests extended to assert coordination decision creation and coordination failure handling (`internal/http/actions_test.go`).

### Testing
- Ran `go test ./internal/workplan -count=1` and all workplan tests passed.
- Ran `go test ./internal/http -count=1` and targeted HTTP compatibility tests (including the new coordination failure test and intake seam) passed.
- Ran `go test ./internal/app -count=1` to validate bootstrap wiring and the test passed.
- Combined verification `go test ./internal/workplan ./internal/http ./internal/app -count=1` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c055f418c48324a42936380594bcd8)