### PR TITLE
Introduce transport-free ActionPlan boundary and compatibility seam

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService)
+	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.PolicyService, result.ConstraintsService, result.ActionPlanService)
 }

--- a/internal/actionplan/compiler.go
+++ b/internal/actionplan/compiler.go
@@ -1,0 +1,175 @@
+package actionplan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"kalita/internal/eventcore"
+)
+
+type compilerExecutionContextKey struct{}
+
+type ExecutionContext struct {
+	ExecutionID   string
+	CorrelationID string
+	CausationID   string
+}
+
+func ContextWithExecution(ctx context.Context, meta ExecutionContext) context.Context {
+	return context.WithValue(ctx, compilerExecutionContextKey{}, meta)
+}
+
+func executionFromContext(ctx context.Context) ExecutionContext {
+	meta, _ := ctx.Value(compilerExecutionContextKey{}).(ExecutionContext)
+	return meta
+}
+
+type DefaultCompiler struct {
+	registry Registry
+	clock    eventcore.Clock
+	ids      eventcore.IDGenerator
+}
+
+func NewCompiler(registry Registry, clock eventcore.Clock, ids eventcore.IDGenerator) *DefaultCompiler {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &DefaultCompiler{registry: registry, clock: clock, ids: ids}
+}
+
+func (c *DefaultCompiler) Compile(_ context.Context, input map[string]any) (ActionPlan, error) {
+	if c.registry == nil {
+		return ActionPlan{}, fmt.Errorf("action registry is nil")
+	}
+	reason := strings.TrimSpace(stringValue(input["reason"]))
+	rawActions, ok := input["actions"]
+	if !ok {
+		return ActionPlan{}, fmt.Errorf("actions is required")
+	}
+	items, err := actionItems(rawActions)
+	if err != nil {
+		return ActionPlan{}, err
+	}
+	createdAt := c.clock.Now()
+	plan := ActionPlan{
+		ID:        c.ids.NewID(),
+		CreatedAt: createdAt,
+		Reason:    reason,
+		Actions:   make([]Action, 0, len(items)),
+	}
+	for idx, item := range items {
+		actionType := ActionType(strings.TrimSpace(stringValue(item["type"])))
+		if actionType == "" {
+			return ActionPlan{}, fmt.Errorf("actions[%d].type is required", idx)
+		}
+		def, ok := c.registry.Get(actionType)
+		if !ok {
+			return ActionPlan{}, fmt.Errorf("unknown action type %q", actionType)
+		}
+		params, err := paramsValue(item["params"])
+		if err != nil {
+			return ActionPlan{}, fmt.Errorf("actions[%d].params: %w", idx, err)
+		}
+		if def.Validate != nil {
+			if err := def.Validate(params); err != nil {
+				return ActionPlan{}, fmt.Errorf("actions[%d] validation failed: %w", idx, err)
+			}
+		}
+		action := Action{
+			ID:            c.ids.NewID(),
+			Type:          def.Type,
+			Params:        cloneMap(params),
+			Reversibility: def.Reversibility,
+			Idempotency:   def.Idempotency,
+			CreatedAt:     createdAt,
+		}
+		if def.Reversibility != ReversibilityIrreversible {
+			if def.CompensationBuilder == nil {
+				return ActionPlan{}, fmt.Errorf("action type %q requires compensation", def.Type)
+			}
+			compensationParams, err := def.CompensationBuilder(params)
+			if err != nil {
+				return ActionPlan{}, fmt.Errorf("actions[%d] compensation failed: %w", idx, err)
+			}
+			action.Compensation = &Action{
+				ID:            c.ids.NewID(),
+				Type:          def.Type,
+				Params:        cloneMap(compensationParams),
+				Reversibility: ReversibilityIrreversible,
+				Idempotency:   def.Idempotency,
+				CreatedAt:     createdAt,
+			}
+		}
+		plan.Actions = append(plan.Actions, action)
+	}
+	return plan, nil
+}
+
+func actionItems(raw any) ([]map[string]any, error) {
+	switch v := raw.(type) {
+	case []map[string]any:
+		return v, nil
+	case []any:
+		out := make([]map[string]any, 0, len(v))
+		for i, item := range v {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("actions[%d] must be an object", i)
+			}
+			out = append(out, m)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("actions must be an array")
+	}
+}
+
+func paramsValue(raw any) (map[string]any, error) {
+	if raw == nil {
+		return map[string]any{}, nil
+	}
+	params, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("must be an object")
+	}
+	return cloneMap(params), nil
+}
+
+func stringValue(raw any) string {
+	s, _ := raw.(string)
+	return s
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if in == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = cloneValue(v)
+	}
+	return out
+}
+
+func cloneSlice(in []any) []any {
+	out := make([]any, len(in))
+	for i, v := range in {
+		out[i] = cloneValue(v)
+	}
+	return out
+}
+
+func cloneValue(v any) any {
+	switch typed := v.(type) {
+	case map[string]any:
+		return cloneMap(typed)
+	case []any:
+		return cloneSlice(typed)
+	default:
+		return typed
+	}
+}

