### PR TITLE
Implement Slice 5 policy and approval control layer

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	"kalita/internal/command"
 	"kalita/internal/config"
 	"kalita/internal/eventcore"
+	"kalita/internal/policy"
 	"kalita/internal/postgres"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
@@ -33,6 +34,9 @@ type BootstrapResult struct {
 	Planner          workplan.Planner
 	Coordinator      workplan.Coordinator
 	WorkService      *workplan.Service
+	PolicyRepo       policy.PolicyRepository
+	PolicyEvaluator  policy.Evaluator
+	PolicyService    policy.Service
 	Config           config.Config
 }
 
@@ -108,6 +112,9 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	coordinationRepo := workplan.NewInMemoryCoordinationRepository()
 	coordinator := workplan.NewCoordinator(coordinationRepo, eventLog, clock, ids)
 	workService := workplan.NewService(queueRepo, assignmentRouter, planner, coordinator, eventLog, clock, ids)
+	policyRepo := policy.NewInMemoryRepository()
+	policyEvaluator := policy.NewEvaluator()
+	policyService := policy.NewService(policyRepo, policyEvaluator, eventLog, clock, ids)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
@@ -127,6 +134,9 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		Planner:          planner,
 		Coordinator:      coordinator,
 		WorkService:      workService,
+		PolicyRepo:       policyRepo,
+		PolicyEvaluator:  policyEvaluator,
+		PolicyService:    policyService,
 		Config:           cfg,
 	}, nil
 }

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestBootstrapProvidesEventCenterCaseRuntimeAndWorkplan(t *testing.T) {
+func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanAndPolicy(t *testing.T) {
 	cfg := `{
   "port": "8080",
   "dslDir": "../../dsl",
@@ -67,6 +67,15 @@ func TestBootstrapProvidesEventCenterCaseRuntimeAndWorkplan(t *testing.T) {
 	}
 	if result.WorkService == nil {
 		t.Fatal("WorkService is nil")
+	}
+	if result.PolicyRepo == nil {
+		t.Fatal("PolicyRepo is nil")
+	}
+	if result.PolicyEvaluator == nil {
+		t.Fatal("PolicyEvaluator is nil")
+	}
+	if result.PolicyService == nil {
+		t.Fatal("PolicyService is nil")
 	}
 	queues, err := result.QueueRepo.ListQueues(context.Background())
 	if err != nil {

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -11,6 +11,7 @@ import (
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
 	"kalita/internal/eventcore"
+	"kalita/internal/policy"
 	"kalita/internal/runtime"
 	"kalita/internal/validation"
 	"kalita/internal/workplan"
@@ -24,11 +25,11 @@ type actionRequest struct {
 }
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, nil, nil, nil)
+	return ActionHandlerWithServices(storage, nil, nil, nil, nil)
 }
 
 func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.CommandBus) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, commandBus, nil, nil)
+	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil)
 }
 
 type commandCaseResolver interface {
@@ -39,7 +40,11 @@ type workItemIntakeService interface {
 	IntakeCommand(ctx context.Context, resolved caseruntime.ResolutionResult) (workplan.IntakeResult, error)
 }
 
-func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService) gin.HandlerFunc {
+type policyService interface {
+	EvaluateAndRecord(ctx context.Context, d workplan.CoordinationDecision) (policy.PolicyDecision, *policy.ApprovalRequest, error)
+}
+
+func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		fqn, action, req, ok := parseActionRequest(c, storage)
 		if !ok {
@@ -68,13 +73,42 @@ func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.Comm
 					return
 				}
 				if workService != nil {
-					if _, err := workService.IntakeCommand(c.Request.Context(), resolved); err != nil {
+					intakeResult, err := workService.IntakeCommand(c.Request.Context(), resolved)
+					if err != nil {
 						c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
 							Code:    validation.ErrTypeMismatch,
 							Field:   "action",
 							Message: err.Error(),
 						}}})
 						return
+					}
+					if policyService != nil {
+						policyCtx := policy.ContextWithExecution(c.Request.Context(), policy.ExecutionContext{
+							ExecutionID:   intakeResult.Command.ExecutionID,
+							CorrelationID: intakeResult.Command.CorrelationID,
+							CausationID:   intakeResult.Command.ID,
+						})
+						policyDecision, approvalRequest, err := policyService.EvaluateAndRecord(policyCtx, intakeResult.CoordinationDecision)
+						if err != nil {
+							c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+								Code:    validation.ErrTypeMismatch,
+								Field:   "action",
+								Message: err.Error(),
+							}}})
+							return
+						}
+						if policyDecision.Outcome != policy.PolicyAllow {
+							message := policyDecision.Reason
+							if approvalRequest != nil {
+								message = fmt.Sprintf("%s (approval_request_id=%s)", message, approvalRequest.ID)
+							}
+							c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+								Code:    validation.ErrTypeMismatch,
+								Field:   "action",
+								Message: message,
+							}}})
+							return
+						}
 					}
 				}
 			}

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -13,6 +13,7 @@ import (
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
 	"kalita/internal/eventcore"
+	"kalita/internal/policy"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
 	"kalita/internal/workplan"
@@ -260,6 +261,16 @@ func (f failingCoordinator) CoordinateWorkItem(context.Context, workplan.WorkIte
 	return workplan.CoordinationDecision{}, f.err
 }
 
+type staticPolicyService struct {
+	decision policy.PolicyDecision
+	approval *policy.ApprovalRequest
+	err      error
+}
+
+func (s staticPolicyService) EvaluateAndRecord(context.Context, workplan.CoordinationDecision) (policy.PolicyDecision, *policy.ApprovalRequest, error) {
+	return s.decision, s.approval, s.err
+}
+
 func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -282,7 +293,7 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, coordinator, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -365,7 +376,7 @@ func TestActionHandlerReturnsValidationErrorWhenCaseResolutionFails(t *testing.T
 
 	storage, rec := testHTTPWorkflowStorage()
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -394,7 +405,7 @@ func TestActionHandlerReturnsValidationErrorWhenWorkItemIntakeFails(t *testing.T
 	caseRepo := caseruntime.NewInMemoryCaseRepository()
 	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -430,7 +441,109 @@ func TestActionHandlerReturnsValidationErrorWhenCoordinationFails(t *testing.T) 
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, failingCoordinator{err: errors.New("coordination failed")}, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
+}
+
+func TestActionHandlerPolicyAllowContinuesLegacyFlow(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
+		decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"},
+	}))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestActionHandlerPolicyRequireApprovalStopsBeforeLegacyFlow(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
+		decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"},
+		approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending},
+	}))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
+}
+
+func TestActionHandlerPolicyDenyStopsBeforeLegacyFlow(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(
+		storage,
+		staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}},
+		nil,
+		nil,
+		staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}},
+	))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -578,7 +691,7 @@ func TestActionHandlerReturnsValidationErrorWhenDailyPlanAttachmentFails(t *test
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), failingPlanner{err: errors.New("daily plan failed")}, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -1,0 +1,27 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/workplan"
+)
+
+type DeterministicEvaluator struct{}
+
+func NewEvaluator() *DeterministicEvaluator {
+	return &DeterministicEvaluator{}
+}
+
+func (e *DeterministicEvaluator) EvaluateCoordinationDecision(_ context.Context, d workplan.CoordinationDecision) (PolicyOutcome, string, error) {
+	switch d.Strategy {
+	case "requires_manager_approval":
+		return PolicyRequireApproval, fmt.Sprintf("strategy %s requires manager approval before execution", d.Strategy), nil
+	case "blocked_strategy":
+		return PolicyDeny, fmt.Sprintf("strategy %s is blocked from execution", d.Strategy), nil
+	}
+	if d.Outcome == workplan.CoordinationSelected {
+		return PolicyAllow, fmt.Sprintf("coordination decision %s selected work item %s for execution", d.ID, d.WorkItemID), nil
+	}
+	return PolicyAllow, fmt.Sprintf("coordination strategy %s allowed by default for work item %s", d.Strategy, d.WorkItemID), nil
+}

--- a/internal/policy/evaluator_test.go
+++ b/internal/policy/evaluator_test.go
@@ -1,0 +1,50 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"kalita/internal/workplan"
+)
+
+func TestDeterministicEvaluatorSelectedAllows(t *testing.T) {
+	e := NewEvaluator()
+	outcome, reason, err := e.EvaluateCoordinationDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "wi-1", Outcome: workplan.CoordinationSelected, Strategy: workplan.DefaultCoordinationStrategy})
+	if err != nil {
+		t.Fatalf("EvaluateCoordinationDecision error = %v", err)
+	}
+	if outcome != PolicyAllow {
+		t.Fatalf("outcome = %q", outcome)
+	}
+	if reason == "" {
+		t.Fatal("reason is empty")
+	}
+}
+
+func TestDeterministicEvaluatorRequiresApprovalStrategy(t *testing.T) {
+	e := NewEvaluator()
+	outcome, reason, err := e.EvaluateCoordinationDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "wi-1", Outcome: workplan.CoordinationSelected, Strategy: "requires_manager_approval"})
+	if err != nil {
+		t.Fatalf("EvaluateCoordinationDecision error = %v", err)
+	}
+	if outcome != PolicyRequireApproval {
+		t.Fatalf("outcome = %q", outcome)
+	}
+	if reason == "" {
+		t.Fatal("reason is empty")
+	}
+}
+
+func TestDeterministicEvaluatorBlockedStrategyDenies(t *testing.T) {
+	e := NewEvaluator()
+	outcome, reason, err := e.EvaluateCoordinationDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "wi-1", Outcome: workplan.CoordinationSelected, Strategy: "blocked_strategy"})
+	if err != nil {
+		t.Fatalf("EvaluateCoordinationDecision error = %v", err)
+	}
+	if outcome != PolicyDeny {
+		t.Fatalf("outcome = %q", outcome)
+	}
+	if reason == "" {
+		t.Fatal("reason is empty")
+	}
+}

--- a/internal/policy/repository.go
+++ b/internal/policy/repository.go
@@ -1,0 +1,124 @@
+package policy
+
+import (
+	"context"
+	"sync"
+)
+
+type InMemoryRepository struct {
+	mu sync.RWMutex
+
+	decisionsByID               map[string]PolicyDecision
+	decisionOrder               []string
+	decisionIDsByCoordinationID map[string][]string
+	approvalsByID               map[string]ApprovalRequest
+	approvalOrder               []string
+	approvalIDsByCoordinationID map[string][]string
+}
+
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{
+		decisionsByID:               make(map[string]PolicyDecision),
+		decisionIDsByCoordinationID: make(map[string][]string),
+		approvalsByID:               make(map[string]ApprovalRequest),
+		approvalIDsByCoordinationID: make(map[string][]string),
+	}
+}
+
+func (r *InMemoryRepository) SaveDecision(_ context.Context, d PolicyDecision) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.decisionsByID[d.ID]; ok {
+		if existing.CoordinationDecisionID != d.CoordinationDecisionID {
+			r.decisionIDsByCoordinationID[existing.CoordinationDecisionID] = removeID(r.decisionIDsByCoordinationID[existing.CoordinationDecisionID], d.ID)
+		}
+	} else {
+		r.decisionOrder = append(r.decisionOrder, d.ID)
+	}
+	if !containsID(r.decisionIDsByCoordinationID[d.CoordinationDecisionID], d.ID) {
+		r.decisionIDsByCoordinationID[d.CoordinationDecisionID] = append(r.decisionIDsByCoordinationID[d.CoordinationDecisionID], d.ID)
+	}
+	r.decisionsByID[d.ID] = d
+	return nil
+}
+
+func (r *InMemoryRepository) GetDecision(_ context.Context, id string) (PolicyDecision, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	d, ok := r.decisionsByID[id]
+	if !ok {
+		return PolicyDecision{}, false, nil
+	}
+	return d, true, nil
+}
+
+func (r *InMemoryRepository) ListByCoordinationDecision(_ context.Context, coordinationDecisionID string) ([]PolicyDecision, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.decisionIDsByCoordinationID[coordinationDecisionID]
+	out := make([]PolicyDecision, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, r.decisionsByID[id])
+	}
+	return out, nil
+}
+
+func (r *InMemoryRepository) SaveApprovalRequest(_ context.Context, a ApprovalRequest) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.approvalsByID[a.ID]; ok {
+		if existing.CoordinationDecisionID != a.CoordinationDecisionID {
+			r.approvalIDsByCoordinationID[existing.CoordinationDecisionID] = removeID(r.approvalIDsByCoordinationID[existing.CoordinationDecisionID], a.ID)
+		}
+	} else {
+		r.approvalOrder = append(r.approvalOrder, a.ID)
+	}
+	if !containsID(r.approvalIDsByCoordinationID[a.CoordinationDecisionID], a.ID) {
+		r.approvalIDsByCoordinationID[a.CoordinationDecisionID] = append(r.approvalIDsByCoordinationID[a.CoordinationDecisionID], a.ID)
+	}
+	r.approvalsByID[a.ID] = a
+	return nil
+}
+
+func (r *InMemoryRepository) GetApprovalRequest(_ context.Context, id string) (ApprovalRequest, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.approvalsByID[id]
+	if !ok {
+		return ApprovalRequest{}, false, nil
+	}
+	return a, true, nil
+}
+
+func (r *InMemoryRepository) ListApprovalRequestsByCoordinationDecision(_ context.Context, coordinationDecisionID string) ([]ApprovalRequest, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.approvalIDsByCoordinationID[coordinationDecisionID]
+	out := make([]ApprovalRequest, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, r.approvalsByID[id])
+	}
+	return out, nil
+}
+
+func containsID(ids []string, id string) bool {
+	for _, existing := range ids {
+		if existing == id {
+			return true
+		}
+	}
+	return false
+}
+
+func removeID(ids []string, id string) []string {
+	if len(ids) == 0 {
+		return ids
+	}
+	out := ids[:0]
+	for _, existing := range ids {
+		if existing != id {
+			out = append(out, existing)
+		}
+	}
+	return out
+}

--- a/internal/policy/repository_test.go
+++ b/internal/policy/repository_test.go
@@ -1,0 +1,61 @@
+package policy
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryRepositorySavesGetsAndListsPolicyDecisions(t *testing.T) {
+	repo := NewInMemoryRepository()
+	ctx := context.Background()
+	first := PolicyDecision{ID: "policy-1", CoordinationDecisionID: "coord-1", Outcome: PolicyAllow, Reason: "allowed", CreatedAt: time.Date(2026, 3, 22, 12, 0, 0, 0, time.UTC)}
+	second := PolicyDecision{ID: "policy-2", CoordinationDecisionID: "coord-1", Outcome: PolicyDeny, Reason: "denied", CreatedAt: time.Date(2026, 3, 22, 12, 1, 0, 0, time.UTC)}
+	if err := repo.SaveDecision(ctx, first); err != nil {
+		t.Fatalf("SaveDecision first error = %v", err)
+	}
+	if err := repo.SaveDecision(ctx, second); err != nil {
+		t.Fatalf("SaveDecision second error = %v", err)
+	}
+	got, ok, err := repo.GetDecision(ctx, "policy-1")
+	if err != nil || !ok {
+		t.Fatalf("GetDecision ok=%v err=%v", ok, err)
+	}
+	if got.Reason != "allowed" {
+		t.Fatalf("GetDecision reason = %q", got.Reason)
+	}
+	listed, err := repo.ListByCoordinationDecision(ctx, "coord-1")
+	if err != nil {
+		t.Fatalf("ListByCoordinationDecision error = %v", err)
+	}
+	if len(listed) != 2 || listed[0].ID != "policy-1" || listed[1].ID != "policy-2" {
+		t.Fatalf("listed = %#v", listed)
+	}
+}
+
+func TestInMemoryRepositorySavesGetsAndListsApprovalRequests(t *testing.T) {
+	repo := NewInMemoryRepository()
+	ctx := context.Background()
+	first := ApprovalRequest{ID: "approval-1", CoordinationDecisionID: "coord-1", PolicyDecisionID: "policy-1", Status: ApprovalPending, RequestedFromRole: "manager", CreatedAt: time.Date(2026, 3, 22, 12, 0, 0, 0, time.UTC)}
+	second := ApprovalRequest{ID: "approval-2", CoordinationDecisionID: "coord-1", PolicyDecisionID: "policy-2", Status: ApprovalRejected, RequestedFromRole: "director", CreatedAt: time.Date(2026, 3, 22, 12, 1, 0, 0, time.UTC)}
+	if err := repo.SaveApprovalRequest(ctx, first); err != nil {
+		t.Fatalf("SaveApprovalRequest first error = %v", err)
+	}
+	if err := repo.SaveApprovalRequest(ctx, second); err != nil {
+		t.Fatalf("SaveApprovalRequest second error = %v", err)
+	}
+	got, ok, err := repo.GetApprovalRequest(ctx, "approval-1")
+	if err != nil || !ok {
+		t.Fatalf("GetApprovalRequest ok=%v err=%v", ok, err)
+	}
+	if got.RequestedFromRole != "manager" {
+		t.Fatalf("GetApprovalRequest role = %q", got.RequestedFromRole)
+	}
+	listed, err := repo.ListApprovalRequestsByCoordinationDecision(ctx, "coord-1")
+	if err != nil {
+		t.Fatalf("ListApprovalRequestsByCoordinationDecision error = %v", err)
+	}
+	if len(listed) != 2 || listed[0].ID != "approval-1" || listed[1].ID != "approval-2" {
+		t.Fatalf("listed = %#v", listed)
+	}
+}

--- a/internal/policy/service.go
+++ b/internal/policy/service.go
@@ -1,0 +1,130 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"kalita/internal/eventcore"
+	"kalita/internal/workplan"
+)
+
+type policyExecutionContextKey struct{}
+
+type ExecutionContext struct {
+	ExecutionID   string
+	CorrelationID string
+	CausationID   string
+}
+
+func ContextWithExecution(ctx context.Context, meta ExecutionContext) context.Context {
+	return context.WithValue(ctx, policyExecutionContextKey{}, meta)
+}
+
+func executionFromContext(ctx context.Context) ExecutionContext {
+	meta, _ := ctx.Value(policyExecutionContextKey{}).(ExecutionContext)
+	return meta
+}
+
+type PolicyService struct {
+	repo      PolicyRepository
+	evaluator Evaluator
+	log       eventcore.EventLog
+	clock     eventcore.Clock
+	ids       eventcore.IDGenerator
+}
+
+func NewService(repo PolicyRepository, evaluator Evaluator, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *PolicyService {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &PolicyService{repo: repo, evaluator: evaluator, log: log, clock: clock, ids: ids}
+}
+
+func (s *PolicyService) EvaluateAndRecord(ctx context.Context, d workplan.CoordinationDecision) (PolicyDecision, *ApprovalRequest, error) {
+	if s.repo == nil {
+		return PolicyDecision{}, nil, fmt.Errorf("policy repository is nil")
+	}
+	if s.evaluator == nil {
+		return PolicyDecision{}, nil, fmt.Errorf("policy evaluator is nil")
+	}
+	outcome, reason, err := s.evaluator.EvaluateCoordinationDecision(ctx, d)
+	if err != nil {
+		return PolicyDecision{}, nil, err
+	}
+	if reason == "" {
+		reason = fmt.Sprintf("policy outcome %s", outcome)
+	}
+	now := s.clock.Now()
+	decision := PolicyDecision{
+		ID:                     s.ids.NewID(),
+		CoordinationDecisionID: d.ID,
+		CaseID:                 d.CaseID,
+		WorkItemID:             d.WorkItemID,
+		QueueID:                d.QueueID,
+		Outcome:                outcome,
+		Reason:                 reason,
+		CreatedAt:              now,
+	}
+	if err := s.repo.SaveDecision(ctx, decision); err != nil {
+		return PolicyDecision{}, nil, err
+	}
+	if err := s.appendEvent(ctx, d, decision, "policy_evaluation", string(outcome), map[string]any{
+		"coordination_decision_id": d.ID,
+		"case_id":                  d.CaseID,
+		"work_item_id":             d.WorkItemID,
+		"queue_id":                 d.QueueID,
+		"policy_decision_id":       decision.ID,
+	}, now); err != nil {
+		return PolicyDecision{}, nil, err
+	}
+	if outcome != PolicyRequireApproval {
+		return decision, nil, nil
+	}
+	approval := &ApprovalRequest{
+		ID:                     s.ids.NewID(),
+		CoordinationDecisionID: d.ID,
+		PolicyDecisionID:       decision.ID,
+		CaseID:                 d.CaseID,
+		WorkItemID:             d.WorkItemID,
+		QueueID:                d.QueueID,
+		Status:                 ApprovalPending,
+		RequestedFromRole:      "manager",
+		CreatedAt:              now,
+	}
+	if err := s.repo.SaveApprovalRequest(ctx, *approval); err != nil {
+		return PolicyDecision{}, nil, err
+	}
+	if err := s.appendEvent(ctx, d, decision, "approval_request_created", string(ApprovalPending), map[string]any{
+		"coordination_decision_id": d.ID,
+		"case_id":                  d.CaseID,
+		"work_item_id":             d.WorkItemID,
+		"queue_id":                 d.QueueID,
+		"policy_decision_id":       decision.ID,
+		"approval_request_id":      approval.ID,
+	}, now); err != nil {
+		return PolicyDecision{}, nil, err
+	}
+	return decision, approval, nil
+}
+
+func (s *PolicyService) appendEvent(ctx context.Context, d workplan.CoordinationDecision, decision PolicyDecision, step, status string, payload map[string]any, now time.Time) error {
+	if s.log == nil {
+		return nil
+	}
+	meta := executionFromContext(ctx)
+	return s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{
+		ID:            s.ids.NewID(),
+		ExecutionID:   meta.ExecutionID,
+		CaseID:        d.CaseID,
+		Step:          step,
+		Status:        status,
+		OccurredAt:    now,
+		CorrelationID: meta.CorrelationID,
+		CausationID:   meta.CausationID,
+		Payload:       payload,
+	})
+}

--- a/internal/policy/service_test.go
+++ b/internal/policy/service_test.go
@@ -1,0 +1,105 @@
+package policy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/eventcore"
+	"kalita/internal/workplan"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDGenerator struct {
+	ids []string
+	i   int
+}
+
+func (f *fakeIDGenerator) NewID() string { id := f.ids[f.i]; f.i++; return id }
+
+func TestPolicyServiceAllowCreatesDecisionAndEvent(t *testing.T) {
+	repo := NewInMemoryRepository()
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"policy-1", "event-1"}}
+	service := NewService(repo, NewEvaluator(), log, clock, ids)
+	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
+	decision, approval, err := service.EvaluateAndRecord(ctx, workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", Outcome: workplan.CoordinationSelected, Strategy: workplan.DefaultCoordinationStrategy})
+	if err != nil {
+		t.Fatalf("EvaluateAndRecord error = %v", err)
+	}
+	if decision.Outcome != PolicyAllow || approval != nil {
+		t.Fatalf("decision=%#v approval=%#v", decision, approval)
+	}
+	stored, err := repo.ListByCoordinationDecision(context.Background(), "coord-1")
+	if err != nil || len(stored) != 1 {
+		t.Fatalf("stored=%#v err=%v", stored, err)
+	}
+	_, events, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(events) != 1 || events[0].Step != "policy_evaluation" || events[0].Status != string(PolicyAllow) {
+		t.Fatalf("events = %#v", events)
+	}
+}
+
+func TestPolicyServiceRequireApprovalCreatesDecisionApprovalAndEvents(t *testing.T) {
+	repo := NewInMemoryRepository()
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"policy-1", "event-1", "approval-1", "event-2"}}
+	service := NewService(repo, NewEvaluator(), log, clock, ids)
+	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
+	decision, approval, err := service.EvaluateAndRecord(ctx, workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", Outcome: workplan.CoordinationSelected, Strategy: "requires_manager_approval"})
+	if err != nil {
+		t.Fatalf("EvaluateAndRecord error = %v", err)
+	}
+	if decision.Outcome != PolicyRequireApproval || approval == nil || approval.Status != ApprovalPending {
+		t.Fatalf("decision=%#v approval=%#v", decision, approval)
+	}
+	approvals, err := repo.ListApprovalRequestsByCoordinationDecision(context.Background(), "coord-1")
+	if err != nil || len(approvals) != 1 {
+		t.Fatalf("approvals=%#v err=%v", approvals, err)
+	}
+	_, events, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(events) != 2 || events[0].Step != "policy_evaluation" || events[1].Step != "approval_request_created" || events[1].Status != string(ApprovalPending) {
+		t.Fatalf("events = %#v", events)
+	}
+}
+
+func TestPolicyServiceDenyCreatesDecisionAndEventWithoutApproval(t *testing.T) {
+	repo := NewInMemoryRepository()
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"policy-1", "event-1"}}
+	service := NewService(repo, NewEvaluator(), log, clock, ids)
+	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
+	decision, approval, err := service.EvaluateAndRecord(ctx, workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", Outcome: workplan.CoordinationSelected, Strategy: "blocked_strategy"})
+	if err != nil {
+		t.Fatalf("EvaluateAndRecord error = %v", err)
+	}
+	if decision.Outcome != PolicyDeny || approval != nil {
+		t.Fatalf("decision=%#v approval=%#v", decision, approval)
+	}
+	approvals, err := repo.ListApprovalRequestsByCoordinationDecision(context.Background(), "coord-1")
+	if err != nil {
+		t.Fatalf("ListApprovalRequestsByCoordinationDecision error = %v", err)
+	}
+	if len(approvals) != 0 {
+		t.Fatalf("approvals = %#v", approvals)
+	}
+	_, events, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(events) != 1 || events[0].Step != "policy_evaluation" || events[0].Status != string(PolicyDeny) {
+		t.Fatalf("events = %#v", events)
+	}
+}

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -1,0 +1,67 @@
+package policy
+
+import (
+	"context"
+	"time"
+
+	"kalita/internal/workplan"
+)
+
+type PolicyOutcome string
+
+const (
+	PolicyAllow           PolicyOutcome = "allow"
+	PolicyRequireApproval PolicyOutcome = "require_approval"
+	PolicyDeny            PolicyOutcome = "deny"
+)
+
+type PolicyDecision struct {
+	ID                     string
+	CoordinationDecisionID string
+	CaseID                 string
+	WorkItemID             string
+	QueueID                string
+	Outcome                PolicyOutcome
+	Reason                 string
+	CreatedAt              time.Time
+}
+
+type ApprovalStatus string
+
+const (
+	ApprovalPending  ApprovalStatus = "pending"
+	ApprovalApproved ApprovalStatus = "approved"
+	ApprovalRejected ApprovalStatus = "rejected"
+)
+
+type ApprovalRequest struct {
+	ID                     string
+	CoordinationDecisionID string
+	PolicyDecisionID       string
+	CaseID                 string
+	WorkItemID             string
+	QueueID                string
+	Status                 ApprovalStatus
+	RequestedFromRole      string
+	CreatedAt              time.Time
+	ResolvedAt             *time.Time
+	ResolutionNote         string
+}
+
+type PolicyRepository interface {
+	SaveDecision(ctx context.Context, d PolicyDecision) error
+	GetDecision(ctx context.Context, id string) (PolicyDecision, bool, error)
+	ListByCoordinationDecision(ctx context.Context, coordinationDecisionID string) ([]PolicyDecision, error)
+
+	SaveApprovalRequest(ctx context.Context, r ApprovalRequest) error
+	GetApprovalRequest(ctx context.Context, id string) (ApprovalRequest, bool, error)
+	ListApprovalRequestsByCoordinationDecision(ctx context.Context, coordinationDecisionID string) ([]ApprovalRequest, error)
+}
+
+type Evaluator interface {
+	EvaluateCoordinationDecision(ctx context.Context, d workplan.CoordinationDecision) (PolicyOutcome, string, error)
+}
+
+type Service interface {
+	EvaluateAndRecord(ctx context.Context, d workplan.CoordinationDecision) (PolicyDecision, *ApprovalRequest, error)
+}


### PR DESCRIPTION
### Motivation

- Introduce a minimal transport-free Policy + Approval control layer that decides whether coordinated work may execute, requires approval, or is denied, and records the reason.  
- Preserve incremental, deterministic behavior for Slice 5: keep persistence in-memory, avoid DigitalEmployee/LLM/assignment logic, and avoid changing legacy execution or CRUD handlers.  
- Expose a clear compatibility seam so non-allow outcomes return existing-style validation responses and stop legacy execution, enabling future slices to build on the same artifacts.

### Description

- Add a transport-free `internal/policy` package with `types.go`, `repository.go`, `evaluator.go`, and `service.go` implementing `PolicyDecision` and `ApprovalRequest` types, a thread-safe in-memory repository, a deterministic evaluator, and a service that records decisions and approval requests.  
- Implement `InMemoryRepository` to `Save`/`Get`/`List` policy decisions and approval requests with `sync.RWMutex` protection and preserved append order where practical.  
- Provide a `DeterministicEvaluator` with explicit branches: `requires_manager_approval` → `require_approval`, `blocked_strategy` → `deny`, and default/`CoordinationSelected` → `allow`, always returning a non-empty reason.  
- Implement `PolicyService.EvaluateAndRecord` to persist a `PolicyDecision`, append an execution event `policy_evaluation`, and, for `require_approval`, create an `ApprovalRequest` + `approval_request_created` event; wire the `PolicyRepository`, `Evaluator`, and `PolicyService` in application bootstrap and evaluate policy in the workflow-action compatibility seam (stop legacy execution for non-allow outcomes).

### Testing

- Added unit tests for the policy package: `internal/policy/repository_test.go`, `evaluator_test.go`, and `service_test.go` and executed `go test ./internal/policy -count=1`, which passed.  
- Added/updated compatibility and bootstrap tests under `internal/http` and `internal/app` to exercise the seam and bootstrap exposure, and attempted targeted runs for those packages, but the targeted `go test` runs did not complete within the runner timeout, so they did not finish in this environment.  
- Summary of automated test commands run: `go test ./internal/policy -count=1` (passed); targeted `go test ./internal/app` and `go test ./internal/http` runs were attempted but did not complete within the execution window.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c059de4b8c8324a3e100217cab8ff9)