### PR TITLE
Add execution runtime action runner slice

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.PolicyService, result.ConstraintsService, result.ActionPlanService)
+	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.ExecutionRuntime)
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"kalita/internal/config"
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
+	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
 	"kalita/internal/postgres"
 	"kalita/internal/runtime"
@@ -46,6 +47,11 @@ type BootstrapResult struct {
 	ActionCompiler     actionplan.Compiler
 	ActionValidator    actionplan.Validator
 	ActionPlanService  actionplan.Service
+	ExecutionRepo      executionruntime.ExecutionRepository
+	ExecutionWAL       executionruntime.WAL
+	ActionExecutor     executionruntime.ActionExecutor
+	ExecutionRunner    executionruntime.Runner
+	ExecutionRuntime   executionruntime.Service
 	Config             config.Config
 }
 
@@ -148,6 +154,11 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	actionCompiler := actionplan.NewCompiler(actionRegistry, clock, ids)
 	actionValidator := actionplan.NewValidator(actionRegistry)
 	actionPlanService := actionplan.NewService(actionCompiler, actionValidator, eventLog, clock, ids)
+	executionRepo := executionruntime.NewInMemoryExecutionRepository()
+	executionWAL := executionruntime.NewInMemoryWAL()
+	actionExecutor := executionruntime.NewStubExecutor()
+	executionRunner := executionruntime.NewRunner(executionRepo, executionWAL, actionExecutor, eventLog, clock, ids)
+	executionRuntime := executionruntime.NewService(executionRunner)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
@@ -177,6 +188,11 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		ActionCompiler:     actionCompiler,
 		ActionValidator:    actionValidator,
 		ActionPlanService:  actionPlanService,
+		ExecutionRepo:      executionRepo,
+		ExecutionWAL:       executionWAL,
+		ActionExecutor:     actionExecutor,
+		ExecutionRunner:    executionRunner,
+		ExecutionRuntime:   executionRuntime,
 		Config:             cfg,
 	}, nil
 }

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -86,6 +86,22 @@ func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanPolicyAndExecutionContro
 	if result.ConstraintsService == nil {
 		t.Fatal("ConstraintsService is nil")
 	}