--- a/internal/actionplan/compiler_test.go
+++ b/internal/actionplan/compiler_test.go
@@ -1,0 +1,94 @@
+package actionplan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDGenerator struct {
+	ids []string
+	idx int
+}
+
+func (f *fakeIDGenerator) NewID() string { id := f.ids[f.idx]; f.idx++; return id }
+
+func testRegistry() Registry {
+	registry := NewRegistry()
+	registry.Register(ActionDefinition{
+		Type:          "send_notification",
+		Reversibility: ReversibilityCompensatable,
+		Idempotency:   IdempotencySafe,
+		Validate: func(params map[string]any) error {
+			if strings.TrimSpace(stringValue(params["message"])) == "" {
+				return fmt.Errorf("message is required")
+			}
+			return nil
+		},
+		CompensationBuilder: func(params map[string]any) (map[string]any, error) {
+			return map[string]any{"message": params["message"]}, nil
+		},
+	})
+	registry.Register(ActionDefinition{
+		Type:          "write_audit_log",
+		Reversibility: ReversibilityIrreversible,
+		Idempotency:   IdempotencySafe,
+		Validate: func(params map[string]any) error {
+			if strings.TrimSpace(stringValue(params["entry"])) == "" {
+				return fmt.Errorf("entry is required")
+			}
+			return nil
+		},
+	})
+	return registry
+}
+
+func TestCompilerCompileValidPlan(t *testing.T) {
+	clock := fakeClock{now: time.Date(2026, 3, 22, 12, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"plan-1", "act-1", "comp-1", "act-2"}}
+	compiler := NewCompiler(testRegistry(), clock, ids)
+
+	plan, err := compiler.Compile(context.Background(), map[string]any{
+		"reason": "policy-approved outreach",
+		"actions": []any{
+			map[string]any{"type": "send_notification", "params": map[string]any{"message": "hello"}},
+			map[string]any{"type": "write_audit_log", "params": map[string]any{"entry": "logged"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Compile error = %v", err)
+	}
+	if plan.ID != "plan-1" || len(plan.Actions) != 2 {
+		t.Fatalf("plan = %#v", plan)
+	}
+	if plan.Actions[0].Compensation == nil || plan.Actions[0].Compensation.ID != "comp-1" {
+		t.Fatalf("first compensation = %#v", plan.Actions[0].Compensation)
+	}
+	if plan.Actions[1].Compensation != nil {
+		t.Fatalf("second compensation = %#v, want nil", plan.Actions[1].Compensation)
+	}
+}
+
+func TestCompilerFailsForUnknownActionType(t *testing.T) {
+	compiler := NewCompiler(testRegistry(), fakeClock{now: time.Now()}, &fakeIDGenerator{ids: []string{"plan-1"}})
+	_, err := compiler.Compile(context.Background(), map[string]any{"reason": "x", "actions": []any{map[string]any{"type": "unknown"}}})
+	if err == nil || !strings.Contains(err.Error(), "unknown action type") {
+		t.Fatalf("Compile error = %v, want unknown action type", err)
+	}
+}
+
+func TestCompilerFailsWhenCompensationMissingForReversibleAction(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(ActionDefinition{Type: "reversible", Reversibility: ReversibilityCompensatable, Idempotency: IdempotencySafe, Validate: func(map[string]any) error { return nil }})
+	compiler := NewCompiler(registry, fakeClock{now: time.Now()}, &fakeIDGenerator{ids: []string{"plan-1", "act-1"}})
+	_, err := compiler.Compile(context.Background(), map[string]any{"reason": "x", "actions": []any{map[string]any{"type": "reversible"}}})
+	if err == nil || !strings.Contains(err.Error(), "requires compensation") {
+		t.Fatalf("Compile error = %v, want compensation failure", err)
+	}
+}

--- a/internal/actionplan/registry.go
+++ b/internal/actionplan/registry.go
@@ -1,0 +1,28 @@
+package actionplan
+
+import "sync"
+
+type InMemoryRegistry struct {
+	mu   sync.RWMutex
+	defs map[ActionType]ActionDefinition
+}
+
+func NewRegistry() *InMemoryRegistry {
+	return &InMemoryRegistry{defs: make(map[ActionType]ActionDefinition)}
+}
+
+func (r *InMemoryRegistry) Register(def ActionDefinition) {
+	if def.Type == "" {
+		panic("actionplan: action definition type is required")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.defs[def.Type] = def
+}
+
+func (r *InMemoryRegistry) Get(actionType ActionType) (ActionDefinition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	def, ok := r.defs[actionType]
+	return def, ok
+}

--- a/internal/actionplan/registry_test.go
+++ b/internal/actionplan/registry_test.go
@@ -1,0 +1,21 @@
+package actionplan
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(ActionDefinition{Type: "send_notification", Validate: func(params map[string]any) error {
+		if params["message"] == "" {
+			return fmt.Errorf("message is required")
+		}
+		return nil
+	}})
+
+	got, ok := registry.Get("send_notification")
+	if !ok || got.Type != "send_notification" {
+		t.Fatalf("Get(send_notification) = %#v ok=%v", got, ok)
+	}
+}

--- a/internal/actionplan/service.go
+++ b/internal/actionplan/service.go
@@ -1,0 +1,68 @@
+package actionplan
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/eventcore"
+)
+
+type actionPlanService struct {
+	compiler  Compiler
+	validator Validator
+	log       eventcore.EventLog
+	clock     eventcore.Clock
+	ids       eventcore.IDGenerator
+}
+
+func NewService(compiler Compiler, validator Validator, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) Service {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &actionPlanService{compiler: compiler, validator: validator, log: log, clock: clock, ids: ids}
+}
+
+func (s *actionPlanService) CreatePlan(ctx context.Context, workItemID string, caseID string, input map[string]any) (ActionPlan, error) {
+	if s.compiler == nil {
+		return ActionPlan{}, fmt.Errorf("action plan compiler is nil")
+	}
+	if s.validator == nil {
+		return ActionPlan{}, fmt.Errorf("action plan validator is nil")
+	}
+	plan, err := s.compiler.Compile(ctx, input)
+	if err != nil {
+		return ActionPlan{}, err
+	}
+	plan.WorkItemID = workItemID
+	plan.CaseID = caseID
+	if err := s.validator.Validate(plan); err != nil {
+		return ActionPlan{}, err
+	}
+	if s.log != nil {
+		meta := executionFromContext(ctx)
+		now := s.clock.Now()
+		if err := s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{
+			ID:            s.ids.NewID(),
+			ExecutionID:   meta.ExecutionID,
+			CaseID:        caseID,
+			Step:          "action_plan_created",
+			Status:        "ready",
+			OccurredAt:    now,
+			CorrelationID: meta.CorrelationID,
+			CausationID:   meta.CausationID,
+			Payload: map[string]any{
+				"action_plan_id": plan.ID,
+				"case_id":        caseID,
+				"work_item_id":   workItemID,
+				"reason":         plan.Reason,
+				"action_count":   len(plan.Actions),
+			},
+		}); err != nil {
+			return ActionPlan{}, err
+		}
+	}
+	return plan, nil
+}

--- a/internal/actionplan/service_test.go
+++ b/internal/actionplan/service_test.go
@@ -1,0 +1,36 @@
+package actionplan
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/eventcore"
+)
+
+func TestServiceCreatePlanEmitsExecutionEvent(t *testing.T) {
+	log := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 13, 0, 0, 0, time.UTC)}
+	compiler := NewCompiler(testRegistry(), clock, &fakeIDGenerator{ids: []string{"plan-1", "act-1", "comp-1"}})
+	validator := NewValidator(testRegistry())
+	service := NewService(compiler, validator, log, clock, &fakeIDGenerator{ids: []string{"event-1"}})
+
+	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
+	plan, err := service.CreatePlan(ctx, "wi-1", "case-1", map[string]any{
+		"reason":  "safe outreach",
+		"actions": []any{map[string]any{"type": "send_notification", "params": map[string]any{"message": "hello"}}},
+	})
+	if err != nil {
+		t.Fatalf("CreatePlan error = %v", err)
+	}
+	if plan.WorkItemID != "wi-1" || plan.CaseID != "case-1" {
+		t.Fatalf("plan = %#v", plan)
+	}
+	_, events, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(events) != 1 || events[0].Step != "action_plan_created" {
+		t.Fatalf("execution events = %#v", events)
+	}
+}

