### PR TITLE
Add execution constraints layer (executioncontrol) and wire into action compatibility seam

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	"kalita/internal/command"
 	"kalita/internal/config"
 	"kalita/internal/eventcore"
+	"kalita/internal/executioncontrol"
 	"kalita/internal/policy"
 	"kalita/internal/postgres"
 	"kalita/internal/runtime"
@@ -21,23 +22,26 @@ import (
 
 // BootstrapResult holds the initialized application components
 type BootstrapResult struct {
-	Storage          *runtime.Storage
-	EventLog         eventcore.EventLog
-	CommandBus       command.CommandBus
-	CaseRepo         caseruntime.CaseRepository
-	CaseResolver     caseruntime.CaseResolver
-	CaseService      *caseruntime.Service
-	QueueRepo        workplan.QueueRepository
-	PlanRepo         workplan.PlanRepository
-	CoordinationRepo workplan.CoordinationRepository
-	AssignmentRouter workplan.AssignmentRouter
-	Planner          workplan.Planner
-	Coordinator      workplan.Coordinator
-	WorkService      *workplan.Service
-	PolicyRepo       policy.PolicyRepository
-	PolicyEvaluator  policy.Evaluator
-	PolicyService    policy.Service
-	Config           config.Config
+	Storage            *runtime.Storage
+	EventLog           eventcore.EventLog
+	CommandBus         command.CommandBus
+	CaseRepo           caseruntime.CaseRepository
+	CaseResolver       caseruntime.CaseResolver
+	CaseService        *caseruntime.Service
+	QueueRepo          workplan.QueueRepository
+	PlanRepo           workplan.PlanRepository
+	CoordinationRepo   workplan.CoordinationRepository
+	AssignmentRouter   workplan.AssignmentRouter
+	Planner            workplan.Planner
+	Coordinator        workplan.Coordinator
+	WorkService        *workplan.Service
+	PolicyRepo         policy.PolicyRepository
+	PolicyEvaluator    policy.Evaluator
+	PolicyService      policy.Service
+	ConstraintsRepo    executioncontrol.ConstraintsRepository
+	ConstraintsPlanner executioncontrol.ConstraintsPlanner
+	ConstraintsService executioncontrol.ConstraintsService
+	Config             config.Config
 }
 
 // Bootstrap initializes the application with all required components
@@ -115,29 +119,35 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	policyRepo := policy.NewInMemoryRepository()
 	policyEvaluator := policy.NewEvaluator()
 	policyService := policy.NewService(policyRepo, policyEvaluator, eventLog, clock, ids)
+	constraintsRepo := executioncontrol.NewInMemoryConstraintsRepository()
+	constraintsPlanner := executioncontrol.NewPlanner()
+	constraintsService := executioncontrol.NewService(constraintsRepo, constraintsPlanner, eventLog, clock, ids)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
 	st.Blob = &blob.LocalBlobStore{Root: cfg.FilesRoot}
 
 	return &BootstrapResult{
-		Storage:          st,
-		EventLog:         eventLog,
-		CommandBus:       commandBus,
-		CaseRepo:         caseRepo,
-		CaseResolver:     caseResolver,
-		CaseService:      caseService,
-		QueueRepo:        queueRepo,
-		PlanRepo:         planRepo,
-		CoordinationRepo: coordinationRepo,
-		AssignmentRouter: assignmentRouter,
-		Planner:          planner,
-		Coordinator:      coordinator,
-		WorkService:      workService,
-		PolicyRepo:       policyRepo,
-		PolicyEvaluator:  policyEvaluator,
-		PolicyService:    policyService,
-		Config:           cfg,
+		Storage:            st,
+		EventLog:           eventLog,
+		CommandBus:         commandBus,
+		CaseRepo:           caseRepo,
+		CaseResolver:       caseResolver,
+		CaseService:        caseService,
+		QueueRepo:          queueRepo,
+		PlanRepo:           planRepo,
+		CoordinationRepo:   coordinationRepo,
+		AssignmentRouter:   assignmentRouter,
+		Planner:            planner,
+		Coordinator:        coordinator,
+		WorkService:        workService,
+		PolicyRepo:         policyRepo,
+		PolicyEvaluator:    policyEvaluator,
+		PolicyService:      policyService,
+		ConstraintsRepo:    constraintsRepo,
+		ConstraintsPlanner: constraintsPlanner,
+		ConstraintsService: constraintsService,
+		Config:             cfg,
 	}, nil
 }
 

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanAndPolicy(t *testing.T) {
+func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanPolicyAndExecutionControl(t *testing.T) {
 	cfg := `{
   "port": "8080",
   "dslDir": "../../dsl",
@@ -76,6 +76,15 @@ func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanAndPolicy(t *testing.T) 
 	}
 	if result.PolicyService == nil {
 		t.Fatal("PolicyService is nil")
+	}
+	if result.ConstraintsRepo == nil {
+		t.Fatal("ConstraintsRepo is nil")
+	}
+	if result.ConstraintsPlanner == nil {
+		t.Fatal("ConstraintsPlanner is nil")
+	}
+	if result.ConstraintsService == nil {
+		t.Fatal("ConstraintsService is nil")
 	}
 	queues, err := result.QueueRepo.ListQueues(context.Background())
 	if err != nil {

--- a/internal/executioncontrol/planner.go
+++ b/internal/executioncontrol/planner.go
@@ -1,0 +1,97 @@
+package executioncontrol
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"kalita/internal/policy"
+	"kalita/internal/workplan"
+)
+
+const UIScopeMarker = "ui.operator"
+
+type DeterministicPlanner struct{}
+
+func NewPlanner() *DeterministicPlanner {
+	return &DeterministicPlanner{}
+}
+
+func (p *DeterministicPlanner) PlanForPolicyDecision(_ context.Context, coordination workplan.CoordinationDecision, policyDecision policy.PolicyDecision) (ExecutionConstraints, error) {
+	if policyDecision.Outcome == policy.PolicyDeny {
+		return ExecutionConstraints{}, fmt.Errorf("execution constraints cannot be created for denied policy decision %s", policyDecision.ID)
+	}
+
+	constraints := ExecutionConstraints{
+		CoordinationDecisionID: coordination.ID,
+		PolicyDecisionID:       policyDecision.ID,
+		CaseID:                 coordination.CaseID,
+		WorkItemID:             coordination.WorkItemID,
+		QueueID:                coordination.QueueID,
+		RiskLevel:              RiskMedium,
+		ExecutionMode:          ExecutionModeDeterministicAPI,
+		MaxTokens:              0,
+		MaxCost:                0,
+		MaxSteps:               10,
+		MaxDurationSec:         300,
+		AllowedScopes:          []string{"default"},
+		ForbiddenOps:           []string{},
+		Reason:                 fmt.Sprintf("baseline execution constraints selected for strategy %s with policy outcome %s", coordination.Strategy, policyDecision.Outcome),
+	}
+
+	switch coordination.Strategy {
+	case "ui_operator_mode":
+		constraints.ExecutionMode = ExecutionModeGuidedUIOperator
+		constraints.RiskLevel = RiskHigh
+		constraints.MaxSteps = 20
+		constraints.MaxDurationSec = 900
+		constraints.AllowedScopes = appendUnique(constraints.AllowedScopes, UIScopeMarker)
+		constraints.Reason = "ui operator strategy requires guided high-risk execution constraints with deterministic UI scope"
+	case "checkpointed_mode":
+		constraints.ExecutionMode = ExecutionModeCheckpointedAutonomy
+		constraints.RiskLevel = RiskHigh
+		constraints.MaxSteps = 5
+		constraints.MaxDurationSec = 300
+		constraints.Reason = "checkpointed strategy requires bounded high-risk autonomy with explicit checkpoints"
+	case "requires_manager_approval":
+		constraints.RiskLevel = RiskHigh
+		constraints.ExecutionMode = ExecutionModeApprovalEachStep
+		constraints.MaxSteps = 1
+		constraints.MaxDurationSec = 60
+		constraints.Reason = "restrictive execution constraints selected because manager approval is required before any execution step"
+	case workplan.DefaultCoordinationStrategy:
+		if policyDecision.Outcome == policy.PolicyAllow {
+			constraints.Reason = "baseline execution constraints selected for default queue selection after policy allow"
+		}
+	}
+
+	if policyDecision.Outcome == policy.PolicyRequireApproval {
+		constraints.RiskLevel = RiskHigh
+		constraints.ExecutionMode = ExecutionModeApprovalEachStep
+		constraints.MaxSteps = 1
+		constraints.MaxDurationSec = 60
+		constraints.Reason = restrictiveReason(coordination.Strategy)
+	}
+
+	constraints.Reason = strings.TrimSpace(constraints.Reason)
+	if constraints.Reason == "" {
+		constraints.Reason = fmt.Sprintf("execution constraints selected for strategy %s with policy outcome %s", coordination.Strategy, policyDecision.Outcome)
+	}
+	return constraints, nil
+}
+
+func restrictiveReason(strategy string) string {
+	if strategy == "requires_manager_approval" {
+		return "restrictive execution constraints selected because manager approval is required before any execution step"
+	}
+	return fmt.Sprintf("restrictive execution constraints selected because policy requires approval before continuing strategy %s", strategy)
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}

--- a/internal/executioncontrol/planner_test.go
+++ b/internal/executioncontrol/planner_test.go
@@ -1,0 +1,107 @@
+package executioncontrol
+
+import (
+	"context"
+	"testing"
+
+	"kalita/internal/policy"
+	"kalita/internal/workplan"
+)
+
+func TestDeterministicPlannerAllowDefaultQueueSelection(t *testing.T) {
+	t.Parallel()
+	planner := NewPlanner()
+	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: workplan.DefaultCoordinationStrategy}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow})
+	if err != nil {
+		t.Fatalf("PlanForPolicyDecision error = %v", err)
+	}
+	if constraints.ExecutionMode != ExecutionModeDeterministicAPI || constraints.RiskLevel != RiskMedium || constraints.MaxSteps != 10 || constraints.MaxDurationSec != 300 {
+		t.Fatalf("constraints = %#v", constraints)
+	}
+	if len(constraints.AllowedScopes) != 1 || constraints.AllowedScopes[0] != "default" {
+		t.Fatalf("AllowedScopes = %#v", constraints.AllowedScopes)
+	}
+	if constraints.Reason == "" {
+		t.Fatal("Reason is empty")
+	}
+}
+
+func TestDeterministicPlannerRequireApprovalRestrictive(t *testing.T) {
+	t.Parallel()
+	planner := NewPlanner()
+	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: workplan.DefaultCoordinationStrategy}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyRequireApproval})
+	if err != nil {
+		t.Fatalf("PlanForPolicyDecision error = %v", err)
+	}
+	if constraints.ExecutionMode != ExecutionModeApprovalEachStep || constraints.RiskLevel != RiskHigh || constraints.MaxSteps != 1 || constraints.MaxDurationSec != 60 {
+		t.Fatalf("constraints = %#v", constraints)
+	}
+	if constraints.Reason == "" {
+		t.Fatal("Reason is empty")
+	}
+}
+
+func TestDeterministicPlannerUIOperatorMode(t *testing.T) {
+	t.Parallel()
+	planner := NewPlanner()
+	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: "ui_operator_mode"}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow})
+	if err != nil {
+		t.Fatalf("PlanForPolicyDecision error = %v", err)
+	}
+	if constraints.ExecutionMode != ExecutionModeGuidedUIOperator || constraints.RiskLevel != RiskHigh || constraints.MaxSteps != 20 || constraints.MaxDurationSec != 900 {
+		t.Fatalf("constraints = %#v", constraints)
+	}
+	if len(constraints.AllowedScopes) != 2 || constraints.AllowedScopes[1] != UIScopeMarker {
+		t.Fatalf("AllowedScopes = %#v", constraints.AllowedScopes)
+	}
+	if constraints.Reason == "" {
+		t.Fatal("Reason is empty")
+	}
+}
+
+func TestDeterministicPlannerCheckpointedMode(t *testing.T) {
+	t.Parallel()
+	planner := NewPlanner()
+	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: "checkpointed_mode"}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow})
+	if err != nil {
+		t.Fatalf("PlanForPolicyDecision error = %v", err)
+	}
+	if constraints.ExecutionMode != ExecutionModeCheckpointedAutonomy || constraints.RiskLevel != RiskHigh || constraints.MaxSteps != 5 || constraints.MaxDurationSec != 300 {
+		t.Fatalf("constraints = %#v", constraints)
+	}
+	if constraints.Reason == "" {
+		t.Fatal("Reason is empty")
+	}
+}
+
+func TestDeterministicPlannerDenyReturnsError(t *testing.T) {
+	t.Parallel()
+	planner := NewPlanner()
+	if _, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", Strategy: workplan.DefaultCoordinationStrategy}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyDeny}); err == nil {
+		t.Fatal("expected error for deny outcome")
+	}
+}
+
+func TestDeterministicPlannerAllBranchesReturnReason(t *testing.T) {
+	t.Parallel()
+	planner := NewPlanner()
+	cases := []struct {
+		coordination workplan.CoordinationDecision
+		decision     policy.PolicyDecision
+	}{
+		{coordination: workplan.CoordinationDecision{ID: "coord-1", Strategy: workplan.DefaultCoordinationStrategy}, decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow}},
+		{coordination: workplan.CoordinationDecision{ID: "coord-2", Strategy: "requires_manager_approval"}, decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyAllow}},
+		{coordination: workplan.CoordinationDecision{ID: "coord-3", Strategy: "ui_operator_mode"}, decision: policy.PolicyDecision{ID: "pol-3", Outcome: policy.PolicyAllow}},
+		{coordination: workplan.CoordinationDecision{ID: "coord-4", Strategy: "checkpointed_mode"}, decision: policy.PolicyDecision{ID: "pol-4", Outcome: policy.PolicyAllow}},
+		{coordination: workplan.CoordinationDecision{ID: "coord-5", Strategy: workplan.DefaultCoordinationStrategy}, decision: policy.PolicyDecision{ID: "pol-5", Outcome: policy.PolicyRequireApproval}},
+	}
+	for _, tc := range cases {
+		constraints, err := planner.PlanForPolicyDecision(context.Background(), tc.coordination, tc.decision)
+		if err != nil {
+			t.Fatalf("PlanForPolicyDecision(%s,%s) error = %v", tc.coordination.Strategy, tc.decision.Outcome, err)
+		}
+		if constraints.Reason == "" {
+			t.Fatalf("Reason empty for strategy=%s outcome=%s", tc.coordination.Strategy, tc.decision.Outcome)
+		}
+	}
+}

--- a/internal/executioncontrol/repository.go
+++ b/internal/executioncontrol/repository.go
@@ -1,0 +1,111 @@
+package executioncontrol
+
+import (
+	"context"
+	"sync"
+)
+
+type InMemoryConstraintsRepository struct {
+	mu                  sync.RWMutex
+	constraintsByID     map[string]ExecutionConstraints
+	order               []string
+	idsByPolicyDecision map[string][]string
+	idsByCoordination   map[string][]string
+	idsByCase           map[string][]string
+}
+
+func NewInMemoryConstraintsRepository() *InMemoryConstraintsRepository {
+	return &InMemoryConstraintsRepository{
+		constraintsByID:     make(map[string]ExecutionConstraints),
+		idsByPolicyDecision: make(map[string][]string),
+		idsByCoordination:   make(map[string][]string),
+		idsByCase:           make(map[string][]string),
+	}
+}
+
+func (r *InMemoryConstraintsRepository) Save(_ context.Context, c ExecutionConstraints) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.constraintsByID[c.ID]; ok {
+		if existing.PolicyDecisionID != c.PolicyDecisionID {
+			r.idsByPolicyDecision[existing.PolicyDecisionID] = removeID(r.idsByPolicyDecision[existing.PolicyDecisionID], c.ID)
+		}
+		if existing.CoordinationDecisionID != c.CoordinationDecisionID {
+			r.idsByCoordination[existing.CoordinationDecisionID] = removeID(r.idsByCoordination[existing.CoordinationDecisionID], c.ID)
+		}
+		if existing.CaseID != c.CaseID {
+			r.idsByCase[existing.CaseID] = removeID(r.idsByCase[existing.CaseID], c.ID)
+		}
+	} else {
+		r.order = append(r.order, c.ID)
+	}
+	if !containsID(r.idsByPolicyDecision[c.PolicyDecisionID], c.ID) {
+		r.idsByPolicyDecision[c.PolicyDecisionID] = append(r.idsByPolicyDecision[c.PolicyDecisionID], c.ID)
+	}
+	if !containsID(r.idsByCoordination[c.CoordinationDecisionID], c.ID) {
+		r.idsByCoordination[c.CoordinationDecisionID] = append(r.idsByCoordination[c.CoordinationDecisionID], c.ID)
+	}
+	if !containsID(r.idsByCase[c.CaseID], c.ID) {
+		r.idsByCase[c.CaseID] = append(r.idsByCase[c.CaseID], c.ID)
+	}
+	r.constraintsByID[c.ID] = c
+	return nil
+}
+
+func (r *InMemoryConstraintsRepository) Get(_ context.Context, id string) (ExecutionConstraints, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.constraintsByID[id]
+	if !ok {
+		return ExecutionConstraints{}, false, nil
+	}
+	return c, true, nil
+}
+
+func (r *InMemoryConstraintsRepository) ListByPolicyDecision(_ context.Context, policyDecisionID string) ([]ExecutionConstraints, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.listByIDs(r.idsByPolicyDecision[policyDecisionID]), nil
+}
+
+func (r *InMemoryConstraintsRepository) ListByCoordinationDecision(_ context.Context, coordinationDecisionID string) ([]ExecutionConstraints, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.listByIDs(r.idsByCoordination[coordinationDecisionID]), nil
+}
+
+func (r *InMemoryConstraintsRepository) ListByCase(_ context.Context, caseID string) ([]ExecutionConstraints, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.listByIDs(r.idsByCase[caseID]), nil
+}
+
+func (r *InMemoryConstraintsRepository) listByIDs(ids []string) []ExecutionConstraints {
+	out := make([]ExecutionConstraints, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, r.constraintsByID[id])
+	}
+	return out
+}
+
+func containsID(ids []string, id string) bool {
+	for _, existing := range ids {
+		if existing == id {
+			return true
+		}
+	}
+	return false
+}
+
+func removeID(ids []string, id string) []string {
+	if len(ids) == 0 {
+		return ids
+	}
+	out := ids[:0]
+	for _, existing := range ids {
+		if existing != id {
+			out = append(out, existing)
+		}
+	}
+	return out
+}

--- a/internal/executioncontrol/repository_test.go
+++ b/internal/executioncontrol/repository_test.go
@@ -1,0 +1,55 @@
+package executioncontrol
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryConstraintsRepositorySaveGetAndList(t *testing.T) {
+	t.Parallel()
+
+	repo := NewInMemoryConstraintsRepository()
+	now := time.Date(2026, 3, 22, 15, 0, 0, 0, time.UTC)
+	first := ExecutionConstraints{ID: "ec-1", PolicyDecisionID: "pol-1", CoordinationDecisionID: "coord-1", CaseID: "case-1", CreatedAt: now}
+	second := ExecutionConstraints{ID: "ec-2", PolicyDecisionID: "pol-1", CoordinationDecisionID: "coord-2", CaseID: "case-2", CreatedAt: now.Add(time.Minute)}
+	third := ExecutionConstraints{ID: "ec-3", PolicyDecisionID: "pol-2", CoordinationDecisionID: "coord-1", CaseID: "case-1", CreatedAt: now.Add(2 * time.Minute)}
+
+	for _, item := range []ExecutionConstraints{first, second, third} {
+		if err := repo.Save(context.Background(), item); err != nil {
+			t.Fatalf("Save(%s) error = %v", item.ID, err)
+		}
+	}
+
+	got, ok, err := repo.Get(context.Background(), "ec-1")
+	if err != nil || !ok {
+		t.Fatalf("Get error = %v ok=%v", err, ok)
+	}
+	if got.ID != first.ID || got.PolicyDecisionID != first.PolicyDecisionID {
+		t.Fatalf("Get = %#v", got)
+	}
+
+	byPolicy, err := repo.ListByPolicyDecision(context.Background(), "pol-1")
+	if err != nil {
+		t.Fatalf("ListByPolicyDecision error = %v", err)
+	}
+	if len(byPolicy) != 2 || byPolicy[0].ID != "ec-1" || byPolicy[1].ID != "ec-2" {
+		t.Fatalf("ListByPolicyDecision = %#v", byPolicy)
+	}
+
+	byCoordination, err := repo.ListByCoordinationDecision(context.Background(), "coord-1")
+	if err != nil {
+		t.Fatalf("ListByCoordinationDecision error = %v", err)
+	}
+	if len(byCoordination) != 2 || byCoordination[0].ID != "ec-1" || byCoordination[1].ID != "ec-3" {
+		t.Fatalf("ListByCoordinationDecision = %#v", byCoordination)
+	}
+
+	byCase, err := repo.ListByCase(context.Background(), "case-1")
+	if err != nil {
+		t.Fatalf("ListByCase error = %v", err)
+	}
+	if len(byCase) != 2 || byCase[0].ID != "ec-1" || byCase[1].ID != "ec-3" {
+		t.Fatalf("ListByCase = %#v", byCase)
+	}
+}

--- a/internal/executioncontrol/service.go
+++ b/internal/executioncontrol/service.go
@@ -1,0 +1,90 @@
+package executioncontrol
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/eventcore"
+	"kalita/internal/policy"
+	"kalita/internal/workplan"
+)
+
+type executionContextKey struct{}
+
+type ExecutionContext struct {
+	ExecutionID   string
+	CorrelationID string
+	CausationID   string
+}
+
+func ContextWithExecution(ctx context.Context, meta ExecutionContext) context.Context {
+	return context.WithValue(ctx, executionContextKey{}, meta)
+}
+
+func executionFromContext(ctx context.Context) ExecutionContext {
+	meta, _ := ctx.Value(executionContextKey{}).(ExecutionContext)
+	return meta
+}
+
+type Service struct {
+	repo    ConstraintsRepository
+	planner ConstraintsPlanner
+	log     eventcore.EventLog
+	clock   eventcore.Clock
+	ids     eventcore.IDGenerator
+}
+
+func NewService(repo ConstraintsRepository, planner ConstraintsPlanner, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *Service {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &Service{repo: repo, planner: planner, log: log, clock: clock, ids: ids}
+}
+
+func (s *Service) CreateAndRecord(ctx context.Context, coordination workplan.CoordinationDecision, policyDecision policy.PolicyDecision) (ExecutionConstraints, error) {
+	if s.repo == nil {
+		return ExecutionConstraints{}, fmt.Errorf("constraints repository is nil")
+	}
+	if s.planner == nil {
+		return ExecutionConstraints{}, fmt.Errorf("constraints planner is nil")
+	}
+	planned, err := s.planner.PlanForPolicyDecision(ctx, coordination, policyDecision)
+	if err != nil {
+		return ExecutionConstraints{}, err
+	}
+	now := s.clock.Now()
+	planned.ID = s.ids.NewID()
+	planned.CreatedAt = now
+	if err := s.repo.Save(ctx, planned); err != nil {
+		return ExecutionConstraints{}, err
+	}
+	if s.log != nil {
+		meta := executionFromContext(ctx)
+		if err := s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{
+			ID:            s.ids.NewID(),
+			ExecutionID:   meta.ExecutionID,
+			CaseID:        coordination.CaseID,
+			Step:          "execution_constraints_created",
+			Status:        "ready",
+			OccurredAt:    now,
+			CorrelationID: meta.CorrelationID,
+			CausationID:   meta.CausationID,
+			Payload: map[string]any{
+				"coordination_decision_id": coordination.ID,
+				"policy_decision_id":       policyDecision.ID,
+				"case_id":                  coordination.CaseID,
+				"work_item_id":             coordination.WorkItemID,
+				"queue_id":                 coordination.QueueID,
+				"execution_constraints_id": planned.ID,
+				"risk_level":               planned.RiskLevel,
+				"execution_mode":           planned.ExecutionMode,
+			},
+		}); err != nil {
+			return ExecutionConstraints{}, err
+		}
+	}
+	return planned, nil
+}

--- a/internal/executioncontrol/service_test.go
+++ b/internal/executioncontrol/service_test.go
@@ -1,0 +1,78 @@
+package executioncontrol
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/eventcore"
+	"kalita/internal/policy"
+	"kalita/internal/workplan"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDs struct {
+	ids []string
+	i   int
+}
+
+func (f *fakeIDs) NewID() string {
+	id := f.ids[f.i]
+	f.i++
+	return id
+}
+
+func TestServiceCreateAndRecordCreatesConstraintsAndEvent(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryConstraintsRepository()
+	log := eventcore.NewInMemoryEventLog()
+	service := NewService(repo, NewPlanner(), log, fakeClock{now: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}, &fakeIDs{ids: []string{"constraints-1", "event-1"}})
+	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cause-1"})
+	coordination := workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: workplan.DefaultCoordinationStrategy}
+	decision := policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow}
+
+	constraints, err := service.CreateAndRecord(ctx, coordination, decision)
+	if err != nil {
+		t.Fatalf("CreateAndRecord error = %v", err)
+	}
+	if constraints.ID != "constraints-1" || constraints.CreatedAt.IsZero() {
+		t.Fatalf("constraints = %#v", constraints)
+	}
+	stored, ok, err := repo.Get(context.Background(), "constraints-1")
+	if err != nil || !ok {
+		t.Fatalf("repo.Get error = %v ok=%v", err, ok)
+	}
+	if stored.ExecutionMode != ExecutionModeDeterministicAPI {
+		t.Fatalf("stored = %#v", stored)
+	}
+	_, executionEvents, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(executionEvents) != 1 {
+		t.Fatalf("executionEvents len = %d", len(executionEvents))
+	}
+	if executionEvents[0].Step != "execution_constraints_created" || executionEvents[0].Status != "ready" {
+		t.Fatalf("executionEvents[0] = %#v", executionEvents[0])
+	}
+}
+
+func TestServiceDeniedPolicyDoesNotCreateConstraints(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryConstraintsRepository()
+	service := NewService(repo, NewPlanner(), nil, fakeClock{now: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}, &fakeIDs{ids: []string{"constraints-1"}})
+	_, err := service.CreateAndRecord(context.Background(), workplan.CoordinationDecision{ID: "coord-1", Strategy: workplan.DefaultCoordinationStrategy}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyDeny})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	items, err := repo.ListByPolicyDecision(context.Background(), "pol-1")
+	if err != nil {
+		t.Fatalf("ListByPolicyDecision error = %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("items = %#v", items)
+	}
+}

--- a/internal/executioncontrol/types.go
+++ b/internal/executioncontrol/types.go
@@ -1,0 +1,66 @@
+package executioncontrol
+
+import (
+	"context"
+	"time"
+
+	"kalita/internal/policy"
+	"kalita/internal/workplan"
+)
+
+type RiskLevel string
+
+const (
+	RiskLow      RiskLevel = "low"
+	RiskMedium   RiskLevel = "medium"
+	RiskHigh     RiskLevel = "high"
+	RiskCritical RiskLevel = "critical"
+)
+
+type ExecutionMode string
+
+const (
+	ExecutionModeDeterministicAPI     ExecutionMode = "deterministic_api"
+	ExecutionModeGuidedUIOperator     ExecutionMode = "guided_ui_operator"
+	ExecutionModeCheckpointedAutonomy ExecutionMode = "checkpointed_autonomy"
+	ExecutionModeApprovalEachStep     ExecutionMode = "approval_each_step"
+)
+
+type ExecutionConstraints struct {
+	ID                     string
+	CoordinationDecisionID string
+	PolicyDecisionID       string
+	CaseID                 string
+	WorkItemID             string
+	QueueID                string
+
+	RiskLevel     RiskLevel
+	ExecutionMode ExecutionMode
+
+	MaxTokens      int
+	MaxCost        float64
+	MaxSteps       int
+	MaxDurationSec int
+
+	AllowedScopes []string
+	ForbiddenOps  []string
+
+	CreatedAt time.Time
+	Reason    string
+}
+
+type ConstraintsRepository interface {
+	Save(ctx context.Context, c ExecutionConstraints) error
+	Get(ctx context.Context, id string) (ExecutionConstraints, bool, error)
+	ListByPolicyDecision(ctx context.Context, policyDecisionID string) ([]ExecutionConstraints, error)
+	ListByCoordinationDecision(ctx context.Context, coordinationDecisionID string) ([]ExecutionConstraints, error)
+	ListByCase(ctx context.Context, caseID string) ([]ExecutionConstraints, error)
+}
+
+type ConstraintsPlanner interface {
+	PlanForPolicyDecision(ctx context.Context, coordination workplan.CoordinationDecision, policyDecision policy.PolicyDecision) (ExecutionConstraints, error)
+}
+
+type ConstraintsService interface {
+	CreateAndRecord(ctx context.Context, coordination workplan.CoordinationDecision, policyDecision policy.PolicyDecision) (ExecutionConstraints, error)
+}

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -11,6 +11,7 @@ import (
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
 	"kalita/internal/eventcore"
+	"kalita/internal/executioncontrol"
 	"kalita/internal/policy"
 	"kalita/internal/runtime"
 	"kalita/internal/validation"
@@ -25,11 +26,11 @@ type actionRequest struct {
 }
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, nil, nil, nil, nil)
+	return ActionHandlerWithServices(storage, nil, nil, nil, nil, nil)
 }
 
 func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.CommandBus) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil)
+	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil, nil)
 }
 
 type commandCaseResolver interface {
@@ -44,7 +45,11 @@ type policyService interface {
 	EvaluateAndRecord(ctx context.Context, d workplan.CoordinationDecision) (policy.PolicyDecision, *policy.ApprovalRequest, error)
 }
 
-func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService) gin.HandlerFunc {
+type constraintsService interface {
+	CreateAndRecord(ctx context.Context, coordination workplan.CoordinationDecision, policyDecision policy.PolicyDecision) (executioncontrol.ExecutionConstraints, error)
+}
+
+func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		fqn, action, req, ok := parseActionRequest(c, storage)
 		if !ok {
@@ -96,6 +101,21 @@ func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.Comm
 								Message: err.Error(),
 							}}})
 							return
+						}
+						if constraintsService != nil && policyDecision.Outcome != policy.PolicyDeny {
+							constraintsCtx := executioncontrol.ContextWithExecution(c.Request.Context(), executioncontrol.ExecutionContext{
+								ExecutionID:   intakeResult.Command.ExecutionID,
+								CorrelationID: intakeResult.Command.CorrelationID,
+								CausationID:   intakeResult.Command.ID,
+							})
+							if _, err := constraintsService.CreateAndRecord(constraintsCtx, intakeResult.CoordinationDecision, policyDecision); err != nil {
+								c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+									Code:    validation.ErrTypeMismatch,
+									Field:   "action",
+									Message: err.Error(),
+								}}})
+								return
+							}
 						}
 						if policyDecision.Outcome != policy.PolicyAllow {
 							message := policyDecision.Reason

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -13,6 +13,7 @@ import (
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
 	"kalita/internal/eventcore"
+	"kalita/internal/executioncontrol"
 	"kalita/internal/policy"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
@@ -271,6 +272,17 @@ func (s staticPolicyService) EvaluateAndRecord(context.Context, workplan.Coordin
 	return s.decision, s.approval, s.err
 }
 
+type staticConstraintsService struct {
+	constraints executioncontrol.ExecutionConstraints
+	err         error
+	calls       int
+}
+
+func (s *staticConstraintsService) CreateAndRecord(context.Context, workplan.CoordinationDecision, policy.PolicyDecision) (executioncontrol.ExecutionConstraints, error) {
+	s.calls++
+	return s.constraints, s.err
+}
+
 func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -293,7 +305,7 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, coordinator, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -376,7 +388,7 @@ func TestActionHandlerReturnsValidationErrorWhenCaseResolutionFails(t *testing.T
 
 	storage, rec := testHTTPWorkflowStorage()
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -405,7 +417,7 @@ func TestActionHandlerReturnsValidationErrorWhenWorkItemIntakeFails(t *testing.T
 	caseRepo := caseruntime.NewInMemoryCaseRepository()
 	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -441,7 +453,7 @@ func TestActionHandlerReturnsValidationErrorWhenCoordinationFails(t *testing.T) 
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, failingCoordinator{err: errors.New("coordination failed")}, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -478,7 +490,7 @@ func TestActionHandlerPolicyAllowContinuesLegacyFlow(t *testing.T) {
 	router := gin.New()
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
 		decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"},
-	}))
+	}, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -514,7 +526,7 @@ func TestActionHandlerPolicyRequireApprovalStopsBeforeLegacyFlow(t *testing.T) {
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
 		decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"},
 		approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending},
-	}))
+	}, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -536,14 +548,21 @@ func TestActionHandlerPolicyDenyStopsBeforeLegacyFlow(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(
-		storage,
-		staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}},
-		nil,
-		nil,
-		staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}},
-	))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -691,7 +710,157 @@ func TestActionHandlerReturnsValidationErrorWhenDailyPlanAttachmentFails(t *test
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), failingPlanner{err: errors.New("daily plan failed")}, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
+}
+
+func TestActionHandlerPolicyAllowCreatesConstraintsBeforeLegacyFlow(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
+
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if constraintsSvc.calls != 1 {
+		t.Fatalf("constraints calls = %d", constraintsSvc.calls)
+	}
+}
+
+func TestActionHandlerPolicyRequireApprovalRecordsConstraintsAndStopsBeforeLegacyFlow(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
+
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"}, approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending}}, constraintsSvc))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if constraintsSvc.calls != 1 {
+		t.Fatalf("constraints calls = %d", constraintsSvc.calls)
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
+}
+
+func TestActionHandlerPolicyDenyDoesNotCreateConstraintsAndStopsBeforeLegacyFlow(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, constraintsSvc))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if constraintsSvc.calls != 0 {
+		t.Fatalf("constraints calls = %d", constraintsSvc.calls)
+	}
+}
+
+func TestActionHandlerConstraintCreationFailureReturnsValidationError(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	constraintsSvc := &staticConstraintsService{err: errors.New("constraints failed")}
+
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -12,14 +12,14 @@ import (
 )
 
 func RunServer(addr string, storage *runtime.Storage) {
-	RunServerWithServices(addr, storage, nil, nil, nil)
+	RunServerWithServices(addr, storage, nil, nil, nil, nil, nil)
 }
 
 func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus command.CommandBus) {
-	RunServerWithServices(addr, storage, commandBus, nil, nil)
+	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil)
 }
 
-func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService) {
+func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -39,7 +39,7 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
-		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
 		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))


### PR DESCRIPTION
### Motivation
- Establish an explicit, transport-free layer that records deterministic execution boundaries (risk, mode, budget, scope) after coordination and policy decisions. 
- Provide a stable artifact for future execution engines (digital employees / UI operators) without replacing legacy runtime or introducing LLM/employee execution yet.

### Description
- Added a new `internal/executioncontrol` package with types `ExecutionConstraints`, `RiskLevel`, and `ExecutionMode`, plus interfaces `ConstraintsRepository`, `ConstraintsPlanner`, and `ConstraintsService` and their in-memory/deterministic implementations (`types.go`, `repository.go`, `planner.go`, `service.go`).
- Implemented a thread-safe in-memory repository that supports `Save`, `Get`, `ListByPolicyDecision`, `ListByCoordinationDecision`, and `ListByCase` while preserving insertion order in indexed lists. 
- Implemented a deterministic `DeterministicPlanner` that rejects `deny`, produces baseline defaults for `allow`, and produces restrictive/high-risk branches for `require_approval`, `requires_manager_approval`, `ui_operator_mode`, and `checkpointed_mode`, always returning a non-empty `Reason`.
- Implemented `Service.CreateAndRecord` that uses the planner, saves the constraints record, and appends an `execution_constraints_created` execution event with the required payload fields.
- Wired components into bootstrap so `ConstraintsRepository`, `ConstraintsPlanner`, and `ConstraintsService` are constructed and returned from `Bootstrap` without changing existing wiring.
- Extended the workflow-action compatibility seam (`internal/http/actions.go` / `router.go`) so that after policy evaluation non-deny outcomes attempt to create constraints (errors surface as validation-style errors), `require_approval` still stops before legacy execution, `deny` still stops, and `allow` records constraints then continues to the existing `runtime.ExecuteWorkflowAction` unchanged.
- Added tests covering repository, planner, service behavior, and HTTP compatibility-seam scenarios; and updated bootstrap test to assert exposure of new components.

### Testing
- Ran `go test ./internal/executioncontrol` and all package tests passed (repository/planner/service tests succeeded).
- Ran `go test ./internal/http` and focused compatibility-seam tests passed (scenarios for allow/require_approval/deny and constraint-creation failure succeeded).
- Ran `go test ./internal/app` and the bootstrap exposure test passed, confirming new components are constructed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05cabd0b08324a92513b82d368589)