+
+	if result.ExecutionRepo == nil {
+		t.Fatal("ExecutionRepo is nil")
+	}
+	if result.ExecutionWAL == nil {
+		t.Fatal("ExecutionWAL is nil")
+	}
+	if result.ActionExecutor == nil {
+		t.Fatal("ActionExecutor is nil")
+	}
+	if result.ExecutionRunner == nil {
+		t.Fatal("ExecutionRunner is nil")
+	}
+	if result.ExecutionRuntime == nil {
+		t.Fatal("ExecutionRuntime is nil")
+	}
 	queues, err := result.QueueRepo.ListQueues(context.Background())
 	if err != nil {
 		t.Fatalf("ListQueues error = %v", err)

--- a/internal/executionruntime/repository.go
+++ b/internal/executionruntime/repository.go
@@ -1,0 +1,107 @@
+package executionruntime
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+type InMemoryExecutionRepository struct {
+	mu                 sync.RWMutex
+	sessions           map[string]ExecutionSession
+	sessionsByWorkItem map[string][]string
+	steps              map[string]StepExecution
+	stepsBySession     map[string][]string
+}
+
+func NewInMemoryExecutionRepository() *InMemoryExecutionRepository {
+	return &InMemoryExecutionRepository{sessions: map[string]ExecutionSession{}, sessionsByWorkItem: map[string][]string{}, steps: map[string]StepExecution{}, stepsBySession: map[string][]string{}}
+}
+
+func (r *InMemoryExecutionRepository) SaveSession(_ context.Context, s ExecutionSession) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.sessions[s.ID]; ok {
+		r.sessionsByWorkItem[existing.WorkItemID] = removeID(r.sessionsByWorkItem[existing.WorkItemID], s.ID)
+	}
+	r.sessions[s.ID] = s
+	r.sessionsByWorkItem[s.WorkItemID] = appendIfMissing(r.sessionsByWorkItem[s.WorkItemID], s.ID)
+	return nil
+}
+func (r *InMemoryExecutionRepository) GetSession(_ context.Context, id string) (ExecutionSession, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	s, ok := r.sessions[id]
+	return s, ok, nil
+}
+func (r *InMemoryExecutionRepository) ListSessionsByWorkItem(_ context.Context, workItemID string) ([]ExecutionSession, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]ExecutionSession, 0, len(r.sessionsByWorkItem[workItemID]))
+	for _, id := range r.sessionsByWorkItem[workItemID] {
+		out = append(out, r.sessions[id])
+	}
+	return out, nil
+}
+func (r *InMemoryExecutionRepository) SaveStep(_ context.Context, s StepExecution) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.steps[s.ID]; ok {
+		r.stepsBySession[existing.ExecutionSessionID] = removeID(r.stepsBySession[existing.ExecutionSessionID], s.ID)
+	}
+	r.steps[s.ID] = cloneStep(s)
+	r.stepsBySession[s.ExecutionSessionID] = appendIfMissing(r.stepsBySession[s.ExecutionSessionID], s.ID)
+	sort.SliceStable(r.stepsBySession[s.ExecutionSessionID], func(i, j int) bool {
+		a, b := r.steps[r.stepsBySession[s.ExecutionSessionID][i]], r.steps[r.stepsBySession[s.ExecutionSessionID][j]]
+		if a.StepIndex == b.StepIndex {
+			return a.ID < b.ID
+		}
+		return a.StepIndex < b.StepIndex
+	})
+	return nil
+}
+func (r *InMemoryExecutionRepository) GetStep(_ context.Context, id string) (StepExecution, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	s, ok := r.steps[id]
+	return cloneStep(s), ok, nil
+}
+func (r *InMemoryExecutionRepository) ListStepsBySession(_ context.Context, sessionID string) ([]StepExecution, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]StepExecution, 0, len(r.stepsBySession[sessionID]))
+	for _, id := range r.stepsBySession[sessionID] {
+		out = append(out, cloneStep(r.steps[id]))
+	}
+	return out, nil
+}
+
+func appendIfMissing(ids []string, id string) []string {
+	for _, existing := range ids {
+		if existing == id {
+			return ids
+		}
+	}
+	return append(ids, id)
+}
+func removeID(ids []string, target string) []string {
+	out := ids[:0]
+	for _, id := range ids {
+		if id != target {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+func cloneStep(s StepExecution) StepExecution {
+	out := s
+	if s.StartedAt != nil {
+		v := *s.StartedAt
+		out.StartedAt = &v
+	}
+	if s.FinishedAt != nil {
+		v := *s.FinishedAt
+		out.FinishedAt = &v
+	}
+	return out
+}

--- a/internal/executionruntime/repository_test.go
+++ b/internal/executionruntime/repository_test.go
@@ -1,0 +1,50 @@
+package executionruntime
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryExecutionRepositorySaveGetListSessions(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryExecutionRepository()
+	now := time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)
+	session := ExecutionSession{ID: "session-1", WorkItemID: "work-1", Status: ExecutionSessionPending, CreatedAt: now, UpdatedAt: now}
+	if err := repo.SaveSession(context.Background(), session); err != nil {
+		t.Fatalf("SaveSession error = %v", err)
+	}
+	got, ok, err := repo.GetSession(context.Background(), "session-1")
+	if err != nil || !ok {
+		t.Fatalf("GetSession = %#v ok=%v err=%v", got, ok, err)
+	}
+	list, err := repo.ListSessionsByWorkItem(context.Background(), "work-1")
+	if err != nil {
+		t.Fatalf("ListSessionsByWorkItem error = %v", err)
+	}
+	if got.ID != session.ID || len(list) != 1 || list[0].ID != session.ID {
+		t.Fatalf("got=%#v list=%#v", got, list)
+	}
+}
+
+func TestInMemoryExecutionRepositorySaveGetListStepsPreservesOrdering(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryExecutionRepository()
+	steps := []StepExecution{{ID: "step-2", ExecutionSessionID: "session-1", StepIndex: 1}, {ID: "step-1", ExecutionSessionID: "session-1", StepIndex: 0}, {ID: "step-3", ExecutionSessionID: "session-1", StepIndex: 2}}
+	for _, step := range steps {
+		if err := repo.SaveStep(context.Background(), step); err != nil {
+			t.Fatalf("SaveStep error = %v", err)
+		}
+	}
+	got, ok, err := repo.GetStep(context.Background(), "step-1")
+	if err != nil || !ok {
+		t.Fatalf("GetStep = %#v ok=%v err=%v", got, ok, err)
+	}
+	list, err := repo.ListStepsBySession(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("ListStepsBySession error = %v", err)
+	}
+	if got.StepIndex != 0 || len(list) != 3 || list[0].ID != "step-1" || list[1].ID != "step-2" || list[2].ID != "step-3" {
+		t.Fatalf("got=%#v list=%#v", got, list)
+	}
+}

--- a/internal/executionruntime/runner.go
+++ b/internal/executionruntime/runner.go
@@ -1,0 +1,214 @@
+package executionruntime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/eventcore"
+	"kalita/internal/executioncontrol"
+)
+
+type executionContextKey struct{}
+
+type ExecutionContext struct{ ExecutionID, CorrelationID, CausationID string }
+
+func ContextWithExecution(ctx context.Context, meta ExecutionContext) context.Context {
+	return context.WithValue(ctx, executionContextKey{}, meta)
+}
+func executionFromContext(ctx context.Context) ExecutionContext {
+	meta, _ := ctx.Value(executionContextKey{}).(ExecutionContext)
+	return meta
+}
+
+type DefaultRunner struct {
+	repo     ExecutionRepository
+	wal      WAL
+	executor ActionExecutor
+	log      eventcore.EventLog
+	clock    eventcore.Clock
+	ids      eventcore.IDGenerator
+}
+
+func NewRunner(repo ExecutionRepository, wal WAL, executor ActionExecutor, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *DefaultRunner {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &DefaultRunner{repo: repo, wal: wal, executor: executor, log: log, clock: clock, ids: ids}
+}
+
+func (r *DefaultRunner) RunPlan(ctx context.Context, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata RunMetadata) (ExecutionSession, error) {
+	if r.repo == nil {
+		return ExecutionSession{}, fmt.Errorf("execution repository is nil")
+	}
+	if r.wal == nil {
+		return ExecutionSession{}, fmt.Errorf("execution WAL is nil")
+	}
+	if r.executor == nil {
+		return ExecutionSession{}, fmt.Errorf("action executor is nil")
+	}
+	now := r.clock.Now()
+	session := ExecutionSession{ID: r.ids.NewID(), ActionPlanID: plan.ID, CaseID: metadata.CaseID, WorkItemID: metadata.WorkItemID, CoordinationDecisionID: metadata.CoordinationDecisionID, PolicyDecisionID: metadata.PolicyDecisionID, ExecutionConstraintsID: constraints.ID, Status: ExecutionSessionPending, CurrentStepIndex: -1, CreatedAt: now, UpdatedAt: now}
+	if err := r.repo.SaveSession(ctx, session); err != nil {
+		return ExecutionSession{}, err
+	}
+	if err := r.appendEvent(ctx, session.CaseID, "execution_session_created", string(session.Status), map[string]any{"execution_session_id": session.ID, "action_plan_id": session.ActionPlanID, "work_item_id": session.WorkItemID, "coordination_decision_id": session.CoordinationDecisionID, "policy_decision_id": session.PolicyDecisionID, "execution_constraints_id": session.ExecutionConstraintsID, "action_count": len(plan.Actions)}); err != nil {
+		return ExecutionSession{}, err
+	}
+	steps := make([]StepExecution, 0, len(plan.Actions))
+	for idx, action := range plan.Actions {
+		step := StepExecution{ID: r.ids.NewID(), ExecutionSessionID: session.ID, ActionID: action.ID, StepIndex: idx, Status: StepPending}
+		if err := r.repo.SaveStep(ctx, step); err != nil {
+			return ExecutionSession{}, err
+		}
+		steps = append(steps, step)
+	}
+	session.Status = ExecutionSessionRunning
+	session.UpdatedAt = r.clock.Now()
+	if err := r.repo.SaveSession(ctx, session); err != nil {
+		return ExecutionSession{}, err
+	}
+	for idx, action := range plan.Actions {
+		step := steps[idx]
+		if err := r.appendWAL(ctx, session, step, action, WALStepIntent, map[string]any{"step_index": idx}); err != nil {
+			return ExecutionSession{}, err
+		}
+		startedAt := r.clock.Now()
+		step.Status = StepRunning
+		step.StartedAt = &startedAt
+		if err := r.repo.SaveStep(ctx, step); err != nil {
+			return ExecutionSession{}, err
+		}
+		session.CurrentStepIndex, session.UpdatedAt = idx, startedAt
+		if err := r.repo.SaveSession(ctx, session); err != nil {
+			return ExecutionSession{}, err
+		}
+		if err := r.appendEvent(ctx, session.CaseID, "execution_step_started", string(step.Status), map[string]any{"execution_session_id": session.ID, "step_execution_id": step.ID, "action_id": action.ID, "step_index": idx}); err != nil {
+			return ExecutionSession{}, err
+		}
+		err := r.executor.ExecuteAction(ctx, action, constraints)
+		finishedAt := r.clock.Now()
+		step.FinishedAt = &finishedAt
+		if err != nil {
+			step.Status, step.FailureReason = StepFailed, err.Error()
+			session.Status, session.FailureReason, session.UpdatedAt = ExecutionSessionFailed, fmt.Sprintf("step %d action %s failed: %v", idx, action.ID, err), finishedAt
+			if saveErr := r.repo.SaveStep(ctx, step); saveErr != nil {
+				return ExecutionSession{}, saveErr
+			}
+			if saveErr := r.repo.SaveSession(ctx, session); saveErr != nil {
+				return ExecutionSession{}, saveErr
+			}
+			if appendErr := r.appendWAL(ctx, session, step, action, WALStepResult, map[string]any{"step_index": idx, "status": string(step.Status), "failure_reason": step.FailureReason}); appendErr != nil {
+				return ExecutionSession{}, appendErr
+			}
+			if appendErr := r.appendEvent(ctx, session.CaseID, "execution_step_failed", string(step.Status), map[string]any{"execution_session_id": session.ID, "step_execution_id": step.ID, "action_id": action.ID, "step_index": idx, "failure_reason": step.FailureReason}); appendErr != nil {
+				return ExecutionSession{}, appendErr
+			}
+			if compErr := r.compensate(ctx, &session, plan.Actions, steps[:idx], constraints); compErr != nil {
+				session.Status, session.FailureReason, session.UpdatedAt = ExecutionSessionFailed, strings.TrimSpace(session.FailureReason+"; compensation failed: "+compErr.Error()), r.clock.Now()
+				if saveErr := r.repo.SaveSession(ctx, session); saveErr != nil {
+					return ExecutionSession{}, saveErr
+				}
+			}
+			if appendErr := r.appendEvent(ctx, session.CaseID, "execution_session_failed", string(session.Status), map[string]any{"execution_session_id": session.ID, "failure_reason": session.FailureReason}); appendErr != nil {
+				return ExecutionSession{}, appendErr
+			}
+			return session, nil
+		}
+		step.Status = StepSucceeded
+		if saveErr := r.repo.SaveStep(ctx, step); saveErr != nil {
+			return ExecutionSession{}, saveErr
+		}
+		steps[idx] = step
+		if appendErr := r.appendWAL(ctx, session, step, action, WALStepResult, map[string]any{"step_index": idx, "status": string(step.Status)}); appendErr != nil {
+			return ExecutionSession{}, appendErr
+		}
+		if appendErr := r.appendEvent(ctx, session.CaseID, "execution_step_succeeded", string(step.Status), map[string]any{"execution_session_id": session.ID, "step_execution_id": step.ID, "action_id": action.ID, "step_index": idx}); appendErr != nil {
+			return ExecutionSession{}, appendErr
+		}
+	}
+	session.Status, session.UpdatedAt = ExecutionSessionSucceeded, r.clock.Now()
+	if err := r.repo.SaveSession(ctx, session); err != nil {
+		return ExecutionSession{}, err
+	}
+	if err := r.appendEvent(ctx, session.CaseID, "execution_session_succeeded", string(session.Status), map[string]any{"execution_session_id": session.ID}); err != nil {
+		return ExecutionSession{}, err
+	}
+	return session, nil
+}
+
+func (r *DefaultRunner) compensate(ctx context.Context, session *ExecutionSession, actions []actionplan.Action, completed []StepExecution, constraints executioncontrol.ExecutionConstraints) error {
+	var targets []int
+	for i := len(completed) - 1; i >= 0; i-- {
+		if completed[i].Status == StepSucceeded && isCompensatable(actions[completed[i].StepIndex]) {
+			targets = append(targets, i)
+		}
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+	session.Status, session.UpdatedAt = ExecutionSessionCompensating, r.clock.Now()
+	if err := r.repo.SaveSession(ctx, *session); err != nil {
+		return err
+	}
+	if err := r.appendEvent(ctx, session.CaseID, "execution_compensation_started", string(session.Status), map[string]any{"execution_session_id": session.ID, "compensation_count": len(targets)}); err != nil {
+		return err
+	}
+	for _, idx := range targets {
+		step, action := completed[idx], actions[completed[idx].StepIndex]
+		step.Status = StepCompensating
+		if err := r.repo.SaveStep(ctx, step); err != nil {
+			return err
+		}
+		if err := r.appendWAL(ctx, *session, step, action, WALCompensationIntent, map[string]any{"step_index": step.StepIndex}); err != nil {
+			return err
+		}
+		if err := r.executor.CompensateAction(ctx, action, constraints); err != nil {
+			step.Status, step.FailureReason = StepFailed, fmt.Sprintf("compensation failed: %v", err)
+			finishedAt := r.clock.Now()
+			step.FinishedAt = &finishedAt
+			if saveErr := r.repo.SaveStep(ctx, step); saveErr != nil {
+				return saveErr
+			}
+			if appendErr := r.appendWAL(ctx, *session, step, action, WALCompensationResult, map[string]any{"step_index": step.StepIndex, "status": string(step.Status), "failure_reason": step.FailureReason}); appendErr != nil {
+				return appendErr
+			}
+			return fmt.Errorf("action %s: %w", action.ID, err)
+		}
+		step.Status = StepCompensated
+		finishedAt := r.clock.Now()
+		step.FinishedAt = &finishedAt
+		if err := r.repo.SaveStep(ctx, step); err != nil {
+			return err
+		}
+		if err := r.appendWAL(ctx, *session, step, action, WALCompensationResult, map[string]any{"step_index": step.StepIndex, "status": string(step.Status)}); err != nil {
+			return err
+		}
+		if err := r.appendEvent(ctx, session.CaseID, "execution_compensation_succeeded", string(step.Status), map[string]any{"execution_session_id": session.ID, "step_execution_id": step.ID, "action_id": action.ID, "step_index": step.StepIndex}); err != nil {
+			return err
+		}
+	}
+	session.Status, session.UpdatedAt = ExecutionSessionCompensated, r.clock.Now()
+	if err := r.repo.SaveSession(ctx, *session); err != nil {
+		return err
+	}
+	return r.appendEvent(ctx, session.CaseID, "execution_session_compensated", string(session.Status), map[string]any{"execution_session_id": session.ID})
+}
+
+func isCompensatable(action actionplan.Action) bool {
+	return action.Reversibility == actionplan.ReversibilityCompensatable || action.Reversibility == actionplan.ReversibilityFullyReversible
+}
+func (r *DefaultRunner) appendWAL(ctx context.Context, session ExecutionSession, step StepExecution, action actionplan.Action, kind WALRecordType, payload map[string]any) error {
+	return r.wal.Append(ctx, WALRecord{ID: r.ids.NewID(), ExecutionSessionID: session.ID, StepExecutionID: step.ID, ActionID: action.ID, Type: kind, CreatedAt: r.clock.Now(), Payload: payload})
+}
+func (r *DefaultRunner) appendEvent(ctx context.Context, caseID, step, status string, payload map[string]any) error {
+	if r.log == nil {
+		return nil
+	}
+	meta := executionFromContext(ctx)
+	return r.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{ID: r.ids.NewID(), ExecutionID: meta.ExecutionID, CaseID: caseID, Step: step, Status: status, OccurredAt: r.clock.Now(), CorrelationID: meta.CorrelationID, CausationID: meta.CausationID, Payload: payload})
+}

--- a/internal/executionruntime/runner_test.go
+++ b/internal/executionruntime/runner_test.go
@@ -1,0 +1,108 @@
+package executionruntime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/eventcore"
+	"kalita/internal/executioncontrol"
+)
+
+func TestRunnerAllActionsSucceedMarksSessionSucceeded(t *testing.T) {
+	t.Parallel()
+	runner, repo, wal := newTestRunner(&fakeIDGenerator{ids: []string{"session-1", "event-1", "step-1", "step-2", "wal-1", "event-2", "wal-2", "event-3", "wal-3", "event-4", "wal-4", "event-5", "event-6"}})
+	plan := testPlan([]actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{}, Reversibility: actionplan.ReversibilityIrreversible}, {ID: "action-2", Type: "legacy_workflow_action", Params: map[string]any{}, Reversibility: actionplan.ReversibilityIrreversible}})
+	session, err := runner.RunPlan(ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cause-1"}), plan, executioncontrol.ExecutionConstraints{ID: "constraints-1"}, RunMetadata{CaseID: "case-1", WorkItemID: "work-1"})
+	if err != nil {
+		t.Fatalf("RunPlan error = %v", err)
+	}
+	if session.Status != ExecutionSessionSucceeded {
+		t.Fatalf("session.Status = %s", session.Status)
+	}
+	steps, _ := repo.ListStepsBySession(context.Background(), session.ID)
+	records, _ := wal.ListBySession(context.Background(), session.ID)
+	if len(steps) != 2 || steps[0].Status != StepSucceeded || steps[1].Status != StepSucceeded {
+		t.Fatalf("steps = %#v", steps)
+	}
+	if len(records) != 4 || records[0].Type != WALStepIntent || records[1].Type != WALStepResult || records[2].Type != WALStepIntent || records[3].Type != WALStepResult {
+		t.Fatalf("records = %#v", records)
+	}
+}
+
+func TestRunnerFailsStepAndCompensatesPriorCompensatableActionsInReverseOrder(t *testing.T) {
+	t.Parallel()
+	executor := &recordingExecutor{}
+	runner, repo, wal := newTestRunnerWithExecutor(executor, &fakeIDGenerator{ids: []string{"session-1", "event-1", "step-1", "step-2", "step-3", "wal-1", "event-2", "wal-2", "event-3", "wal-3", "event-4", "wal-4", "event-5", "event-6", "wal-5", "wal-6", "event-7", "event-8"}})
+	plan := testPlan([]actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{}, Reversibility: actionplan.ReversibilityCompensatable}, {ID: "action-2", Type: "legacy_workflow_action", Params: map[string]any{}, Reversibility: actionplan.ReversibilityCompensatable}, {ID: "action-3", Type: "legacy_workflow_action", Params: map[string]any{"fail": true}, Reversibility: actionplan.ReversibilityIrreversible}})
+	session, err := runner.RunPlan(context.Background(), plan, executioncontrol.ExecutionConstraints{ID: "constraints-1"}, RunMetadata{CaseID: "case-1", WorkItemID: "work-1"})
+	if err != nil {
+		t.Fatalf("RunPlan error = %v", err)
+	}
+	if session.Status != ExecutionSessionCompensated {
+		t.Fatalf("session.Status = %s", session.Status)
+	}
+	if want := []string{"execute:action-1", "execute:action-2", "execute:action-3", "compensate:action-2", "compensate:action-1"}; !equalStrings(executor.calls, want) {
+		t.Fatalf("calls = %#v", executor.calls)
+	}
+	steps, _ := repo.ListStepsBySession(context.Background(), session.ID)
+	records, _ := wal.ListBySession(context.Background(), session.ID)
+	if steps[0].Status != StepCompensated || steps[1].Status != StepCompensated || steps[2].Status != StepFailed {
+		t.Fatalf("steps = %#v", steps)
+	}
+	if len(records) != 10 || records[6].Type != WALCompensationIntent || records[7].Type != WALCompensationResult || records[8].Type != WALCompensationIntent || records[9].Type != WALCompensationResult {
+		t.Fatalf("records = %#v", records)
+	}
+}
+
+func TestRunnerWritesWALIntentBeforeResultOnFailure(t *testing.T) {
+	t.Parallel()
+	runner, _, wal := newTestRunner(&fakeIDGenerator{ids: []string{"session-1", "event-1", "step-1", "wal-1", "event-2", "wal-2", "event-3", "event-4"}})
+	plan := testPlan([]actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"fail": true}, Reversibility: actionplan.ReversibilityIrreversible}})
+	session, err := runner.RunPlan(context.Background(), plan, executioncontrol.ExecutionConstraints{ID: "constraints-1"}, RunMetadata{CaseID: "case-1", WorkItemID: "work-1"})
+	if err != nil {
+		t.Fatalf("RunPlan error = %v", err)
+	}
+	records, _ := wal.ListBySession(context.Background(), session.ID)
+	if len(records) != 2 || records[0].Type != WALStepIntent || records[1].Type != WALStepResult || records[1].Payload["status"] != string(StepFailed) {
+		t.Fatalf("records = %#v", records)
+	}
+}
+
+func newTestRunner(ids eventcore.IDGenerator) (*DefaultRunner, *InMemoryExecutionRepository, *InMemoryWAL) {
+	return newTestRunnerWithExecutor(NewStubExecutor(), ids)
+}
+func newTestRunnerWithExecutor(executor ActionExecutor, ids eventcore.IDGenerator) (*DefaultRunner, *InMemoryExecutionRepository, *InMemoryWAL) {
+	repo := NewInMemoryExecutionRepository()
+	wal := NewInMemoryWAL()
+	return NewRunner(repo, wal, executor, eventcore.NewInMemoryEventLog(), fakeClock{now: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}, ids), repo, wal
+}
+func testPlan(actions []actionplan.Action) actionplan.ActionPlan {
+	return actionplan.ActionPlan{ID: "plan-1", Actions: actions, CreatedAt: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC), Reason: "test"}
+}
+
+type recordingExecutor struct{ calls []string }
+
+func (e *recordingExecutor) ExecuteAction(_ context.Context, action actionplan.Action, _ executioncontrol.ExecutionConstraints) error {
+	e.calls = append(e.calls, "execute:"+action.ID)
+	if shouldFail(action.Params, "fail") {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+func (e *recordingExecutor) CompensateAction(_ context.Context, action actionplan.Action, _ executioncontrol.ExecutionConstraints) error {
+	e.calls = append(e.calls, "compensate:"+action.ID)
+	return nil
+}
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/executionruntime/service.go
+++ b/internal/executionruntime/service.go
@@ -1,0 +1,73 @@
+package executionruntime
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/executioncontrol"
+)
+
+type runtimeService struct{ runner Runner }
+
+func NewService(runner Runner) Service { return &runtimeService{runner: runner} }
+func (s *runtimeService) StartExecution(ctx context.Context, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata RunMetadata) (ExecutionSession, error) {
+	if s.runner == nil {
+		return ExecutionSession{}, fmt.Errorf("execution runner is nil")
+	}
+	return s.runner.RunPlan(ctx, plan, constraints, metadata)
+}
+
+type StubExecutor struct{}
+
+func NewStubExecutor() *StubExecutor { return &StubExecutor{} }
+func (e *StubExecutor) ExecuteAction(_ context.Context, action actionplan.Action, _ executioncontrol.ExecutionConstraints) error {
+	if shouldFail(action.Params, "fail") {
+		return fmt.Errorf("stub execution requested failure")
+	}
+	return nil
+}
+func (e *StubExecutor) CompensateAction(_ context.Context, action actionplan.Action, _ executioncontrol.ExecutionConstraints) error {
+	if !isCompensatable(action) {
+		return fmt.Errorf("action %s is not compensatable", action.ID)
+	}
+	params := action.Params
+	if action.Compensation != nil {
+		params = action.Compensation.Params
+	}
+	if shouldFail(params, "compensation_fail") {
+		return fmt.Errorf("stub compensation requested failure")
+	}
+	return nil
+}
+
+type LegacyWorkflowActionExecutor struct{}
+
+func NewLegacyWorkflowActionExecutor() *LegacyWorkflowActionExecutor {
+	return &LegacyWorkflowActionExecutor{}
+}
+func (e *LegacyWorkflowActionExecutor) ExecuteAction(_ context.Context, action actionplan.Action, _ executioncontrol.ExecutionConstraints) error {
+	if action.Type != "legacy_workflow_action" {
+		return fmt.Errorf("unsupported action type %q", action.Type)
+	}
+	if shouldFail(action.Params, "fail") {
+		return fmt.Errorf("legacy workflow adapter requested failure")
+	}
+	return nil
+}
+func (e *LegacyWorkflowActionExecutor) CompensateAction(_ context.Context, action actionplan.Action, _ executioncontrol.ExecutionConstraints) error {
+	if !isCompensatable(action) {
+		return fmt.Errorf("action %s is not compensatable", action.ID)
+	}
+	if shouldFail(action.Params, "compensation_fail") {
+		return fmt.Errorf("legacy workflow adapter compensation requested failure")
+	}
+	return nil
+}
+func shouldFail(params map[string]any, key string) bool {
+	if params == nil {
+		return false
+	}
+	b, _ := params[key].(bool)
+	return b
+}

--- a/internal/executionruntime/service_test.go
+++ b/internal/executionruntime/service_test.go
@@ -1,0 +1,61 @@
+package executionruntime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/eventcore"
+	"kalita/internal/executioncontrol"
+)
+
+func TestServiceEmitsExecutionSessionAndStepEvents(t *testing.T) {
+	t.Parallel()
+	repo, wal, log := NewInMemoryExecutionRepository(), NewInMemoryWAL(), eventcore.NewInMemoryEventLog()
+	ids := &fakeIDGenerator{ids: []string{"session-1", "event-1", "step-1", "wal-1", "event-2", "wal-2", "event-3", "event-4"}}
+	service := NewService(NewRunner(repo, wal, NewStubExecutor(), log, fakeClock{now: time.Date(2026, 3, 22, 17, 0, 0, 0, time.UTC)}, ids))
+	_, err := service.StartExecution(ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cause-1"}), testPlan([]actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{}, Reversibility: actionplan.ReversibilityIrreversible}}), executioncontrol.ExecutionConstraints{ID: "constraints-1"}, RunMetadata{CaseID: "case-1", WorkItemID: "work-1"})
+	if err != nil {
+		t.Fatalf("StartExecution error = %v", err)
+	}
+	_, events, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(events) < 4 || events[0].Step != "execution_session_created" || events[1].Step != "execution_step_started" || events[2].Step != "execution_step_succeeded" || events[3].Step != "execution_session_succeeded" {
+		t.Fatalf("events = %#v", events)
+	}
+}
+
+func TestStubExecutorFailureRecordsReasons(t *testing.T) {
+	t.Parallel()
+	repo, wal := NewInMemoryExecutionRepository(), NewInMemoryWAL()
+	service := NewService(NewRunner(repo, wal, NewStubExecutor(), eventcore.NewInMemoryEventLog(), fakeClock{now: time.Date(2026, 3, 22, 17, 30, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"session-1", "event-1", "step-1", "wal-1", "event-2", "wal-2", "event-3", "event-4"}}))
+	session, err := service.StartExecution(context.Background(), testPlan([]actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"fail": true}, Reversibility: actionplan.ReversibilityIrreversible}}), executioncontrol.ExecutionConstraints{ID: "constraints-1"}, RunMetadata{CaseID: "case-1", WorkItemID: "work-1"})
+	if err != nil {
+		t.Fatalf("StartExecution error = %v", err)
+	}
+	steps, _ := repo.ListStepsBySession(context.Background(), session.ID)
+	if session.Status != ExecutionSessionFailed || session.FailureReason == "" || len(steps) != 1 || steps[0].Status != StepFailed || steps[0].FailureReason == "" {
+		t.Fatalf("session=%#v steps=%#v", session, steps)
+	}
+}
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDGenerator struct {
+	ids []string
+	i   int
+}
+
+func (f *fakeIDGenerator) NewID() string {
+	if f.i >= len(f.ids) {
+		return "generated-id"
+	}
+	id := f.ids[f.i]
+	f.i++
+	return id
+}