--- a/internal/actionplan/types.go
+++ b/internal/actionplan/types.go
@@ -1,0 +1,72 @@
+package actionplan
+
+import (
+	"context"
+	"time"
+)
+
+type ActionType string
+
+const (
+	ReversibilityFullyReversible = "fully_reversible"
+	ReversibilityCompensatable   = "compensatable"
+	ReversibilityIrreversible    = "irreversible"
+
+	IdempotencySafe        = "safe"
+	IdempotencyConditional = "conditional"
+	IdempotencyUnsafe      = "unsafe"
+)
+
+type Action struct {
+	ID string
+
+	Type   ActionType
+	Params map[string]any
+
+	Reversibility string
+	Compensation  *Action
+
+	Idempotency string
+
+	CreatedAt time.Time
+}
+
+type ActionPlan struct {
+	ID string
+
+	WorkItemID string
+	CaseID     string
+
+	Actions []Action
+
+	CreatedAt time.Time
+	Reason    string
+}
+
+type ActionDefinition struct {
+	Type ActionType
+
+	Validate func(params map[string]any) error
+
+	Reversibility string
+	Idempotency   string
+
+	CompensationBuilder func(params map[string]any) (map[string]any, error)
+}
+
+type Registry interface {
+	Register(def ActionDefinition)
+	Get(actionType ActionType) (ActionDefinition, bool)
+}
+
+type Compiler interface {
+	Compile(ctx context.Context, input map[string]any) (ActionPlan, error)
+}
+
+type Validator interface {
+	Validate(plan ActionPlan) error
+}
+
+type Service interface {
+	CreatePlan(ctx context.Context, workItemID string, caseID string, input map[string]any) (ActionPlan, error)
+}

