### PR TITLE
Add managed digital employee slice

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.ExecutionRuntime)
+	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.EmployeeService)
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	"kalita/internal/catalog"
 	"kalita/internal/command"
 	"kalita/internal/config"
+	"kalita/internal/employee"
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
 	"kalita/internal/executionruntime"
@@ -47,6 +48,10 @@ type BootstrapResult struct {
 	ActionCompiler     actionplan.Compiler
 	ActionValidator    actionplan.Validator
 	ActionPlanService  actionplan.Service
+	EmployeeDirectory  employee.Directory
+	AssignmentRepo     employee.AssignmentRepository
+	EmployeeSelector   employee.Selector
+	EmployeeService    employee.Service
 	ExecutionRepo      executionruntime.ExecutionRepository
 	ExecutionWAL       executionruntime.WAL
 	ActionExecutor     executionruntime.ActionExecutor
@@ -159,6 +164,26 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	actionExecutor := executionruntime.NewStubExecutor()
 	executionRunner := executionruntime.NewRunner(executionRepo, executionWAL, actionExecutor, eventLog, clock, ids)
 	executionRuntime := executionruntime.NewService(executionRunner)
+	employeeDirectory := employee.NewInMemoryDirectory()
+	assignmentRepo := employee.NewInMemoryAssignmentRepository()
+	employeeSelector := employee.NewSelector(employeeDirectory)
+	employeeService := employee.NewService(assignmentRepo, employeeSelector, executionRuntime, eventLog, clock, ids)
+	defaultEmployee := employee.DigitalEmployee{
+		ID:                  "employee-legacy-operator",
+		Code:                "legacy_operator_default",
+		Role:                "legacy_operator",
+		Enabled:             true,
+		QueueMemberships:    []string{defaultQueue.ID},
+		AllowedActionTypes:  []actionplan.ActionType{"legacy_workflow_action"},
+		AllowedCommandTypes: []string{"workflow.action"},
+		PolicyProfile:       "default",
+		ExecutionProfile:    "default",
+		CreatedAt:           clock.Now(),
+		UpdatedAt:           clock.Now(),
+	}
+	if err := employeeDirectory.SaveEmployee(context.Background(), defaultEmployee); err != nil {
+		return nil, fmt.Errorf("seed default employee: %w", err)
+	}
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
@@ -188,6 +213,10 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		ActionCompiler:     actionCompiler,
 		ActionValidator:    actionValidator,
 		ActionPlanService:  actionPlanService,
+		EmployeeDirectory:  employeeDirectory,
+		AssignmentRepo:     assignmentRepo,
+		EmployeeSelector:   employeeSelector,
+		EmployeeService:    employeeService,
 		ExecutionRepo:      executionRepo,
 		ExecutionWAL:       executionWAL,
 		ActionExecutor:     actionExecutor,

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -5,9 +5,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/workplan"
 )
 