--- a/internal/executionruntime/types.go
+++ b/internal/executionruntime/types.go
@@ -1,0 +1,110 @@
+package executionruntime
+
+import (
+	"context"
+	"time"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/executioncontrol"
+)
+
+type ExecutionSessionStatus string
+
+const (
+	ExecutionSessionPending      ExecutionSessionStatus = "pending"
+	ExecutionSessionRunning      ExecutionSessionStatus = "running"
+	ExecutionSessionSucceeded    ExecutionSessionStatus = "succeeded"
+	ExecutionSessionFailed       ExecutionSessionStatus = "failed"
+	ExecutionSessionCompensating ExecutionSessionStatus = "compensating"
+	ExecutionSessionCompensated  ExecutionSessionStatus = "compensated"
+)
+
+type StepStatus string
+
+const (
+	StepPending      StepStatus = "pending"
+	StepRunning      StepStatus = "running"
+	StepSucceeded    StepStatus = "succeeded"
+	StepFailed       StepStatus = "failed"
+	StepCompensating StepStatus = "compensating"
+	StepCompensated  StepStatus = "compensated"
+)
+
+type ExecutionSession struct {
+	ID                     string
+	ActionPlanID           string
+	CaseID                 string
+	WorkItemID             string
+	CoordinationDecisionID string
+	PolicyDecisionID       string
+	ExecutionConstraintsID string
+	Status                 ExecutionSessionStatus
+	CurrentStepIndex       int
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	FailureReason          string
+}
+
+type StepExecution struct {
+	ID                 string
+	ExecutionSessionID string
+	ActionID           string
+	StepIndex          int
+	Status             StepStatus
+	StartedAt          *time.Time
+	FinishedAt         *time.Time
+	FailureReason      string
+}
+
+type WALRecordType string
+
+const (
+	WALStepIntent         WALRecordType = "step_intent"
+	WALStepResult         WALRecordType = "step_result"
+	WALCompensationIntent WALRecordType = "compensation_intent"
+	WALCompensationResult WALRecordType = "compensation_result"
+)
+
+type WALRecord struct {
+	ID                 string
+	ExecutionSessionID string
+	StepExecutionID    string
+	ActionID           string
+	Type               WALRecordType
+	CreatedAt          time.Time
+	Payload            map[string]any
+}
+
+type ExecutionRepository interface {
+	SaveSession(ctx context.Context, s ExecutionSession) error
+	GetSession(ctx context.Context, id string) (ExecutionSession, bool, error)
+	ListSessionsByWorkItem(ctx context.Context, workItemID string) ([]ExecutionSession, error)
+	SaveStep(ctx context.Context, s StepExecution) error
+	GetStep(ctx context.Context, id string) (StepExecution, bool, error)
+	ListStepsBySession(ctx context.Context, sessionID string) ([]StepExecution, error)
+}
+
+type WAL interface {
+	Append(ctx context.Context, r WALRecord) error
+	ListBySession(ctx context.Context, sessionID string) ([]WALRecord, error)
+}
+
+type ActionExecutor interface {
+	ExecuteAction(ctx context.Context, action actionplan.Action, constraints executioncontrol.ExecutionConstraints) error
+	CompensateAction(ctx context.Context, action actionplan.Action, constraints executioncontrol.ExecutionConstraints) error
+}
+
+type Runner interface {
+	RunPlan(ctx context.Context, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata RunMetadata) (ExecutionSession, error)
+}
+
+type Service interface {
+	StartExecution(ctx context.Context, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata RunMetadata) (ExecutionSession, error)
+}
+
+type RunMetadata struct {
+	CaseID                 string
+	WorkItemID             string
+	CoordinationDecisionID string
+	PolicyDecisionID       string
+}