--- a/internal/actionplan/validator.go
+++ b/internal/actionplan/validator.go
@@ -1,0 +1,72 @@
+package actionplan
+
+import (
+	"fmt"
+	"strings"
+)
+
+type DefaultValidator struct {
+	registry       Registry
+	forbiddenTypes map[ActionType]struct{}
+}
+
+func NewValidator(registry Registry, forbiddenTypes ...ActionType) *DefaultValidator {
+	forbidden := make(map[ActionType]struct{}, len(forbiddenTypes))
+	for _, actionType := range forbiddenTypes {
+		forbidden[actionType] = struct{}{}
+	}
+	return &DefaultValidator{registry: registry, forbiddenTypes: forbidden}
+}
+
+func (v *DefaultValidator) Validate(plan ActionPlan) error {
+	if strings.TrimSpace(plan.Reason) == "" {
+		return fmt.Errorf("reason is required")
+	}
+	if len(plan.Actions) == 0 {
+		return fmt.Errorf("action plan must contain at least one action")
+	}
+	for i, action := range plan.Actions {
+		if _, forbidden := v.forbiddenTypes[action.Type]; forbidden {
+			return fmt.Errorf("actions[%d] uses forbidden action type %q", i, action.Type)
+		}
+		def, ok := v.registry.Get(action.Type)
+		if !ok {
+			return fmt.Errorf("actions[%d] has unknown action type %q", i, action.Type)
+		}
+		if def.Validate != nil {
+			if err := def.Validate(action.Params); err != nil {
+				return fmt.Errorf("actions[%d] validation failed: %w", i, err)
+			}
+		}
+		if action.Reversibility == "" {
+			return fmt.Errorf("actions[%d] reversibility is required", i)
+		}
+		if action.Idempotency == "" {
+			return fmt.Errorf("actions[%d] idempotency is required", i)
+		}
+		if def.Reversibility != action.Reversibility {
+			return fmt.Errorf("actions[%d] reversibility mismatch for %q", i, action.Type)
+		}
+		if def.Idempotency != action.Idempotency {
+			return fmt.Errorf("actions[%d] idempotency mismatch for %q", i, action.Type)
+		}
+		if def.Reversibility == ReversibilityIrreversible {
+			if action.Compensation != nil {
+				return fmt.Errorf("actions[%d] compensation must be nil for irreversible action %q", i, action.Type)
+			}
+			continue
+		}
+		if action.Compensation == nil {
+			return fmt.Errorf("actions[%d] compensation is required for %q", i, action.Type)
+		}
+		if action.Compensation.Type != action.Type {
+			return fmt.Errorf("actions[%d] compensation type mismatch for %q", i, action.Type)
+		}
+		if def.Validate != nil {
+			if err := def.Validate(action.Compensation.Params); err != nil {
+				return fmt.Errorf("actions[%d] compensation validation failed: %w", i, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/actionplan/validator_test.go
+++ b/internal/actionplan/validator_test.go
@@ -1,0 +1,31 @@
+package actionplan
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidatorRejectsEmptyPlan(t *testing.T) {
+	validator := NewValidator(testRegistry())
+	err := validator.Validate(ActionPlan{Reason: "reason"})
+	if err == nil || !strings.Contains(err.Error(), "at least one action") {
+		t.Fatalf("Validate error = %v", err)
+	}
+}
+
+func TestValidatorRejectsMissingReason(t *testing.T) {
+	validator := NewValidator(testRegistry())
+	err := validator.Validate(ActionPlan{Actions: []Action{{Type: "write_audit_log", Params: map[string]any{"entry": "x"}, Reversibility: ReversibilityIrreversible, Idempotency: IdempotencySafe, CreatedAt: time.Now()}}})
+	if err == nil || !strings.Contains(err.Error(), "reason is required") {
+		t.Fatalf("Validate error = %v", err)
+	}
+}
+
+func TestValidatorRejectsMissingCompensation(t *testing.T) {
+	validator := NewValidator(testRegistry())
+	err := validator.Validate(ActionPlan{Reason: "reason", Actions: []Action{{Type: "send_notification", Params: map[string]any{"message": "x"}, Reversibility: ReversibilityCompensatable, Idempotency: IdempotencySafe, CreatedAt: time.Now()}}})
+	if err == nil || !strings.Contains(err.Error(), "compensation is required") {
+		t.Fatalf("Validate error = %v", err)
+	}
+}

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"kalita/internal/actionplan"
 	"kalita/internal/blob"
 	"kalita/internal/caseruntime"
 	"kalita/internal/catalog"
@@ -41,6 +42,10 @@ type BootstrapResult struct {
 	ConstraintsRepo    executioncontrol.ConstraintsRepository
 	ConstraintsPlanner executioncontrol.ConstraintsPlanner
 	ConstraintsService executioncontrol.ConstraintsService
+	ActionRegistry     actionplan.Registry
+	ActionCompiler     actionplan.Compiler
+	ActionValidator    actionplan.Validator
+	ActionPlanService  actionplan.Service
 	Config             config.Config
 }
 
@@ -122,6 +127,27 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	constraintsRepo := executioncontrol.NewInMemoryConstraintsRepository()
 	constraintsPlanner := executioncontrol.NewPlanner()
 	constraintsService := executioncontrol.NewService(constraintsRepo, constraintsPlanner, eventLog, clock, ids)
+	actionRegistry := actionplan.NewRegistry()
+	actionRegistry.Register(actionplan.ActionDefinition{
+		Type:          "legacy_workflow_action",
+		Reversibility: actionplan.ReversibilityIrreversible,
+		Idempotency:   actionplan.IdempotencyConditional,
+		Validate: func(params map[string]any) error {
+			if strings.TrimSpace(stringValue(params["entity"])) == "" {
+				return fmt.Errorf("entity is required")
+			}
+			if strings.TrimSpace(stringValue(params["record_id"])) == "" {
+				return fmt.Errorf("record_id is required")
+			}
+			if strings.TrimSpace(stringValue(params["action"])) == "" {
+				return fmt.Errorf("action is required")
+			}
+			return nil
+		},
+	})
+	actionCompiler := actionplan.NewCompiler(actionRegistry, clock, ids)
+	actionValidator := actionplan.NewValidator(actionRegistry)
+	actionPlanService := actionplan.NewService(actionCompiler, actionValidator, eventLog, clock, ids)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
@@ -147,6 +173,10 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		ConstraintsRepo:    constraintsRepo,
 		ConstraintsPlanner: constraintsPlanner,
 		ConstraintsService: constraintsService,
+		ActionRegistry:     actionRegistry,
+		ActionCompiler:     actionCompiler,
+		ActionValidator:    actionValidator,
+		ActionPlanService:  actionPlanService,
 		Config:             cfg,
 	}, nil
 }
@@ -156,4 +186,9 @@ func tern[T any](cond bool, a, b T) T {
 		return a
 	}
 	return b
+}
+
+func stringValue(v any) string {
+	s, _ := v.(string)
+	return s
 }

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 
+	"kalita/internal/actionplan"
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
 	"kalita/internal/eventcore"
@@ -26,11 +27,11 @@ type actionRequest struct {
 }
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, nil, nil, nil, nil, nil)
+	return ActionHandlerWithServices(storage, nil, nil, nil, nil, nil, nil)
 }
 
 func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.CommandBus) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil, nil)