-func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanPolicyAndExecutionControl(t *testing.T) {
+func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanPolicyExecutionControlAndEmployeeLayer(t *testing.T) {
 	cfg := `{
   "port": "8080",
   "dslDir": "../../dsl",
@@ -86,7 +89,18 @@ func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanPolicyAndExecutionContro
 	if result.ConstraintsService == nil {
 		t.Fatal("ConstraintsService is nil")
 	}
-
+	if result.EmployeeDirectory == nil {
+		t.Fatal("EmployeeDirectory is nil")
+	}
+	if result.AssignmentRepo == nil {
+		t.Fatal("AssignmentRepo is nil")
+	}
+	if result.EmployeeSelector == nil {
+		t.Fatal("EmployeeSelector is nil")
+	}
+	if result.EmployeeService == nil {
+		t.Fatal("EmployeeService is nil")
+	}
 	if result.ExecutionRepo == nil {
 		t.Fatal("ExecutionRepo is nil")
 	}
@@ -108,5 +122,19 @@ func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanPolicyAndExecutionContro
 	}
 	if len(queues) == 0 || queues[0].ID != "default-intake" {
 		t.Fatalf("queues = %#v", queues)
+	}
+	employees, err := result.EmployeeDirectory.ListEmployees(context.Background())
+	if err != nil {
+		t.Fatalf("ListEmployees error = %v", err)
+	}
+	if len(employees) == 0 || employees[0].Role != "legacy_operator" {
+		t.Fatalf("employees = %#v", employees)
+	}
+	selected, reason, err := result.EmployeeSelector.SelectForWorkItem(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "default-intake"}, actionplan.ActionPlan{ID: "plan-1", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action"}}})
+	if err != nil {
+		t.Fatalf("SelectForWorkItem error = %v", err)
+	}
+	if selected.ID != employees[0].ID || reason == "" {
+		t.Fatalf("selected = %#v reason=%q", selected, reason)
 	}
 }

--- a/internal/employee/repository.go
+++ b/internal/employee/repository.go
@@ -1,0 +1,163 @@
+package employee
+
+import (
+	"context"
+	"sync"
+
+	"kalita/internal/actionplan"
+)
+
+type InMemoryDirectory struct {
+	mu              sync.RWMutex
+	employeesByID   map[string]DigitalEmployee
+	employeeOrder   []string
+	employeeByQueue map[string][]string
+}
+
+func NewInMemoryDirectory() *InMemoryDirectory {
+	return &InMemoryDirectory{employeesByID: map[string]DigitalEmployee{}, employeeByQueue: map[string][]string{}}
+}
+
+func (r *InMemoryDirectory) SaveEmployee(_ context.Context, e DigitalEmployee) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.employeesByID[e.ID]; ok {
+		for _, queueID := range existing.QueueMemberships {
+			r.employeeByQueue[queueID] = removeString(r.employeeByQueue[queueID], e.ID)
+		}
+	} else {
+		r.employeeOrder = append(r.employeeOrder, e.ID)
+	}
+	r.employeesByID[e.ID] = cloneEmployee(e)
+	for _, queueID := range e.QueueMemberships {
+		if !containsString(r.employeeByQueue[queueID], e.ID) {
+			r.employeeByQueue[queueID] = append(r.employeeByQueue[queueID], e.ID)
+		}
+	}
+	return nil
+}
+
+func (r *InMemoryDirectory) GetEmployee(_ context.Context, id string) (DigitalEmployee, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.employeesByID[id]
+	if !ok {
+		return DigitalEmployee{}, false, nil
+	}
+	return cloneEmployee(e), true, nil
+}
+
+func (r *InMemoryDirectory) ListEmployees(_ context.Context) ([]DigitalEmployee, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]DigitalEmployee, 0, len(r.employeeOrder))
+	for _, id := range r.employeeOrder {
+		out = append(out, cloneEmployee(r.employeesByID[id]))
+	}
+	return out, nil
+}
+
+func (r *InMemoryDirectory) ListEmployeesByQueue(_ context.Context, queueID string) ([]DigitalEmployee, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.employeeByQueue[queueID]
+	out := make([]DigitalEmployee, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, cloneEmployee(r.employeesByID[id]))
+	}
+	return out, nil
+}
+
+type InMemoryAssignmentRepository struct {
+	mu                 sync.RWMutex
+	assignmentsByID    map[string]Assignment
+	assignmentOrder    []string
+	assignmentsByWork  map[string][]string
+	assignmentsByEmpID map[string][]string
+}
+
+func NewInMemoryAssignmentRepository() *InMemoryAssignmentRepository {
+	return &InMemoryAssignmentRepository{assignmentsByID: map[string]Assignment{}, assignmentsByWork: map[string][]string{}, assignmentsByEmpID: map[string][]string{}}
+}
+
+func (r *InMemoryAssignmentRepository) SaveAssignment(_ context.Context, a Assignment) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.assignmentsByID[a.ID]; ok {
+		if existing.WorkItemID != a.WorkItemID {
+			r.assignmentsByWork[existing.WorkItemID] = removeString(r.assignmentsByWork[existing.WorkItemID], a.ID)
+		}
+		if existing.EmployeeID != a.EmployeeID {
+			r.assignmentsByEmpID[existing.EmployeeID] = removeString(r.assignmentsByEmpID[existing.EmployeeID], a.ID)
+		}
+	} else {
+		r.assignmentOrder = append(r.assignmentOrder, a.ID)
+	}
+	r.assignmentsByID[a.ID] = a
+	if !containsString(r.assignmentsByWork[a.WorkItemID], a.ID) {
+		r.assignmentsByWork[a.WorkItemID] = append(r.assignmentsByWork[a.WorkItemID], a.ID)
+	}
+	if !containsString(r.assignmentsByEmpID[a.EmployeeID], a.ID) {
+		r.assignmentsByEmpID[a.EmployeeID] = append(r.assignmentsByEmpID[a.EmployeeID], a.ID)
+	}
+	return nil
+}
+
+func (r *InMemoryAssignmentRepository) GetAssignment(_ context.Context, id string) (Assignment, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.assignmentsByID[id]
+	if !ok {
+		return Assignment{}, false, nil
+	}
+	return a, true, nil
+}
+
+func (r *InMemoryAssignmentRepository) ListAssignmentsByWorkItem(_ context.Context, workItemID string) ([]Assignment, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.assignmentsByWork[workItemID]
+	out := make([]Assignment, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, r.assignmentsByID[id])
+	}
+	return out, nil
+}
+
+func (r *InMemoryAssignmentRepository) ListAssignmentsByEmployee(_ context.Context, employeeID string) ([]Assignment, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.assignmentsByEmpID[employeeID]
+	out := make([]Assignment, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, r.assignmentsByID[id])
+	}
+	return out, nil
+}
+
+func cloneEmployee(e DigitalEmployee) DigitalEmployee {
+	out := e
+	out.QueueMemberships = append([]string(nil), e.QueueMemberships...)
+	out.AllowedActionTypes = append([]actionplan.ActionType(nil), e.AllowedActionTypes...)
+	out.AllowedCommandTypes = append([]string(nil), e.AllowedCommandTypes...)
+	return out
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(items []string, target string) []string {
+	out := items[:0]
+	for _, item := range items {
+		if item != target {
+			out = append(out, item)
+		}
+	}
+	return out
+}

--- a/internal/employee/repository_test.go
+++ b/internal/employee/repository_test.go
@@ -1,0 +1,82 @@
+package employee
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/actionplan"
+)
+
+func TestInMemoryDirectorySaveGetListEmployee(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryDirectory()
+	now := time.Date(2026, 3, 22, 18, 0, 0, 0, time.UTC)
+	emp := DigitalEmployee{ID: "emp-1", Code: "legacy-op", Role: "legacy_operator", Enabled: false, QueueMemberships: []string{"default-intake"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}, AllowedCommandTypes: []string{"workflow.action"}, CreatedAt: now, UpdatedAt: now}
+	if err := repo.SaveEmployee(context.Background(), emp); err != nil {
+		t.Fatalf("SaveEmployee error = %v", err)
+	}
+	got, ok, err := repo.GetEmployee(context.Background(), emp.ID)
+	if err != nil || !ok {
+		t.Fatalf("GetEmployee = %#v ok=%v err=%v", got, ok, err)
+	}
+	got.QueueMemberships[0] = "mutated"
+	reloaded, _, _ := repo.GetEmployee(context.Background(), emp.ID)
+	if reloaded.QueueMemberships[0] != "default-intake" {
+		t.Fatalf("employee clone failed: %#v", reloaded)
+	}
+	list, err := repo.ListEmployees(context.Background())
+	if err != nil {
+		t.Fatalf("ListEmployees error = %v", err)
+	}
+	if len(list) != 1 || list[0].ID != emp.ID || list[0].Enabled {
+		t.Fatalf("list = %#v", list)
+	}
+}
+
+func TestInMemoryDirectoryListEmployeesByQueue(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryDirectory()
+	employees := []DigitalEmployee{{ID: "emp-1", QueueMemberships: []string{"q-1"}}, {ID: "emp-2", QueueMemberships: []string{"q-1", "q-2"}}, {ID: "emp-3", QueueMemberships: []string{"q-2"}}}
+	for _, employee := range employees {
+		if err := repo.SaveEmployee(context.Background(), employee); err != nil {
+			t.Fatalf("SaveEmployee(%s) error = %v", employee.ID, err)
+		}
+	}
+	list, err := repo.ListEmployeesByQueue(context.Background(), "q-1")
+	if err != nil {
+		t.Fatalf("ListEmployeesByQueue error = %v", err)
+	}
+	if len(list) != 2 || list[0].ID != "emp-1" || list[1].ID != "emp-2" {
+		t.Fatalf("list = %#v", list)
+	}
+}
+
+func TestInMemoryAssignmentRepositorySaveGetListByWorkItemAndEmployee(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryAssignmentRepository()
+	assignments := []Assignment{{ID: "asn-1", WorkItemID: "work-1", EmployeeID: "emp-1"}, {ID: "asn-2", WorkItemID: "work-1", EmployeeID: "emp-2"}, {ID: "asn-3", WorkItemID: "work-2", EmployeeID: "emp-1"}}
+	for _, assignment := range assignments {
+		if err := repo.SaveAssignment(context.Background(), assignment); err != nil {
+			t.Fatalf("SaveAssignment(%s) error = %v", assignment.ID, err)
+		}
+	}
+	got, ok, err := repo.GetAssignment(context.Background(), "asn-1")
+	if err != nil || !ok {
+		t.Fatalf("GetAssignment = %#v ok=%v err=%v", got, ok, err)
+	}
+	byWork, err := repo.ListAssignmentsByWorkItem(context.Background(), "work-1")
+	if err != nil {
+		t.Fatalf("ListAssignmentsByWorkItem error = %v", err)
+	}
+	if len(byWork) != 2 || byWork[0].ID != "asn-1" || byWork[1].ID != "asn-2" {
+		t.Fatalf("byWork = %#v", byWork)
+	}
+	byEmployee, err := repo.ListAssignmentsByEmployee(context.Background(), "emp-1")
+	if err != nil {
+		t.Fatalf("ListAssignmentsByEmployee error = %v", err)
+	}
+	if len(byEmployee) != 2 || byEmployee[0].ID != "asn-1" || byEmployee[1].ID != "asn-3" {
+		t.Fatalf("byEmployee = %#v", byEmployee)
+	}
+}

--- a/internal/employee/selector.go
+++ b/internal/employee/selector.go
@@ -1,0 +1,50 @@
+package employee
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/workplan"
+)
+
+type deterministicSelector struct{ directory Directory }
+
+func NewSelector(directory Directory) Selector { return &deterministicSelector{directory: directory} }
+
+func (s *deterministicSelector) SelectForWorkItem(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan) (DigitalEmployee, string, error) {
+	if s.directory == nil {
+		return DigitalEmployee{}, "", fmt.Errorf("employee directory is nil")
+	}
+	employees, err := s.directory.ListEmployeesByQueue(ctx, wi.QueueID)
+	if err != nil {
+		return DigitalEmployee{}, "", err
+	}
+	for _, employee := range employees {
+		if !employee.Enabled {
+			continue
+		}
+		if !containsString(employee.QueueMemberships, wi.QueueID) {
+			continue
+		}
+		if !allowsAllActionTypes(employee, plan.Actions) {
+			continue
+		}
+		reason := fmt.Sprintf("selected employee %s for queue %s by deterministic directory order", employee.ID, wi.QueueID)
+		return employee, reason, nil
+	}
+	return DigitalEmployee{}, "", fmt.Errorf("no eligible digital employee for queue %s and work item %s", wi.QueueID, wi.ID)
+}
+
+func allowsAllActionTypes(employee DigitalEmployee, actions []actionplan.Action) bool {
+	allowed := make(map[actionplan.ActionType]struct{}, len(employee.AllowedActionTypes))
+	for _, actionType := range employee.AllowedActionTypes {
+		allowed[actionType] = struct{}{}
+	}
+	for _, action := range actions {
+		if _, ok := allowed[action.Type]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/employee/selector_test.go
+++ b/internal/employee/selector_test.go
@@ -1,0 +1,61 @@
+package employee
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/workplan"
+)
+
+func TestSelectorSelectsEnabledEmployeeInMatchingQueue(t *testing.T) {
+	t.Parallel()
+	directory := NewInMemoryDirectory()
+	_ = directory.SaveEmployee(context.Background(), DigitalEmployee{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	selector := NewSelector(directory)
+	emp, reason, err := selector.SelectForWorkItem(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}})
+	if err != nil {
+		t.Fatalf("SelectForWorkItem error = %v", err)
+	}
+	if emp.ID != "emp-1" || strings.TrimSpace(reason) == "" {
+		t.Fatalf("emp=%#v reason=%q", emp, reason)
+	}
+}
+
+func TestSelectorRejectsDisabledEmployee(t *testing.T) {
+	t.Parallel()
+	directory := NewInMemoryDirectory()
+	_ = directory.SaveEmployee(context.Background(), DigitalEmployee{ID: "emp-1", Enabled: false, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	selector := NewSelector(directory)
+	_, _, err := selector.SelectForWorkItem(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}})
+	if err == nil {
+		t.Fatal("expected error for disabled employee")
+	}
+}
+
+func TestSelectorRejectsEmployeeMissingRequiredActionType(t *testing.T) {
+	t.Parallel()
+	directory := NewInMemoryDirectory()
+	_ = directory.SaveEmployee(context.Background(), DigitalEmployee{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"other_action"}})
+	selector := NewSelector(directory)
+	_, _, err := selector.SelectForWorkItem(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}})
+	if err == nil {
+		t.Fatal("expected error for missing action type")
+	}
+}
+
+func TestSelectorUsesDeterministicInsertionOrder(t *testing.T) {
+	t.Parallel()
+	directory := NewInMemoryDirectory()
+	_ = directory.SaveEmployee(context.Background(), DigitalEmployee{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	_ = directory.SaveEmployee(context.Background(), DigitalEmployee{ID: "emp-2", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	selector := NewSelector(directory)
+	emp, _, err := selector.SelectForWorkItem(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}})
+	if err != nil {
+		t.Fatalf("SelectForWorkItem error = %v", err)
+	}
+	if emp.ID != "emp-1" {
+		t.Fatalf("selected employee = %#v", emp)
+	}
+}

--- a/internal/employee/service.go
+++ b/internal/employee/service.go
@@ -1,0 +1,63 @@
+package employee
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/eventcore"
+	"kalita/internal/executioncontrol"
+	"kalita/internal/executionruntime"
+	"kalita/internal/workplan"
+)
+
+type employeeService struct {
+	assignments AssignmentRepository
+	selector    Selector
+	runtime     executionruntime.Service
+	log         eventcore.EventLog
+	clock       eventcore.Clock
+	ids         eventcore.IDGenerator
+}
+
+func NewService(assignments AssignmentRepository, selector Selector, runtime executionruntime.Service, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) Service {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &employeeService{assignments: assignments, selector: selector, runtime: runtime, log: log, clock: clock, ids: ids}
+}
+
+func (s *employeeService) AssignAndStartExecution(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata RunMetadata) (Assignment, executionruntime.ExecutionSession, error) {
+	if s.assignments == nil {
+		return Assignment{}, executionruntime.ExecutionSession{}, fmt.Errorf("assignment repository is nil")
+	}
+	if s.selector == nil {
+		return Assignment{}, executionruntime.ExecutionSession{}, fmt.Errorf("employee selector is nil")
+	}
+	if s.runtime == nil {
+		return Assignment{}, executionruntime.ExecutionSession{}, fmt.Errorf("execution runtime service is nil")
+	}
+	employee, reason, err := s.selector.SelectForWorkItem(ctx, wi, plan)
+	if err != nil {
+		return Assignment{}, executionruntime.ExecutionSession{}, err
+	}
+	now := s.clock.Now()
+	assignment := Assignment{ID: s.ids.NewID(), WorkItemID: wi.ID, CaseID: metadata.CaseID, QueueID: metadata.QueueID, EmployeeID: employee.ID, AssignedAt: now, Reason: reason}
+	if err := s.assignments.SaveAssignment(ctx, assignment); err != nil {
+		return Assignment{}, executionruntime.ExecutionSession{}, err
+	}
+	if s.log != nil {
+		meta := executionruntime.ExecutionMetadataFromContext(ctx)
+		if err := s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{ID: s.ids.NewID(), ExecutionID: meta.ExecutionID, CaseID: metadata.CaseID, Step: "employee_assigned", Status: "assigned", OccurredAt: now, CorrelationID: meta.CorrelationID, CausationID: meta.CausationID, Payload: map[string]any{"employee_id": employee.ID, "work_item_id": wi.ID, "case_id": metadata.CaseID, "queue_id": metadata.QueueID, "assignment_id": assignment.ID}}); err != nil {
+			return Assignment{}, executionruntime.ExecutionSession{}, err
+		}
+	}
+	session, err := s.runtime.StartExecution(ctx, plan, constraints, executionruntime.RunMetadata{CaseID: metadata.CaseID, WorkItemID: wi.ID, CoordinationDecisionID: metadata.CoordinationDecisionID, PolicyDecisionID: metadata.PolicyDecisionID})
+	if err != nil {
+		return Assignment{}, executionruntime.ExecutionSession{}, err
+	}
+	return assignment, session, nil
+}

--- a/internal/employee/service_test.go
+++ b/internal/employee/service_test.go
@@ -1,0 +1,85 @@
+package employee
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/eventcore"
+	"kalita/internal/executioncontrol"
+	"kalita/internal/executionruntime"
+	"kalita/internal/workplan"
+)
+
+type staticExecutionRuntime struct {
+	session executionruntime.ExecutionSession
+	err     error
+	calls   int
+}
+
+func (s *staticExecutionRuntime) StartExecution(context.Context, actionplan.ActionPlan, executioncontrol.ExecutionConstraints, executionruntime.RunMetadata) (executionruntime.ExecutionSession, error) {
+	s.calls++
+	return s.session, s.err
+}
+
+func TestEmployeeServiceAssignsEmitsEventAndStartsExecution(t *testing.T) {
+	t.Parallel()
+	directory := NewInMemoryDirectory()
+	_ = directory.SaveEmployee(context.Background(), DigitalEmployee{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	assignments := NewInMemoryAssignmentRepository()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 19, 0, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"assignment-1", "event-1"}}
+	runtimeSvc := &staticExecutionRuntime{session: executionruntime.ExecutionSession{ID: "session-1", Status: executionruntime.ExecutionSessionSucceeded}}
+	service := NewService(assignments, NewSelector(directory), runtimeSvc, eventLog, clock, ids)
+	ctx := executionruntime.ContextWithExecution(context.Background(), executionruntime.ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
+	assignment, session, err := service.AssignAndStartExecution(ctx, workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{ID: "plan-1", Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, executioncontrol.ExecutionConstraints{ID: "constraints-1"}, RunMetadata{CaseID: "case-1", QueueID: "q-1", CoordinationDecisionID: "coord-1", PolicyDecisionID: "policy-1"})
+	if err != nil {
+		t.Fatalf("AssignAndStartExecution error = %v", err)
+	}
+	if assignment.ID != "assignment-1" || session.ID != "session-1" || runtimeSvc.calls != 1 {
+		t.Fatalf("assignment=%#v session=%#v calls=%d", assignment, session, runtimeSvc.calls)
+	}
+	stored, ok, err := assignments.GetAssignment(context.Background(), "assignment-1")
+	if err != nil || !ok || stored.EmployeeID != "emp-1" {
+		t.Fatalf("GetAssignment = %#v ok=%v err=%v", stored, ok, err)
+	}
+	_, execEvents, err := eventLog.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil {
+		t.Fatalf("ListByCorrelation error = %v", err)
+	}
+	if len(execEvents) != 1 || execEvents[0].Step != "employee_assigned" || execEvents[0].Status != "assigned" {
+		t.Fatalf("execEvents = %#v", execEvents)
+	}
+	if execEvents[0].Payload["assignment_id"] != "assignment-1" {
+		t.Fatalf("payload = %#v", execEvents[0].Payload)
+	}
+}
+
+func TestEmployeeServiceFailsWhenNoEligibleEmployeeExists(t *testing.T) {
+	t.Parallel()
+	service := NewService(NewInMemoryAssignmentRepository(), NewSelector(NewInMemoryDirectory()), &staticExecutionRuntime{}, nil, fakeClock{now: time.Now().UTC()}, &fakeIDGenerator{})
+	_, _, err := service.AssignAndStartExecution(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, executioncontrol.ExecutionConstraints{ID: "constraints-1"}, RunMetadata{CaseID: "case-1", QueueID: "q-1"})
+	if err == nil {
+		t.Fatal("expected error when no eligible employee exists")
+	}
+}
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDGenerator struct {
+	ids []string
+	i   int
+}
+
+func (f *fakeIDGenerator) NewID() string {
+	if f.i >= len(f.ids) {
+		return ""
+	}
+	id := f.ids[f.i]
+	f.i++
+	return id
+}

--- a/internal/employee/types.go
+++ b/internal/employee/types.go
@@ -1,0 +1,64 @@
+package employee
+
+import (
+	"context"
+	"time"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/executioncontrol"
+	"kalita/internal/executionruntime"
+	"kalita/internal/workplan"
+)
+
+type DigitalEmployee struct {
+	ID                  string
+	Code                string
+	Role                string
+	Enabled             bool
+	QueueMemberships    []string
+	AllowedActionTypes  []actionplan.ActionType
+	AllowedCommandTypes []string
+	PolicyProfile       string
+	ExecutionProfile    string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type Assignment struct {
+	ID         string
+	WorkItemID string
+	CaseID     string
+	QueueID    string
+	EmployeeID string
+	AssignedAt time.Time
+	Reason     string
+}
+
+type Directory interface {
+	SaveEmployee(ctx context.Context, e DigitalEmployee) error
+	GetEmployee(ctx context.Context, id string) (DigitalEmployee, bool, error)
+	ListEmployees(ctx context.Context) ([]DigitalEmployee, error)
+	ListEmployeesByQueue(ctx context.Context, queueID string) ([]DigitalEmployee, error)
+}
+
+type AssignmentRepository interface {
+	SaveAssignment(ctx context.Context, a Assignment) error
+	GetAssignment(ctx context.Context, id string) (Assignment, bool, error)
+	ListAssignmentsByWorkItem(ctx context.Context, workItemID string) ([]Assignment, error)
+	ListAssignmentsByEmployee(ctx context.Context, employeeID string) ([]Assignment, error)
+}
+
+type Selector interface {
+	SelectForWorkItem(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan) (DigitalEmployee, string, error)
+}
+
+type Service interface {
+	AssignAndStartExecution(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata RunMetadata) (Assignment, executionruntime.ExecutionSession, error)
+}
+
+type RunMetadata struct {
+	CaseID                 string
+	QueueID                string
+	CoordinationDecisionID string
+	PolicyDecisionID       string
+}

--- a/internal/executionruntime/runner.go
+++ b/internal/executionruntime/runner.go
@@ -22,6 +22,10 @@ func executionFromContext(ctx context.Context) ExecutionContext {
 	return meta
 }
 
+func ExecutionMetadataFromContext(ctx context.Context) ExecutionContext {
+	return executionFromContext(ctx)
+}
+
 type DefaultRunner struct {
 	repo     ExecutionRepository
 	wal      WAL

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -11,6 +11,7 @@ import (
 	"kalita/internal/actionplan"
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
+	"kalita/internal/employee"
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
 	"kalita/internal/executionruntime"
@@ -56,14 +57,14 @@ type actionPlanService interface {
 	CreatePlan(ctx context.Context, workItemID string, caseID string, input map[string]any) (actionplan.ActionPlan, error)
 }
 
-type executionRuntimeService interface {
-	StartExecution(ctx context.Context, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata executionruntime.RunMetadata) (executionruntime.ExecutionSession, error)
+type employeeService interface {
+	AssignAndStartExecution(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata employee.RunMetadata) (employee.Assignment, executionruntime.ExecutionSession, error)
 }
 
-func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, executionRuntimeServices ...executionRuntimeService) gin.HandlerFunc {
-	var executionRuntimeService executionRuntimeService
-	if len(executionRuntimeServices) > 0 {
-		executionRuntimeService = executionRuntimeServices[0]
+func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, employeeServices ...employeeService) gin.HandlerFunc {
+	var employeeService employeeService
+	if len(employeeServices) > 0 {
+		employeeService = employeeServices[0]
 	}
 	return func(c *gin.Context) {
 		fqn, action, req, ok := parseActionRequest(c, storage)
@@ -170,9 +171,9 @@ func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.Comm
 								}}})
 								return
 							}
-							if executionRuntimeService != nil {
+							if employeeService != nil {
 								runtimeCtx := executionruntime.ContextWithExecution(c.Request.Context(), executionruntime.ExecutionContext{ExecutionID: intakeResult.Command.ExecutionID, CorrelationID: intakeResult.Command.CorrelationID, CausationID: intakeResult.Command.ID})
-								if _, err := executionRuntimeService.StartExecution(runtimeCtx, plan, constraints, executionruntime.RunMetadata{CaseID: intakeResult.Case.ID, WorkItemID: intakeResult.WorkItem.ID, CoordinationDecisionID: intakeResult.CoordinationDecision.ID, PolicyDecisionID: policyDecision.ID}); err != nil {
+								if _, _, err := employeeService.AssignAndStartExecution(runtimeCtx, intakeResult.WorkItem, plan, constraints, employee.RunMetadata{CaseID: intakeResult.Case.ID, QueueID: intakeResult.WorkItem.QueueID, CoordinationDecisionID: intakeResult.CoordinationDecision.ID, PolicyDecisionID: policyDecision.ID}); err != nil {
 									c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{Code: validation.ErrTypeMismatch, Field: "action", Message: err.Error()}}})
 									return
 								}

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -13,6 +13,7 @@ import (
 	"kalita/internal/actionplan"
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
+	"kalita/internal/employee"
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
 	"kalita/internal/executionruntime"
@@ -300,21 +301,24 @@ func (s *staticActionPlanService) CreatePlan(context.Context, string, string, ma
 	return s.plan, s.err
 }
 
-type staticExecutionRuntimeService struct {
+type staticEmployeeService struct {
+	assignment  employee.Assignment
 	session     executionruntime.ExecutionSession
 	err         error
 	calls       int
 	plans       []actionplan.ActionPlan
 	constraints []executioncontrol.ExecutionConstraints
-	metadata    []executionruntime.RunMetadata
+	metadata    []employee.RunMetadata
+	workItems   []workplan.WorkItem
 }
 
-func (s *staticExecutionRuntimeService) StartExecution(_ context.Context, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata executionruntime.RunMetadata) (executionruntime.ExecutionSession, error) {
+func (s *staticEmployeeService) AssignAndStartExecution(_ context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata employee.RunMetadata) (employee.Assignment, executionruntime.ExecutionSession, error) {
 	s.calls++
+	s.workItems = append(s.workItems, wi)
 	s.plans = append(s.plans, plan)
 	s.constraints = append(s.constraints, constraints)
 	s.metadata = append(s.metadata, metadata)
-	return s.session, s.err
+	return s.assignment, s.session, s.err
 }
 
 func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
@@ -679,7 +683,7 @@ func TestActionHandlerReturnsValidationErrorWhenCommandAdmissionFails(t *testing
 	}
 }
 
-func TestActionHandlerPolicyAllowStartsExecutionSession(t *testing.T) {
+func TestActionHandlerPolicyAllowAssignsEmployeeAndStartsExecutionSession(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
@@ -697,9 +701,9 @@ func TestActionHandlerPolicyAllowStartsExecutionSession(t *testing.T) {
 	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 	actionPlanSvc := &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "legacy workflow action approved for execution", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}
-	executionSvc := &staticExecutionRuntimeService{session: executionruntime.ExecutionSession{ID: "session-1", Status: executionruntime.ExecutionSessionSucceeded}}
+	employeeSvc := &staticEmployeeService{assignment: employee.Assignment{ID: "assignment-1", EmployeeID: "employee-1"}, session: executionruntime.ExecutionSession{ID: "session-1", Status: executionruntime.ExecutionSessionSucceeded}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, actionPlanSvc, executionSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, actionPlanSvc, employeeSvc))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -711,18 +715,18 @@ func TestActionHandlerPolicyAllowStartsExecutionSession(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
 	}
-	if executionSvc.calls != 1 {
-		t.Fatalf("execution calls = %d", executionSvc.calls)
+	if employeeSvc.calls != 1 {
+		t.Fatalf("employee service calls = %d", employeeSvc.calls)
 	}
-	if len(executionSvc.constraints) != 1 || executionSvc.constraints[0].ID != "constraints-1" {
-		t.Fatalf("constraints = %#v", executionSvc.constraints)
+	if len(employeeSvc.constraints) != 1 || employeeSvc.constraints[0].ID != "constraints-1" {
+		t.Fatalf("constraints = %#v", employeeSvc.constraints)
 	}
-	if len(executionSvc.metadata) != 1 || executionSvc.metadata[0].WorkItemID != "work-1" || executionSvc.metadata[0].CaseID != "case-1" {
-		t.Fatalf("metadata = %#v", executionSvc.metadata)
+	if len(employeeSvc.metadata) != 1 || employeeSvc.workItems[0].ID != "work-1" || employeeSvc.metadata[0].CaseID != "case-1" || employeeSvc.metadata[0].QueueID != "default-intake" {
+		t.Fatalf("workItems=%#v metadata=%#v", employeeSvc.workItems, employeeSvc.metadata)
 	}
 }
 
-func TestActionHandlerExecutionStartupFailureReturnsValidationError(t *testing.T) {
+func TestActionHandlerNoEligibleEmployeeReturnsValidationError(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
@@ -739,9 +743,9 @@ func TestActionHandlerExecutionStartupFailureReturnsValidationError(t *testing.T
 	}
 	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
-	executionSvc := &staticExecutionRuntimeService{err: errors.New("execution startup failed")}
+	employeeSvc := &staticEmployeeService{err: errors.New("no eligible digital employee")}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "ready", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}, executionSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "ready", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}, employeeSvc))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -19,7 +19,7 @@ func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus c
 	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil, nil)
 }
 
-func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, executionRuntimeServices ...executionRuntimeService) {
+func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, employeeServices ...employeeService) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -39,7 +39,7 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
-		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService, actionPlanService, executionRuntimeServices...))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService, actionPlanService, employeeServices...))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
 		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))


### PR DESCRIPTION
### Motivation
- Introduce a minimal, deterministic Digital Employee layer as managed actors to enable governed assignment and execution without adding LLM or manager autonomy. 
- Provide an explicit transport-free actor boundary (roles, queue memberships, capability lists, assignment records) that integrates with the existing policy/coordination/actionplan/execution pipeline. 
- Preserve existing legacy compatibility flow while routing the policy-allow path through employee assignment so employees can be used to start execution in a governed way. 

### Description
- Add a new transport-free package `internal/employee` containing `types.go`, `repository.go`, `selector.go`, and `service.go` that define `DigitalEmployee`, `Assignment`, an in-memory `Directory`, an in-memory `AssignmentRepository`, a deterministic `Selector`, and a `Service` that persists an assignment, emits `employee_assigned` execution events, and starts execution via `executionruntime.Service`. 
- Implement thread-safe in-memory repositories that preserve practical insertion order and provide list-by-queue and list-by-work/employee indexes. 
- Implement a deterministic selector (`NewSelector`) that filters only enabled employees in the work item queue and requires the employee to allow all action types in the `ActionPlan`, and returns a non-empty reason; selection is stable by directory insertion order. 
- Implement `employee.Service.AssignAndStartExecution` which creates one `Assignment`, appends a correlated execution event (`Step: "employee_assigned"`, `Status: "assigned"`), and delegates to the existing `executionruntime.Service` to start the session. 
- Wire bootstrap (`internal/app/bootstrap.go`) to construct and expose `EmployeeDirectory`, `AssignmentRepo`, `EmployeeSelector`, and `EmployeeService`, and seed a deterministic default employee (`role: "legacy_operator"`) that can handle the `legacy_workflow_action` on the `default-intake` queue. 
- Extend the legacy compatibility seam (`internal/http/actions.go`) so the policy-allow path now calls the employee service (if provided) to assign and start execution while leaving deny/require-approval behavior unchanged. 
- Add small helper to expose execution metadata from context (`ExecutionMetadataFromContext`) to allow the employee service to write correlated execution events without bypassing the runtime stack. 
- Add unit tests for directory, assignment repo, selector, service behavior, and updated HTTP/ bootstrap integration tests to cover selection, assignment, event emission, execution start, and error cases. 

### Testing
- Ran targeted package tests: `go test -count=1 ./internal/employee` and `go test -run 'TestActionHandlerPolicyAllowAssignsEmployeeAndStartsExecutionSession|TestActionHandlerNoEligibleEmployeeReturnsValidationError' ./internal/http` and the tests passed. 
- Ran broader integration tests: `GOMAXPROCS=2 go test -count=1 ./internal/employee ./internal/app ./internal/http` and `GOMAXPROCS=2 go test -count=1 ./...` and all executed tests completed successfully. 
- New tests added include `internal/employee` repo/selector/service unit tests and updates to `internal/http` and `internal/app` tests to validate the compatibility seam and bootstrap exposure of the employee layer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c06881fe248324b19626906bfe9f68)