--- a/internal/executionruntime/wal.go
+++ b/internal/executionruntime/wal.go
@@ -1,0 +1,41 @@
+package executionruntime
+
+import (
+	"context"
+	"sync"
+)
+
+type InMemoryWAL struct {
+	mu        sync.RWMutex
+	records   []WALRecord
+	bySession map[string][]int
+}
+
+func NewInMemoryWAL() *InMemoryWAL { return &InMemoryWAL{bySession: map[string][]int{}} }
+func (w *InMemoryWAL) Append(_ context.Context, r WALRecord) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	idx := len(w.records)
+	w.records = append(w.records, cloneWALRecord(r))
+	w.bySession[r.ExecutionSessionID] = append(w.bySession[r.ExecutionSessionID], idx)
+	return nil
+}
+func (w *InMemoryWAL) ListBySession(_ context.Context, sessionID string) ([]WALRecord, error) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	out := make([]WALRecord, 0, len(w.bySession[sessionID]))
+	for _, idx := range w.bySession[sessionID] {
+		out = append(out, cloneWALRecord(w.records[idx]))
+	}
+	return out, nil
+}
+func cloneWALRecord(r WALRecord) WALRecord {
+	out := r
+	if r.Payload != nil {
+		out.Payload = map[string]any{}
+		for k, v := range r.Payload {
+			out.Payload[k] = v
+		}
+	}
+	return out
+}