+	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil, nil, nil)
 }
 
 type commandCaseResolver interface {
@@ -39,6 +40,7 @@ type commandCaseResolver interface {
 
 type workItemIntakeService interface {
 	IntakeCommand(ctx context.Context, resolved caseruntime.ResolutionResult) (workplan.IntakeResult, error)
+	AttachActionPlan(ctx context.Context, workItemID string, plan actionplan.ActionPlan) (workplan.WorkItem, error)
 }
 
 type policyService interface {
@@ -49,7 +51,11 @@ type constraintsService interface {
 	CreateAndRecord(ctx context.Context, coordination workplan.CoordinationDecision, policyDecision policy.PolicyDecision) (executioncontrol.ExecutionConstraints, error)
 }
 
-func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService) gin.HandlerFunc {
+type actionPlanService interface {
+	CreatePlan(ctx context.Context, workItemID string, caseID string, input map[string]any) (actionplan.ActionPlan, error)
+}
+
+func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		fqn, action, req, ok := parseActionRequest(c, storage)
 		if !ok {
@@ -128,6 +134,30 @@ func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.Comm
 								Message: message,
 							}}})
 							return
+						}
+						if actionPlanService != nil {
+							planCtx := actionplan.ContextWithExecution(c.Request.Context(), actionplan.ExecutionContext{
+								ExecutionID:   intakeResult.Command.ExecutionID,
+								CorrelationID: intakeResult.Command.CorrelationID,
+								CausationID:   intakeResult.Command.ID,
+							})
+							plan, err := actionPlanService.CreatePlan(planCtx, intakeResult.WorkItem.ID, intakeResult.Case.ID, actionPlanInput(fqn, c.Param("id"), action, req))
+							if err != nil {
+								c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+									Code:    validation.ErrTypeMismatch,
+									Field:   "action",
+									Message: err.Error(),
+								}}})
+								return
+							}
+							if _, err := workService.AttachActionPlan(c.Request.Context(), intakeResult.WorkItem.ID, plan); err != nil {
+								c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
+									Code:    validation.ErrTypeMismatch,
+									Field:   "action",
+									Message: err.Error(),
+								}}})
+								return
+							}
 						}
 					}
 				}