--- a/internal/executionruntime/wal_test.go
+++ b/internal/executionruntime/wal_test.go
@@ -1,0 +1,25 @@
+package executionruntime
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryWALAppendListBySessionPreservesOrdering(t *testing.T) {
+	t.Parallel()
+	wal := NewInMemoryWAL()
+	records := []WALRecord{{ID: "wal-1", ExecutionSessionID: "session-1", Type: WALStepIntent, CreatedAt: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}, {ID: "wal-2", ExecutionSessionID: "session-2", Type: WALStepIntent, CreatedAt: time.Date(2026, 3, 22, 16, 0, 1, 0, time.UTC)}, {ID: "wal-3", ExecutionSessionID: "session-1", Type: WALStepResult, CreatedAt: time.Date(2026, 3, 22, 16, 0, 2, 0, time.UTC)}}
+	for _, record := range records {
+		if err := wal.Append(context.Background(), record); err != nil {
+			t.Fatalf("Append error = %v", err)
+		}
+	}
+	got, err := wal.ListBySession(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("ListBySession error = %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "wal-1" || got[1].ID != "wal-3" {
+		t.Fatalf("records = %#v", got)
+	}
+}

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -13,6 +13,7 @@ import (
 	"kalita/internal/command"
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
+	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
 	"kalita/internal/runtime"
 	"kalita/internal/validation"
@@ -27,11 +28,11 @@ type actionRequest struct {
 }
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, nil, nil, nil, nil, nil, nil)
+	return ActionHandlerWithServices(storage, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.CommandBus) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil, nil, nil)
+	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil, nil, nil, nil)
 }
 
 type commandCaseResolver interface {
@@ -55,7 +56,15 @@ type actionPlanService interface {
 	CreatePlan(ctx context.Context, workItemID string, caseID string, input map[string]any) (actionplan.ActionPlan, error)
 }
 
-func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService) gin.HandlerFunc {
+type executionRuntimeService interface {
+	StartExecution(ctx context.Context, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata executionruntime.RunMetadata) (executionruntime.ExecutionSession, error)
+}
+
+func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, executionRuntimeServices ...executionRuntimeService) gin.HandlerFunc {
+	var executionRuntimeService executionRuntimeService
+	if len(executionRuntimeServices) > 0 {
+		executionRuntimeService = executionRuntimeServices[0]
+	}
 	return func(c *gin.Context) {
 		fqn, action, req, ok := parseActionRequest(c, storage)
 		if !ok {
@@ -108,13 +117,16 @@ func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.Comm
 							}}})
 							return
 						}
+						var constraints executioncontrol.ExecutionConstraints
 						if constraintsService != nil && policyDecision.Outcome != policy.PolicyDeny {
 							constraintsCtx := executioncontrol.ContextWithExecution(c.Request.Context(), executioncontrol.ExecutionContext{
 								ExecutionID:   intakeResult.Command.ExecutionID,
 								CorrelationID: intakeResult.Command.CorrelationID,
 								CausationID:   intakeResult.Command.ID,
 							})
-							if _, err := constraintsService.CreateAndRecord(constraintsCtx, intakeResult.CoordinationDecision, policyDecision); err != nil {
+							var err error
+							constraints, err = constraintsService.CreateAndRecord(constraintsCtx, intakeResult.CoordinationDecision, policyDecision)
+							if err != nil {
 								c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
 									Code:    validation.ErrTypeMismatch,
 									Field:   "action",
@@ -157,6 +169,13 @@ func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.Comm
 									Message: err.Error(),
 								}}})
 								return
+							}
+							if executionRuntimeService != nil {
+								runtimeCtx := executionruntime.ContextWithExecution(c.Request.Context(), executionruntime.ExecutionContext{ExecutionID: intakeResult.Command.ExecutionID, CorrelationID: intakeResult.Command.CorrelationID, CausationID: intakeResult.Command.ID})
+								if _, err := executionRuntimeService.StartExecution(runtimeCtx, plan, constraints, executionruntime.RunMetadata{CaseID: intakeResult.Case.ID, WorkItemID: intakeResult.WorkItem.ID, CoordinationDecisionID: intakeResult.CoordinationDecision.ID, PolicyDecisionID: policyDecision.ID}); err != nil {
+									c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{Code: validation.ErrTypeMismatch, Field: "action", Message: err.Error()}}})
+									return
+								}
 							}
 						}
 					}

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -15,6 +15,7 @@ import (
 	"kalita/internal/command"
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
+	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
@@ -297,6 +298,23 @@ type staticActionPlanService struct {
 func (s *staticActionPlanService) CreatePlan(context.Context, string, string, map[string]any) (actionplan.ActionPlan, error) {
 	s.calls++
 	return s.plan, s.err
+}
+
+type staticExecutionRuntimeService struct {
+	session     executionruntime.ExecutionSession
+	err         error
+	calls       int
+	plans       []actionplan.ActionPlan
+	constraints []executioncontrol.ExecutionConstraints
+	metadata    []executionruntime.RunMetadata
+}
+
+func (s *staticExecutionRuntimeService) StartExecution(_ context.Context, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata executionruntime.RunMetadata) (executionruntime.ExecutionSession, error) {
+	s.calls++
+	s.plans = append(s.plans, plan)
+	s.constraints = append(s.constraints, constraints)
+	s.metadata = append(s.metadata, metadata)
+	return s.session, s.err
 }
 
 func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
@@ -645,6 +663,85 @@ func TestActionHandlerReturnsValidationErrorWhenCommandAdmissionFails(t *testing
 	storage, rec := testHTTPWorkflowStorage()
 	router := gin.New()
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithCommandBus(storage, denyCommandBus{}))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
+		t.Fatalf("status mutated to %v", got)
+	}
+}
+
+func TestActionHandlerPolicyAllowStartsExecutionSession(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 30, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	actionPlanSvc := &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "legacy workflow action approved for execution", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}
+	executionSvc := &staticExecutionRuntimeService{session: executionruntime.ExecutionSession{ID: "session-1", Status: executionruntime.ExecutionSessionSucceeded}}
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, actionPlanSvc, executionSvc))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if executionSvc.calls != 1 {
+		t.Fatalf("execution calls = %d", executionSvc.calls)
+	}
+	if len(executionSvc.constraints) != 1 || executionSvc.constraints[0].ID != "constraints-1" {
+		t.Fatalf("constraints = %#v", executionSvc.constraints)
+	}
+	if len(executionSvc.metadata) != 1 || executionSvc.metadata[0].WorkItemID != "work-1" || executionSvc.metadata[0].CaseID != "case-1" {
+		t.Fatalf("metadata = %#v", executionSvc.metadata)
+	}
+}
+
+func TestActionHandlerExecutionStartupFailureReturnsValidationError(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 30, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	executionSvc := &staticExecutionRuntimeService{err: errors.New("execution startup failed")}
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "ready", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}, executionSvc))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -19,7 +19,7 @@ func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus c
 	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil, nil)
 }
 