@@ -227,5 +257,20 @@ func buildWorkflowActionCommand(c *gin.Context, fqn, action string, req actionRe
 			"action":         action,
 			"record_version": req.RecordVersion,
 		},
+	}
+}
+
+func actionPlanInput(fqn, recordID, action string, req actionRequest) map[string]any {
+	return map[string]any{
+		"reason": "legacy workflow action approved for execution",
+		"actions": []any{map[string]any{
+			"type": "legacy_workflow_action",
+			"params": map[string]any{
+				"entity":         fqn,
+				"record_id":      recordID,
+				"action":         action,
+				"record_version": req.RecordVersion,
+			},
+		}},
 	}
 }

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"kalita/internal/actionplan"
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
 	"kalita/internal/eventcore"
@@ -248,6 +249,10 @@ func (s failingWorkService) IntakeCommand(context.Context, caseruntime.Resolutio
 	return workplan.IntakeResult{}, s.err
 }
 
+func (s failingWorkService) AttachActionPlan(context.Context, string, actionplan.ActionPlan) (workplan.WorkItem, error) {
+	return workplan.WorkItem{}, s.err
+}
+
 type failingPlanner struct {
 	err error
 }
@@ -283,6 +288,17 @@ func (s *staticConstraintsService) CreateAndRecord(context.Context, workplan.Coo
 	return s.constraints, s.err
 }
 
+type staticActionPlanService struct {
+	plan  actionplan.ActionPlan
+	err   error
+	calls int
+}
+
+func (s *staticActionPlanService) CreatePlan(context.Context, string, string, map[string]any) (actionplan.ActionPlan, error) {
+	s.calls++
+	return s.plan, s.err
+}
+
 func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -305,7 +321,7 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, coordinator, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -388,7 +404,7 @@ func TestActionHandlerReturnsValidationErrorWhenCaseResolutionFails(t *testing.T
 
 	storage, rec := testHTTPWorkflowStorage()
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -417,7 +433,7 @@ func TestActionHandlerReturnsValidationErrorWhenWorkItemIntakeFails(t *testing.T
 	caseRepo := caseruntime.NewInMemoryCaseRepository()
 	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -453,7 +469,7 @@ func TestActionHandlerReturnsValidationErrorWhenCoordinationFails(t *testing.T) 
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, failingCoordinator{err: errors.New("coordination failed")}, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -490,7 +506,7 @@ func TestActionHandlerPolicyAllowContinuesLegacyFlow(t *testing.T) {
 	router := gin.New()
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
 		decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"},
-	}, nil))
+	}, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -501,6 +517,49 @@ func TestActionHandlerPolicyAllowContinuesLegacyFlow(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestActionHandlerPolicyAllowCreatesAndAttachesActionPlanBeforeLegacyFlow(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 30, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	actionPlanSvc := &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "legacy workflow action approved for execution", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, nil, actionPlanSvc))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if actionPlanSvc.calls != 1 {
+		t.Fatalf("CreatePlan calls = %d", actionPlanSvc.calls)
+	}
+	stored, ok, err := queueRepo.GetWorkItem(context.Background(), "work-1")
+	if err != nil || !ok {
+		t.Fatalf("GetWorkItem = %#v ok=%v err=%v", stored, ok, err)
+	}
+	if stored.ActionPlan == nil || stored.ActionPlan.ID != "action-plan-1" {
+		t.Fatalf("stored work item = %#v", stored)
 	}
 }
 