-func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService) {
+func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, executionRuntimeServices ...executionRuntimeService) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -39,7 +39,7 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
-		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService, actionPlanService))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService, actionPlanService, executionRuntimeServices...))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
 		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))


### PR DESCRIPTION
### Motivation
- Introduce a transport-free Execution Runtime to run typed `ActionPlan` step-by-step, record write-ahead intent, track per-step status, and support failure + compensation hooks. 
- Provide a deterministic, in-memory, testable runtime for the next Kalita vNext slice without touching DigitalEmployee, LLM logic, CRUD rewrite, or replacing the legacy execution path yet. 

### Description
- Add a new package `internal/executionruntime` containing typed models (`ExecutionSession`, `StepExecution`, `WALRecord`), interfaces, an in-memory repository, an append-only in-memory WAL, a deterministic `DefaultRunner`, and a runtime `Service` (`types.go`, `repository.go`, `wal.go`, `runner.go`, `service.go`). 
- Implement a deterministic stub executor and a `LegacyWorkflowActionExecutor` adapter so action execution is controllable in tests and the compatibility seam can defer to legacy behavior when appropriate. 
- Ensure runner semantics: create a session and step records, append `step_intent` before execution, call `ActionExecutor.ExecuteAction`, append `step_result` after execution, emit `eventcore.ExecutionEvent` records for session/step/compensation lifecycle, and run reverse-order compensation for previously succeeded compensatable actions. 
- Wire bootstrap to create and expose `ExecutionRepository`, `WAL`, `ActionExecutor`, `Runner`, and `ExecutionRuntime` and extend the existing workflow compatibility seam (HTTP handler) to start an execution session on the allow path while preserving deny/require-approval behavior. 

### Testing
- Unit tests added for repository ordering, WAL ordering, runner success/failure/compensation, and service event emission (`go test ./internal/executionruntime -count=1`) and they passed. 
- Focused HTTP compatibility tests exercising execution startup and startup-failure behavior were run (`go test ./internal/http -run 'TestActionHandlerPolicyAllowStartsExecutionSession|TestActionHandlerExecutionStartupFailureReturnsValidationError|TestActionHandlerPolicyRequireApprovalStopsBeforeLegacyFlow|TestActionHandlerPolicyDenyStopsBeforeLegacyFlow' -count=1 -v`) and passed. 
- Bootstrap wiring check ran (`go test ./internal/app -run TestBootstrapProvidesEventCenterCaseRuntimeWorkplanPolicyAndExecutionControl -count=1 -v`) and passed, and `go build ./cmd/server` also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c06432d49c832498cea411d7ab8a7a)