@@ -526,7 +585,7 @@ func TestActionHandlerPolicyRequireApprovalStopsBeforeLegacyFlow(t *testing.T) {
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
 		decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"},
 		approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending},
-	}, nil))
+	}, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -562,7 +621,7 @@ func TestActionHandlerPolicyDenyStopsBeforeLegacyFlow(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -710,7 +769,7 @@ func TestActionHandlerReturnsValidationErrorWhenDailyPlanAttachmentFails(t *test
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), failingPlanner{err: errors.New("daily plan failed")}, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -747,7 +806,7 @@ func TestActionHandlerPolicyAllowCreatesConstraintsBeforeLegacyFlow(t *testing.T
 	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -784,7 +843,7 @@ func TestActionHandlerPolicyRequireApprovalRecordsConstraintsAndStopsBeforeLegac
 	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"}, approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending}}, constraintsSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"}, approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending}}, constraintsSvc, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -823,7 +882,7 @@ func TestActionHandlerPolicyDenyDoesNotCreateConstraintsAndStopsBeforeLegacyFlow
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, constraintsSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, constraintsSvc, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -860,7 +919,7 @@ func TestActionHandlerConstraintCreationFailureReturnsValidationError(t *testing
 	constraintsSvc := &staticConstraintsService{err: errors.New("constraints failed")}
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -12,14 +12,14 @@ import (
 )
 
 func RunServer(addr string, storage *runtime.Storage) {
-	RunServerWithServices(addr, storage, nil, nil, nil, nil, nil)
+	RunServerWithServices(addr, storage, nil, nil, nil, nil, nil, nil)
 }
 
 func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus command.CommandBus) {
-	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil)
+	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil, nil)
 }
 
-func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService) {
+func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -39,7 +39,7 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
-		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService, actionPlanService))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
 		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))

--- a/internal/workplan/repository.go
+++ b/internal/workplan/repository.go
@@ -3,6 +3,8 @@ package workplan
 import (
 	"context"
 	"sync"
+
+	"kalita/internal/actionplan"
 )
 
 type InMemoryQueueRepository struct {
@@ -122,7 +124,60 @@ func cloneWorkItem(wi WorkItem) WorkItem {
 		due := *wi.DueAt
 		out.DueAt = &due
 	}
+	if wi.ActionPlan != nil {
+		plan := cloneActionPlan(*wi.ActionPlan)
+		out.ActionPlan = &plan
+	}
 	return out
+}
+
+func cloneActionPlan(plan actionplan.ActionPlan) actionplan.ActionPlan {
+	out := plan
+	out.Actions = make([]actionplan.Action, 0, len(plan.Actions))
+	for _, action := range plan.Actions {
+		out.Actions = append(out.Actions, cloneAction(action))
+	}
+	return out
+}
+
+func cloneAction(action actionplan.Action) actionplan.Action {
+	out := action
+	out.Params = cloneAnyMap(action.Params)
+	if action.Compensation != nil {
+		compensation := cloneAction(*action.Compensation)
+		out.Compensation = &compensation
+	}
+	return out
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = cloneAnyValue(v)
+	}
+	return out
+}
+
+func cloneAnySlice(in []any) []any {
+	out := make([]any, len(in))
+	for i, v := range in {
+		out[i] = cloneAnyValue(v)
+	}
+	return out
+}
+
+func cloneAnyValue(v any) any {
+	switch typed := v.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		return cloneAnySlice(typed)
+	default:
+		return typed
+	}
 }
 
 func containsID(ids []string, target string) bool {

--- a/internal/workplan/service.go
+++ b/internal/workplan/service.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"kalita/internal/actionplan"
 	"kalita/internal/caseruntime"
 	"kalita/internal/eventcore"
 )
@@ -130,4 +131,23 @@ func workItemReason(c caseruntime.Case, cmd eventcore.Command) string {
 		return fmt.Sprintf("intake %s for %s", c.Kind, cmd.TargetRef)
 	}
 	return fmt.Sprintf("intake %s", c.Kind)
+}
+
+func (s *Service) AttachActionPlan(ctx context.Context, workItemID string, plan actionplan.ActionPlan) (WorkItem, error) {
+	if s.repo == nil {
+		return WorkItem{}, fmt.Errorf("queue repository is nil")
+	}
+	workItem, ok, err := s.repo.GetWorkItem(ctx, workItemID)
+	if err != nil {
+		return WorkItem{}, err
+	}
+	if !ok {
+		return WorkItem{}, fmt.Errorf("work item %s not found", workItemID)
+	}
+	workItem.ActionPlan = &plan
+	workItem.UpdatedAt = s.clock.Now()
+	if err := s.repo.SaveWorkItem(ctx, workItem); err != nil {
+		return WorkItem{}, err
+	}
+	return workItem, nil
 }

--- a/internal/workplan/service_test.go
+++ b/internal/workplan/service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"kalita/internal/actionplan"
 	"kalita/internal/caseruntime"
 	"kalita/internal/eventcore"
 )
@@ -96,5 +97,32 @@ func TestServiceReturnsErrorWhenPlanAttachmentFails(t *testing.T) {
 
 	if _, err := service.IntakeCommand(context.Background(), resolved); err == nil {
 		t.Fatal("IntakeCommand error = nil, want non-nil")
+	}
+}
+
+func TestServiceAttachActionPlanStoresTypedPlanOnWorkItem(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryQueueRepository()
+	now := time.Date(2026, 3, 22, 15, 30, 0, 0, time.UTC)
+	workItem := WorkItem{ID: "work-1", CaseID: "case-1", QueueID: "queue-1", Status: string(WorkItemOpen), CreatedAt: now, UpdatedAt: now}
+	if err := repo.SaveWorkItem(context.Background(), workItem); err != nil {
+		t.Fatalf("SaveWorkItem error = %v", err)
+	}
+	service := NewService(repo, nil, nil, nil, nil, fakeClock{now: now.Add(time.Minute)}, &fakeIDGenerator{ids: []string{}})
+	plan := actionplan.ActionPlan{ID: "plan-1", WorkItemID: "work-1", CaseID: "case-1", Reason: "boundary", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: now}}, CreatedAt: now}
+
+	updated, err := service.AttachActionPlan(context.Background(), "work-1", plan)
+	if err != nil {
+		t.Fatalf("AttachActionPlan error = %v", err)
+	}
+	if updated.ActionPlan == nil || updated.ActionPlan.ID != "plan-1" {
+		t.Fatalf("updated work item = %#v", updated)
+	}
+	stored, ok, err := repo.GetWorkItem(context.Background(), "work-1")
+	if err != nil || !ok {
+		t.Fatalf("GetWorkItem = %#v ok=%v err=%v", stored, ok, err)
+	}
+	if stored.ActionPlan == nil || stored.ActionPlan.Reason != "boundary" {
+		t.Fatalf("stored work item = %#v", stored)
 	}
 }

--- a/internal/workplan/types.go
+++ b/internal/workplan/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"kalita/internal/actionplan"
 	"kalita/internal/caseruntime"
 )
 
@@ -25,6 +26,7 @@ type WorkItem struct {
 	AssignedEmployeeID string
 	PlanID             string
 	DueAt              *time.Time
+	ActionPlan         *actionplan.ActionPlan
 	CreatedAt          time.Time
 	UpdatedAt          time.Time
 }


### PR DESCRIPTION
### Motivation
- Establish a deterministic, transport-free safety boundary between LLM/decision proposals and side-effectful execution by introducing a typed ActionPlan layer. 
- Ensure every executable action is from a closed, registry-backed set and validated before execution so compensation and idempotency are known ahead of time. 
- Provide a compatibility seam so the new ActionPlan can be produced and attached to existing WorkItem state without replacing legacy execution yet. 

### Description
- Add a new `internal/actionplan` package containing core types (`Action`, `ActionPlan`, `ActionDefinition`), an in-memory `Registry`, a deterministic `DefaultCompiler` (precomputes compensation), a `DefaultValidator`, and a `Service` that emits an `action_plan_created` execution event. 
- Extend `WorkItem` with a typed `ActionPlan` field and update the in-memory workplan repository to deep-clone attached plans/actions to keep the boundary durable and mutation-safe. 
- Wire the HTTP action path so that after intake → policy → constraints an approved workflow action is compiled into an `ActionPlan` (using a bootstrap-registered `legacy_workflow_action`) and attached to the `WorkItem` before continuing legacy execution. 
- Wire bootstrap and server startup to provision a minimal closed set (a `legacy_workflow_action`) and to pass the new compiler/validator/service into the runtime; add focused unit tests for registry, compiler, validator, service, and compatibility flows. 

### Testing
- Added unit tests in `internal/actionplan` for registry, compiler (valid/invalid plans and compensation generation), validator rules, and service event emission, and added tests that ensure `ActionPlan` attaches to `WorkItem` and the HTTP flow calls the planner and attaches a plan. 
- Ran the full test suite with `go test ./...` and targeted runs `go test ./internal/actionplan ./internal/workplan ./internal/http ./internal/app ./cmd/server/...`; all tests passed. 
- Verified the new compatibility HTTP test that an approved workflow action creates and attaches an `ActionPlan` before legacy execution, and verified the `action_plan_created` execution event is emitted by the service.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05fea479883249c2cf6fbc13791a3)