### PR TITLE
Add governed Proposal layer (transport-free)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.EmployeeService)
+	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.ProposalService, result.EmployeeDirectory, result.EmployeeService)
 }

--- a/internal/actionplan/compiler.go
+++ b/internal/actionplan/compiler.go
@@ -25,6 +25,10 @@ func executionFromContext(ctx context.Context) ExecutionContext {
 	return meta
 }
 
+func ExecutionMetadataFromContext(ctx context.Context) ExecutionContext {
+	return executionFromContext(ctx)
+}
+
 type DefaultCompiler struct {
 	registry Registry
 	clock    eventcore.Clock

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
 	"kalita/internal/postgres"
+	"kalita/internal/proposal"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
 	"kalita/internal/workplan"
@@ -48,6 +49,10 @@ type BootstrapResult struct {
 	ActionCompiler     actionplan.Compiler
 	ActionValidator    actionplan.Validator
 	ActionPlanService  actionplan.Service
+	ProposalRepo       proposal.Repository
+	ProposalValidator  proposal.Validator
+	ProposalCompiler   proposal.CompilerAdapter
+	ProposalService    proposal.Service
 	EmployeeDirectory  employee.Directory
 	AssignmentRepo     employee.AssignmentRepository
 	EmployeeSelector   employee.Selector
@@ -159,6 +164,10 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	actionCompiler := actionplan.NewCompiler(actionRegistry, clock, ids)
 	actionValidator := actionplan.NewValidator(actionRegistry)
 	actionPlanService := actionplan.NewService(actionCompiler, actionValidator, eventLog, clock, ids)
+	proposalRepo := proposal.NewInMemoryRepository()
+	proposalValidator := proposal.NewValidator()
+	proposalCompiler := proposal.NewCompilerAdapter(actionPlanService)
+	proposalService := proposal.NewService(proposalRepo, proposalValidator, proposalCompiler, eventLog, clock, ids)
 	executionRepo := executionruntime.NewInMemoryExecutionRepository()
 	executionWAL := executionruntime.NewInMemoryWAL()
 	actionExecutor := executionruntime.NewStubExecutor()
@@ -213,6 +222,10 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		ActionCompiler:     actionCompiler,
 		ActionValidator:    actionValidator,
 		ActionPlanService:  actionPlanService,
+		ProposalRepo:       proposalRepo,
+		ProposalValidator:  proposalValidator,
+		ProposalCompiler:   proposalCompiler,
+		ProposalService:    proposalService,
 		EmployeeDirectory:  employeeDirectory,
 		AssignmentRepo:     assignmentRepo,
 		EmployeeSelector:   employeeSelector,

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -110,6 +110,18 @@ func TestBootstrapProvidesEventCenterCaseRuntimeWorkplanPolicyExecutionControlAn
 	if result.ActionExecutor == nil {
 		t.Fatal("ActionExecutor is nil")
 	}
+	if result.ProposalRepo == nil {
+		t.Fatal("ProposalRepo is nil")
+	}
+	if result.ProposalValidator == nil {
+		t.Fatal("ProposalValidator is nil")
+	}
+	if result.ProposalCompiler == nil {
+		t.Fatal("ProposalCompiler is nil")
+	}
+	if result.ProposalService == nil {
+		t.Fatal("ProposalService is nil")
+	}
 	if result.ExecutionRunner == nil {
 		t.Fatal("ExecutionRunner is nil")
 	}

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -16,6 +16,7 @@ import (
 	"kalita/internal/executioncontrol"
 	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
+	"kalita/internal/proposal"
 	"kalita/internal/runtime"
 	"kalita/internal/validation"
 	"kalita/internal/workplan"
@@ -29,11 +30,11 @@ type actionRequest struct {
 }
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, nil, nil, nil, nil, nil, nil, nil)
+	return ActionHandlerWithServices(storage, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.CommandBus) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil, nil, nil, nil)
+	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 type commandCaseResolver interface {
@@ -61,7 +62,13 @@ type employeeService interface {
 	AssignAndStartExecution(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata employee.RunMetadata) (employee.Assignment, executionruntime.ExecutionSession, error)
 }
 
-func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, employeeServices ...employeeService) gin.HandlerFunc {
+type proposalService interface {
+	CreateProposal(ctx context.Context, actor employee.DigitalEmployee, wi workplan.WorkItem, assignment employee.Assignment, payload map[string]any, justification string) (proposal.Proposal, error)
+	ValidateProposal(ctx context.Context, proposalID string, actor employee.DigitalEmployee) (proposal.Proposal, error)
+	CompileProposal(ctx context.Context, proposalID string) (proposal.Proposal, actionplan.ActionPlan, error)
+}
+
+func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, proposalService proposalService, employeeDirectory employee.Directory, employeeServices ...employeeService) gin.HandlerFunc {
 	var employeeService employeeService
 	if len(employeeServices) > 0 {
 		employeeService = employeeServices[0]
@@ -154,7 +161,8 @@ func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.Comm
 								CorrelationID: intakeResult.Command.CorrelationID,
 								CausationID:   intakeResult.Command.ID,
 							})
-							plan, err := actionPlanService.CreatePlan(planCtx, intakeResult.WorkItem.ID, intakeResult.Case.ID, actionPlanInput(fqn, c.Param("id"), action, req))
+							planInput := actionPlanInput(fqn, c.Param("id"), action, req)
+							plan, err := createGovernedPlan(planCtx, actionPlanService, proposalService, employeeDirectory, intakeResult.WorkItem, planInput)
 							if err != nil {
 								c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
 									Code:    validation.ErrTypeMismatch,
@@ -293,4 +301,117 @@ func actionPlanInput(fqn, recordID, action string, req actionRequest) map[string
 			},
 		}},
 	}
+}
+
+func createGovernedPlan(ctx context.Context, actionPlanService actionPlanService, proposalSvc proposalService, directory employee.Directory, wi workplan.WorkItem, input map[string]any) (actionplan.ActionPlan, error) {
+	if proposalSvc == nil || directory == nil {
+		return actionPlanService.CreatePlan(ctx, wi.ID, wi.CaseID, input)
+	}
+	actor, assignment, err := selectProposalActor(ctx, directory, wi, input)
+	if err != nil {
+		return actionplan.ActionPlan{}, err
+	}
+	meta := actionplan.ExecutionMetadataFromContext(ctx)
+	proposalCtx := proposal.ContextWithExecution(ctx, proposal.ExecutionContext{ExecutionID: meta.ExecutionID, CorrelationID: meta.CorrelationID, CausationID: meta.CausationID})
+	created, err := proposalSvc.CreateProposal(proposalCtx, actor, wi, assignment, input, legacyProposalJustification(input))
+	if err != nil {
+		return actionplan.ActionPlan{}, err
+	}
+	validated, err := proposalSvc.ValidateProposal(proposalCtx, created.ID, actor)
+	if err != nil {
+		return actionplan.ActionPlan{}, err
+	}
+	if validated.Status != proposal.ProposalValidated {
+		if validated.RejectionReason == "" {
+			return actionplan.ActionPlan{}, fmt.Errorf("proposal %s rejected", validated.ID)
+		}
+		return actionplan.ActionPlan{}, fmt.Errorf("proposal rejected: %s", validated.RejectionReason)
+	}
+	_, plan, err := proposalSvc.CompileProposal(proposalCtx, validated.ID)
+	if err != nil {
+		return actionplan.ActionPlan{}, err
+	}
+	return plan, nil
+}
+
+func selectProposalActor(ctx context.Context, directory employee.Directory, wi workplan.WorkItem, payload map[string]any) (employee.DigitalEmployee, employee.Assignment, error) {
+	if directory == nil {
+		return employee.DigitalEmployee{}, employee.Assignment{}, fmt.Errorf("employee directory is nil")
+	}
+	actions, err := proposalActionTypes(payload)
+	if err != nil {
+		return employee.DigitalEmployee{}, employee.Assignment{}, err
+	}
+	employees, err := directory.ListEmployeesByQueue(ctx, wi.QueueID)
+	if err != nil {
+		return employee.DigitalEmployee{}, employee.Assignment{}, err
+	}
+	for _, actor := range employees {
+		if !actor.Enabled || !allowsProposalActions(actor, actions) {
+			continue
+		}
+		return actor, employee.Assignment{ID: fmt.Sprintf("proposal-%s-%s", wi.ID, actor.ID), WorkItemID: wi.ID, CaseID: wi.CaseID, QueueID: wi.QueueID, EmployeeID: actor.ID}, nil
+	}
+	return employee.DigitalEmployee{}, employee.Assignment{}, fmt.Errorf("no eligible proposal actor for queue %s and work item %s", wi.QueueID, wi.ID)
+}
+
+func proposalActionTypes(payload map[string]any) ([]actionplan.ActionType, error) {
+	rawActions, ok := payload["actions"]
+	if !ok {
+		return nil, fmt.Errorf("proposal payload actions are required")
+	}
+	items, err := proposalActionItems(rawActions)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]actionplan.ActionType, 0, len(items))
+	for i, item := range items {
+		rawType, _ := item["type"].(string)
+		typeName := actionplan.ActionType(rawType)
+		if typeName == "" {
+			return nil, fmt.Errorf("proposal action %d type is required", i)
+		}
+		out = append(out, typeName)
+	}
+	return out, nil
+}
+
+func proposalActionItems(raw any) ([]map[string]any, error) {
+	switch v := raw.(type) {
+	case []any:
+		out := make([]map[string]any, 0, len(v))
+		for i, item := range v {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("actions[%d] must be an object", i)
+			}
+			out = append(out, m)
+		}
+		return out, nil
+	case []map[string]any:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("actions must be an array")
+	}
+}
+
+func allowsProposalActions(actor employee.DigitalEmployee, actions []actionplan.ActionType) bool {
+	allowed := map[actionplan.ActionType]struct{}{}
+	for _, actionType := range actor.AllowedActionTypes {
+		allowed[actionType] = struct{}{}
+	}
+	for _, actionType := range actions {
+		if _, ok := allowed[actionType]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func legacyProposalJustification(input map[string]any) string {
+	reason, _ := input["reason"].(string)
+	if reason == "" {
+		return "legacy workflow action approved for execution"
+	}
+	return reason
 }

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -18,6 +18,7 @@ import (
 	"kalita/internal/executioncontrol"
 	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
+	"kalita/internal/proposal"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
 	"kalita/internal/workplan"
@@ -290,6 +291,58 @@ func (s *staticConstraintsService) CreateAndRecord(context.Context, workplan.Coo
 	return s.constraints, s.err
 }
 
+type staticProposalService struct {
+	created   []map[string]any
+	validated []string
+	compiled  []string
+	proposal  proposal.Proposal
+	plan      actionplan.ActionPlan
+	err       error
+}
+
+func (s *staticProposalService) CreateProposal(_ context.Context, actor employee.DigitalEmployee, wi workplan.WorkItem, assignment employee.Assignment, payload map[string]any, justification string) (proposal.Proposal, error) {
+	if s.err != nil {
+		return proposal.Proposal{}, s.err
+	}
+	s.created = append(s.created, payload)
+	p := s.proposal
+	if p.ID == "" {
+		p = proposal.Proposal{ID: "proposal-1", Status: proposal.ProposalDraft, ActorID: actor.ID, WorkItemID: wi.ID, AssignmentID: assignment.ID, Payload: payload, Justification: justification}
+	}
+	return p, nil
+}
+func (s *staticProposalService) ValidateProposal(_ context.Context, proposalID string, _ employee.DigitalEmployee) (proposal.Proposal, error) {
+	if s.err != nil {
+		return proposal.Proposal{}, s.err
+	}
+	s.validated = append(s.validated, proposalID)
+	p := s.proposal
+	if p.ID == "" {
+		p.ID = proposalID
+	}
+	if p.Status == "" {
+		p.Status = proposal.ProposalValidated
+	}
+	return p, nil
+}
+func (s *staticProposalService) CompileProposal(_ context.Context, proposalID string) (proposal.Proposal, actionplan.ActionPlan, error) {
+	if s.err != nil {
+		return proposal.Proposal{}, actionplan.ActionPlan{}, s.err
+	}
+	s.compiled = append(s.compiled, proposalID)
+	p := s.proposal
+	if p.ID == "" {
+		p.ID = proposalID
+	}
+	p.Status = proposal.ProposalCompiled
+	plan := s.plan
+	if plan.ID == "" {
+		plan = actionplan.ActionPlan{ID: "action-plan-1"}
+	}
+	p.ActionPlanID = plan.ID
+	return p, plan, nil
+}
+
 type staticActionPlanService struct {
 	plan  actionplan.ActionPlan
 	err   error
@@ -343,7 +396,7 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, coordinator, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -426,7 +479,7 @@ func TestActionHandlerReturnsValidationErrorWhenCaseResolutionFails(t *testing.T
 
 	storage, rec := testHTTPWorkflowStorage()
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -455,7 +508,7 @@ func TestActionHandlerReturnsValidationErrorWhenWorkItemIntakeFails(t *testing.T
 	caseRepo := caseruntime.NewInMemoryCaseRepository()
 	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -491,7 +544,7 @@ func TestActionHandlerReturnsValidationErrorWhenCoordinationFails(t *testing.T) 
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, failingCoordinator{err: errors.New("coordination failed")}, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -528,7 +581,7 @@ func TestActionHandlerPolicyAllowContinuesLegacyFlow(t *testing.T) {
 	router := gin.New()
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
 		decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"},
-	}, nil, nil))
+	}, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -561,7 +614,7 @@ func TestActionHandlerPolicyAllowCreatesAndAttachesActionPlanBeforeLegacyFlow(t 
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 	actionPlanSvc := &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "legacy workflow action approved for execution", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, nil, actionPlanSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, nil, actionPlanSvc, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -607,7 +660,7 @@ func TestActionHandlerPolicyRequireApprovalStopsBeforeLegacyFlow(t *testing.T) {
 	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
 		decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"},
 		approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending},
-	}, nil, nil))
+	}, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -643,7 +696,7 @@ func TestActionHandlerPolicyDenyStopsBeforeLegacyFlow(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -703,7 +756,7 @@ func TestActionHandlerPolicyAllowAssignsEmployeeAndStartsExecutionSession(t *tes
 	actionPlanSvc := &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "legacy workflow action approved for execution", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}
 	employeeSvc := &staticEmployeeService{assignment: employee.Assignment{ID: "assignment-1", EmployeeID: "employee-1"}, session: executionruntime.ExecutionSession{ID: "session-1", Status: executionruntime.ExecutionSessionSucceeded}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, actionPlanSvc, employeeSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, actionPlanSvc, nil, nil, employeeSvc))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -745,7 +798,7 @@ func TestActionHandlerNoEligibleEmployeeReturnsValidationError(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 	employeeSvc := &staticEmployeeService{err: errors.New("no eligible digital employee")}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "ready", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}, employeeSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "ready", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}, nil, nil, employeeSvc))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -870,7 +923,7 @@ func TestActionHandlerReturnsValidationErrorWhenDailyPlanAttachmentFails(t *test
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), failingPlanner{err: errors.New("daily plan failed")}, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -907,7 +960,7 @@ func TestActionHandlerPolicyAllowCreatesConstraintsBeforeLegacyFlow(t *testing.T
 	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -944,7 +997,7 @@ func TestActionHandlerPolicyRequireApprovalRecordsConstraintsAndStopsBeforeLegac
 	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"}, approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending}}, constraintsSvc, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"}, approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending}}, constraintsSvc, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -983,7 +1036,7 @@ func TestActionHandlerPolicyDenyDoesNotCreateConstraintsAndStopsBeforeLegacyFlow
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, constraintsSvc, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, constraintsSvc, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -1020,7 +1073,7 @@ func TestActionHandlerConstraintCreationFailureReturnsValidationError(t *testing
 	constraintsSvc := &staticConstraintsService{err: errors.New("constraints failed")}
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -1034,5 +1087,87 @@ func TestActionHandlerConstraintCreationFailureReturnsValidationError(t *testing
 	}
 	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
 		t.Fatalf("status mutated to %v", got)
+	}
+}
+
+func TestActionHandlerPolicyAllowCreatesProposalValidatesCompilesThenContinues(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 30, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	directory := employee.NewInMemoryDirectory()
+	if err := directory.SaveEmployee(context.Background(), employee.DigitalEmployee{ID: "employee-1", Enabled: true, QueueMemberships: []string{"default-intake"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}}); err != nil {
+		t.Fatalf("SaveEmployee error = %v", err)
+	}
+	proposalSvc := &staticProposalService{plan: actionplan.ActionPlan{ID: "action-plan-1", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action"}}}}
+	employeeSvc := &staticEmployeeService{assignment: employee.Assignment{ID: "assignment-1", EmployeeID: "employee-1"}, session: executionruntime.ExecutionSession{ID: "session-1", Status: executionruntime.ExecutionSessionSucceeded}}
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{}, proposalSvc, directory, employeeSvc))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if len(proposalSvc.created) != 1 || len(proposalSvc.validated) != 1 || len(proposalSvc.compiled) != 1 {
+		t.Fatalf("proposal calls create=%d validate=%d compile=%d", len(proposalSvc.created), len(proposalSvc.validated), len(proposalSvc.compiled))
+	}
+	if employeeSvc.calls != 1 || len(employeeSvc.plans) != 1 || employeeSvc.plans[0].ID != "action-plan-1" {
+		t.Fatalf("employee calls=%d plans=%#v", employeeSvc.calls, employeeSvc.plans)
+	}
+}
+
+func TestActionHandlerInvalidProposalReturnsValidationStyleError(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	storage, rec := testHTTPWorkflowStorage()
+	eventLog := eventcore.NewInMemoryEventLog()
+	clock := fakeClock{now: time.Date(2026, 3, 22, 14, 30, 0, 0, time.UTC)}
+	ids := &fakeIDGenerator{ids: []string{"cmd-1", "corr-1", "exec-1", "admission-event-1", "case-1", "case-event-1", "work-1", "work-event-1", "plan-1", "plan-event-1", "coord-1", "coord-event-1"}}
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	if err := queueRepo.SaveQueue(context.Background(), workplan.WorkQueue{ID: "default-intake", AllowedCaseKinds: []string{"workflow.action"}}); err != nil {
+		t.Fatalf("SaveQueue error = %v", err)
+	}
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
+	directory := employee.NewInMemoryDirectory()
+	_ = directory.SaveEmployee(context.Background(), employee.DigitalEmployee{ID: "employee-1", Enabled: true, QueueMemberships: []string{"default-intake"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	proposalSvc := &staticProposalService{proposal: proposal.Proposal{ID: "proposal-1", Status: proposal.ProposalRejected, RejectionReason: "proposal rejected by deterministic validator"}}
+	router := gin.New()
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, nil, &staticActionPlanService{}, proposalSvc, directory))
+
+	body := map[string]any{"record_version": 3}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/test/WorkflowTask/"+rec.ID+"/_actions/submit", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if len(proposalSvc.compiled) != 0 {
+		t.Fatalf("compile should not be called: %#v", proposalSvc.compiled)
 	}
 }

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -5,6 +5,7 @@ import (
 
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
+	"kalita/internal/employee"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
 
@@ -12,14 +13,14 @@ import (
 )
 
 func RunServer(addr string, storage *runtime.Storage) {
-	RunServerWithServices(addr, storage, nil, nil, nil, nil, nil, nil)
+	RunServerWithServices(addr, storage, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus command.CommandBus) {
-	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil, nil)
+	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil, nil, nil, nil)
 }
 
-func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, employeeServices ...employeeService) {
+func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, proposalService proposalService, employeeDirectory employee.Directory, employeeServices ...employeeService) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -39,7 +40,7 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
-		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService, actionPlanService, employeeServices...))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService, actionPlanService, proposalService, employeeDirectory, employeeServices...))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
 		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))

--- a/internal/proposal/compiler_adapter.go
+++ b/internal/proposal/compiler_adapter.go
@@ -1,0 +1,21 @@
+package proposal
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/actionplan"
+)
+
+type compilerAdapter struct{ service actionplan.Service }
+
+func NewCompilerAdapter(service actionplan.Service) CompilerAdapter {
+	return &compilerAdapter{service: service}
+}
+
+func (a *compilerAdapter) CompileToActionPlan(ctx context.Context, p Proposal) (actionplan.ActionPlan, error) {
+	if a.service == nil {
+		return actionplan.ActionPlan{}, fmt.Errorf("action plan service is nil")
+	}
+	return a.service.CreatePlan(ctx, p.WorkItemID, p.CaseID, cloneMap(p.Payload))
+}

--- a/internal/proposal/repository.go
+++ b/internal/proposal/repository.go
@@ -1,0 +1,128 @@
+package proposal
+
+import (
+	"context"
+	"sync"
+)
+
+type InMemoryRepository struct {
+	mu               sync.RWMutex
+	proposalsByID    map[string]Proposal
+	proposalOrder    []string
+	proposalsByWork  map[string][]string
+	proposalsByActor map[string][]string
+}
+
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{
+		proposalsByID:    map[string]Proposal{},
+		proposalsByWork:  map[string][]string{},
+		proposalsByActor: map[string][]string{},
+	}
+}
+
+func (r *InMemoryRepository) Save(_ context.Context, p Proposal) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.proposalsByID[p.ID]; ok {
+		if existing.WorkItemID != p.WorkItemID {
+			r.proposalsByWork[existing.WorkItemID] = removeString(r.proposalsByWork[existing.WorkItemID], p.ID)
+		}
+		if existing.ActorID != p.ActorID {
+			r.proposalsByActor[existing.ActorID] = removeString(r.proposalsByActor[existing.ActorID], p.ID)
+		}
+	} else {
+		r.proposalOrder = append(r.proposalOrder, p.ID)
+	}
+	r.proposalsByID[p.ID] = cloneProposal(p)
+	if !containsString(r.proposalsByWork[p.WorkItemID], p.ID) {
+		r.proposalsByWork[p.WorkItemID] = append(r.proposalsByWork[p.WorkItemID], p.ID)
+	}
+	if !containsString(r.proposalsByActor[p.ActorID], p.ID) {
+		r.proposalsByActor[p.ActorID] = append(r.proposalsByActor[p.ActorID], p.ID)
+	}
+	return nil
+}
+
+func (r *InMemoryRepository) Get(_ context.Context, id string) (Proposal, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.proposalsByID[id]
+	if !ok {
+		return Proposal{}, false, nil
+	}
+	return cloneProposal(p), true, nil
+}
+
+func (r *InMemoryRepository) ListByWorkItem(_ context.Context, workItemID string) ([]Proposal, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.proposalsByWork[workItemID]
+	out := make([]Proposal, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, cloneProposal(r.proposalsByID[id]))
+	}
+	return out, nil
+}
+
+func (r *InMemoryRepository) ListByActor(_ context.Context, actorID string) ([]Proposal, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.proposalsByActor[actorID]
+	out := make([]Proposal, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, cloneProposal(r.proposalsByID[id]))
+	}
+	return out, nil
+}
+
+func cloneProposal(p Proposal) Proposal {
+	out := p
+	out.Payload = cloneMap(p.Payload)
+	return out
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if in == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = cloneValue(v)
+	}
+	return out
+}
+func cloneSlice(in []any) []any {
+	out := make([]any, len(in))
+	for i, v := range in {
+		out[i] = cloneValue(v)
+	}
+	return out
+}
+func cloneValue(v any) any {
+	switch typed := v.(type) {
+	case map[string]any:
+		return cloneMap(typed)
+	case []any:
+		return cloneSlice(typed)
+	default:
+		return typed
+	}
+}
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+func removeString(items []string, target string) []string {
+	out := items[:0]
+	for _, item := range items {
+		if item != target {
+			out = append(out, item)
+		}
+	}
+	return out
+}

--- a/internal/proposal/repository_test.go
+++ b/internal/proposal/repository_test.go
@@ -1,0 +1,38 @@
+package proposal
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRepositorySaveGetAndList(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	first := Proposal{ID: "p-1", WorkItemID: "w-1", ActorID: "a-1", Payload: map[string]any{"actions": []any{map[string]any{"type": "legacy_workflow_action"}}}}
+	second := Proposal{ID: "p-2", WorkItemID: "w-1", ActorID: "a-2", Payload: map[string]any{"actions": []any{map[string]any{"type": "legacy_workflow_action"}}}}
+	if err := repo.Save(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Save(context.Background(), second); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := repo.Get(context.Background(), "p-1")
+	if err != nil || !ok || got.ID != "p-1" {
+		t.Fatalf("got=%#v ok=%v err=%v", got, ok, err)
+	}
+	listed, err := repo.ListByWorkItem(context.Background(), "w-1")
+	if err != nil || len(listed) != 2 || listed[0].ID != "p-1" || listed[1].ID != "p-2" {
+		t.Fatalf("listed=%#v err=%v", listed, err)
+	}
+}
+
+func TestRepositoryListByActor(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	_ = repo.Save(context.Background(), Proposal{ID: "p-1", WorkItemID: "w-1", ActorID: "a-1"})
+	_ = repo.Save(context.Background(), Proposal{ID: "p-2", WorkItemID: "w-2", ActorID: "a-1"})
+	listed, err := repo.ListByActor(context.Background(), "a-1")
+	if err != nil || len(listed) != 2 {
+		t.Fatalf("listed=%#v err=%v", listed, err)
+	}
+}

--- a/internal/proposal/service.go
+++ b/internal/proposal/service.go
@@ -1,0 +1,132 @@
+package proposal
+
+import (
+	"context"
+	"fmt"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/employee"
+	"kalita/internal/eventcore"
+	"kalita/internal/workplan"
+)
+
+type proposalService struct {
+	repo      Repository
+	validator Validator
+	compiler  CompilerAdapter
+	log       eventcore.EventLog
+	clock     eventcore.Clock
+	ids       eventcore.IDGenerator
+}
+
+func NewService(repo Repository, validator Validator, compiler CompilerAdapter, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) Service {
+	if clock == nil {
+		clock = eventcore.RealClock{}
+	}
+	if ids == nil {
+		ids = eventcore.NewULIDGenerator()
+	}
+	return &proposalService{repo: repo, validator: validator, compiler: compiler, log: log, clock: clock, ids: ids}
+}
+
+func (s *proposalService) CreateProposal(ctx context.Context, actor employee.DigitalEmployee, wi workplan.WorkItem, assignment employee.Assignment, payload map[string]any, justification string) (Proposal, error) {
+	if s.repo == nil {
+		return Proposal{}, fmt.Errorf("proposal repository is nil")
+	}
+	now := s.clock.Now()
+	p := Proposal{ID: s.ids.NewID(), Type: ProposalTypeActionIntent, Status: ProposalDraft, ActorID: actor.ID, CaseID: wi.CaseID, WorkItemID: wi.ID, AssignmentID: assignment.ID, Payload: cloneMap(payload), Justification: justification, CreatedAt: now, UpdatedAt: now}
+	if err := s.repo.Save(ctx, p); err != nil {
+		return Proposal{}, err
+	}
+	if err := s.appendEvent(ctx, p, "proposal_created", string(ProposalDraft), map[string]any{"proposal_id": p.ID, "work_item_id": p.WorkItemID, "actor_id": p.ActorID, "assignment_id": p.AssignmentID}); err != nil {
+		return Proposal{}, err
+	}
+	return p, nil
+}
+
+func (s *proposalService) ValidateProposal(ctx context.Context, proposalID string, actor employee.DigitalEmployee) (Proposal, error) {
+	if s.repo == nil {
+		return Proposal{}, fmt.Errorf("proposal repository is nil")
+	}
+	if s.validator == nil {
+		return Proposal{}, fmt.Errorf("proposal validator is nil")
+	}
+	p, ok, err := s.repo.Get(ctx, proposalID)
+	if err != nil {
+		return Proposal{}, err
+	}
+	if !ok {
+		return Proposal{}, fmt.Errorf("proposal %s not found", proposalID)
+	}
+	status, reason, err := s.validator.Validate(ctx, p, actor)
+	if err != nil {
+		return Proposal{}, err
+	}
+	p.Status = status
+	p.RejectionReason = reason
+	p.UpdatedAt = s.clock.Now()
+	if err := s.repo.Save(ctx, p); err != nil {
+		return Proposal{}, err
+	}
+	step := "proposal_validated"
+	if status == ProposalRejected {
+		step = "proposal_rejected"
+	}
+	if err := s.appendEvent(ctx, p, step, string(status), map[string]any{"proposal_id": p.ID, "work_item_id": p.WorkItemID, "actor_id": p.ActorID, "rejection_reason": p.RejectionReason}); err != nil {
+		return Proposal{}, err
+	}
+	return p, nil
+}
+
+func (s *proposalService) CompileProposal(ctx context.Context, proposalID string) (Proposal, actionplan.ActionPlan, error) {
+	if s.repo == nil {
+		return Proposal{}, actionplan.ActionPlan{}, fmt.Errorf("proposal repository is nil")
+	}
+	if s.compiler == nil {
+		return Proposal{}, actionplan.ActionPlan{}, fmt.Errorf("proposal compiler adapter is nil")
+	}
+	p, ok, err := s.repo.Get(ctx, proposalID)
+	if err != nil {
+		return Proposal{}, actionplan.ActionPlan{}, err
+	}
+	if !ok {
+		return Proposal{}, actionplan.ActionPlan{}, fmt.Errorf("proposal %s not found", proposalID)
+	}
+	if p.Status != ProposalValidated {
+		return Proposal{}, actionplan.ActionPlan{}, fmt.Errorf("proposal %s must be validated before compilation", proposalID)
+	}
+	plan, err := s.compiler.CompileToActionPlan(ctx, p)
+	if err != nil {
+		return Proposal{}, actionplan.ActionPlan{}, err
+	}
+	p.ActionPlanID = plan.ID
+	p.Status = ProposalCompiled
+	p.RejectionReason = ""
+	p.UpdatedAt = s.clock.Now()
+	if err := s.repo.Save(ctx, p); err != nil {
+		return Proposal{}, actionplan.ActionPlan{}, err
+	}
+	if err := s.appendEvent(ctx, p, "proposal_compiled", string(ProposalCompiled), map[string]any{"proposal_id": p.ID, "work_item_id": p.WorkItemID, "actor_id": p.ActorID, "action_plan_id": p.ActionPlanID}); err != nil {
+		return Proposal{}, actionplan.ActionPlan{}, err
+	}
+	return p, plan, nil
+}
+
+func (s *proposalService) appendEvent(ctx context.Context, p Proposal, step, status string, payload map[string]any) error {
+	if s.log == nil {
+		return nil
+	}
+	meta := actionplanExecutionFromContext(ctx)
+	return s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{ID: s.ids.NewID(), ExecutionID: meta.ExecutionID, CaseID: p.CaseID, Step: step, Status: status, OccurredAt: s.clock.Now(), CorrelationID: meta.CorrelationID, CausationID: meta.CausationID, Payload: payload})
+}
+
+type ExecutionContext struct{ ExecutionID, CorrelationID, CausationID string }
+type proposalExecutionContextKey struct{}
+
+func ContextWithExecution(ctx context.Context, meta ExecutionContext) context.Context {
+	return context.WithValue(ctx, proposalExecutionContextKey{}, meta)
+}
+func actionplanExecutionFromContext(ctx context.Context) ExecutionContext {
+	meta, _ := ctx.Value(proposalExecutionContextKey{}).(ExecutionContext)
+	return meta
+}

--- a/internal/proposal/service_test.go
+++ b/internal/proposal/service_test.go
@@ -1,0 +1,86 @@
+package proposal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/employee"
+	"kalita/internal/eventcore"
+	"kalita/internal/workplan"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (f fakeClock) Now() time.Time { return f.now }
+
+type fakeIDs struct {
+	ids []string
+	i   int
+}
+
+func (f *fakeIDs) NewID() string {
+	if f.i >= len(f.ids) {
+		return ""
+	}
+	id := f.ids[f.i]
+	f.i++
+	return id
+}
+
+type staticCompiler struct {
+	plan  actionplan.ActionPlan
+	err   error
+	calls int
+}
+
+func (s *staticCompiler) CompileToActionPlan(context.Context, Proposal) (actionplan.ActionPlan, error) {
+	s.calls++
+	return s.plan, s.err
+}
+
+func TestServiceCreateProposalEmitsEvent(t *testing.T) {
+	log := eventcore.NewInMemoryEventLog()
+	svc := NewService(NewInMemoryRepository(), NewValidator(), &staticCompiler{}, log, fakeClock{now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}, &fakeIDs{ids: []string{"proposal-1", "event-1"}})
+	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
+	proposal, err := svc.CreateProposal(ctx, employee.DigitalEmployee{ID: "emp-1"}, workplan.WorkItem{ID: "work-1", CaseID: "case-1"}, employee.Assignment{ID: "assignment-1"}, map[string]any{"actions": []any{map[string]any{"type": "legacy_workflow_action"}}}, "because")
+	if err != nil || proposal.Status != ProposalDraft {
+		t.Fatalf("proposal=%#v err=%v", proposal, err)
+	}
+	_, events, _ := log.ListByCorrelation(context.Background(), "corr-1")
+	if len(events) != 1 || events[0].Step != "proposal_created" {
+		t.Fatalf("events=%#v", events)
+	}
+}
+
+func TestServiceValidateProposalUpdatesStatus(t *testing.T) {
+	repo := NewInMemoryRepository()
+	_ = repo.Save(context.Background(), Proposal{ID: "proposal-1", Type: ProposalTypeActionIntent, Status: ProposalDraft, ActorID: "emp-1", CaseID: "case-1", WorkItemID: "work-1", Payload: map[string]any{"actions": []any{map[string]any{"type": "legacy_workflow_action"}}}, Justification: "because"})
+	svc := NewService(repo, NewValidator(), &staticCompiler{}, eventcore.NewInMemoryEventLog(), fakeClock{now: time.Now().UTC()}, &fakeIDs{ids: []string{"event-1"}})
+	proposal, err := svc.ValidateProposal(context.Background(), "proposal-1", employee.DigitalEmployee{ID: "emp-1", AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	if err != nil || proposal.Status != ProposalValidated {
+		t.Fatalf("proposal=%#v err=%v", proposal, err)
+	}
+}
+
+func TestRejectedProposalCannotCompile(t *testing.T) {
+	repo := NewInMemoryRepository()
+	_ = repo.Save(context.Background(), Proposal{ID: "proposal-1", Type: ProposalTypeActionIntent, Status: ProposalRejected})
+	svc := NewService(repo, NewValidator(), &staticCompiler{}, nil, fakeClock{now: time.Now().UTC()}, &fakeIDs{})
+	_, _, err := svc.CompileProposal(context.Background(), "proposal-1")
+	if err == nil {
+		t.Fatal("expected compile error")
+	}
+}
+
+func TestValidatedProposalCompilesToActionPlanAndUpdatesProposal(t *testing.T) {
+	repo := NewInMemoryRepository()
+	_ = repo.Save(context.Background(), Proposal{ID: "proposal-1", Type: ProposalTypeActionIntent, Status: ProposalValidated, ActorID: "emp-1", CaseID: "case-1", WorkItemID: "work-1", Payload: map[string]any{"actions": []any{map[string]any{"type": "legacy_workflow_action"}}}, Justification: "because"})
+	compiler := &staticCompiler{plan: actionplan.ActionPlan{ID: "plan-1"}}
+	svc := NewService(repo, NewValidator(), compiler, eventcore.NewInMemoryEventLog(), fakeClock{now: time.Now().UTC()}, &fakeIDs{ids: []string{"event-1"}})
+	proposal, plan, err := svc.CompileProposal(context.Background(), "proposal-1")
+	if err != nil || plan.ID != "plan-1" || proposal.ActionPlanID != "plan-1" || proposal.Status != ProposalCompiled || compiler.calls != 1 {
+		t.Fatalf("proposal=%#v plan=%#v calls=%d err=%v", proposal, plan, compiler.calls, err)
+	}
+}

--- a/internal/proposal/types.go
+++ b/internal/proposal/types.go
@@ -1,0 +1,66 @@
+package proposal
+
+import (
+	"context"
+	"time"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/employee"
+	"kalita/internal/workplan"
+)
+
+type ProposalType string
+
+const (
+	ProposalTypeActionIntent ProposalType = "action_intent"
+)
+
+type ProposalStatus string
+
+const (
+	ProposalDraft     ProposalStatus = "draft"
+	ProposalValidated ProposalStatus = "validated"
+	ProposalRejected  ProposalStatus = "rejected"
+	ProposalCompiled  ProposalStatus = "compiled"
+)
+
+type Proposal struct {
+	ID     string
+	Type   ProposalType
+	Status ProposalStatus
+
+	ActorID      string
+	CaseID       string
+	WorkItemID   string
+	AssignmentID string
+
+	Payload       map[string]any
+	Justification string
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	RejectionReason string
+	ActionPlanID    string
+}
+
+type Repository interface {
+	Save(ctx context.Context, p Proposal) error
+	Get(ctx context.Context, id string) (Proposal, bool, error)
+	ListByWorkItem(ctx context.Context, workItemID string) ([]Proposal, error)
+	ListByActor(ctx context.Context, actorID string) ([]Proposal, error)
+}
+
+type Validator interface {
+	Validate(ctx context.Context, p Proposal, actor employee.DigitalEmployee) (ProposalStatus, string, error)
+}
+
+type CompilerAdapter interface {
+	CompileToActionPlan(ctx context.Context, p Proposal) (actionplan.ActionPlan, error)
+}
+
+type Service interface {
+	CreateProposal(ctx context.Context, actor employee.DigitalEmployee, wi workplan.WorkItem, assignment employee.Assignment, payload map[string]any, justification string) (Proposal, error)
+	ValidateProposal(ctx context.Context, proposalID string, actor employee.DigitalEmployee) (Proposal, error)
+	CompileProposal(ctx context.Context, proposalID string) (Proposal, actionplan.ActionPlan, error)
+}

--- a/internal/proposal/validator.go
+++ b/internal/proposal/validator.go
@@ -1,0 +1,73 @@
+package proposal
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/employee"
+)
+
+type deterministicValidator struct{}
+
+func NewValidator() Validator { return &deterministicValidator{} }
+
+func (v *deterministicValidator) Validate(_ context.Context, p Proposal, actor employee.DigitalEmployee) (ProposalStatus, string, error) {
+	if len(p.Payload) == 0 {
+		return ProposalRejected, "proposal payload is required", nil
+	}
+	if strings.TrimSpace(p.Justification) == "" {
+		return ProposalRejected, "proposal justification is required", nil
+	}
+	switch p.Type {
+	case ProposalTypeActionIntent:
+	default:
+		return ProposalRejected, fmt.Sprintf("proposal type %q is not supported", p.Type), nil
+	}
+	rawActions, ok := p.Payload["actions"]
+	if !ok {
+		return ProposalRejected, "proposal payload actions are required", nil
+	}
+	actions, err := actionItems(rawActions)
+	if err != nil {
+		return ProposalRejected, fmt.Sprintf("proposal payload actions are invalid: %v", err), nil
+	}
+	if len(actions) == 0 {
+		return ProposalRejected, "proposal payload actions are required", nil
+	}
+	allowed := map[actionplan.ActionType]struct{}{}
+	for _, t := range actor.AllowedActionTypes {
+		allowed[t] = struct{}{}
+	}
+	for i, item := range actions {
+		rawType, _ := item["type"].(string)
+		actionType := actionplan.ActionType(strings.TrimSpace(rawType))
+		if actionType == "" {
+			return ProposalRejected, fmt.Sprintf("proposal action %d type is required", i), nil
+		}
+		if _, ok := allowed[actionType]; !ok {
+			return ProposalRejected, fmt.Sprintf("proposal action type %q is not allowed for actor %s", actionType, actor.ID), nil
+		}
+	}
+	return ProposalValidated, "", nil
+}
+
+func actionItems(raw any) ([]map[string]any, error) {
+	switch v := raw.(type) {
+	case []map[string]any:
+		return v, nil
+	case []any:
+		out := make([]map[string]any, 0, len(v))
+		for i, item := range v {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("actions[%d] must be an object", i)
+			}
+			out = append(out, m)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("actions must be an array")
+	}
+}

--- a/internal/proposal/validator_test.go
+++ b/internal/proposal/validator_test.go
@@ -1,0 +1,41 @@
+package proposal
+
+import (
+	"context"
+	"testing"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/employee"
+)
+
+func TestValidatorRejectsEmptyPayload(t *testing.T) {
+	assertValidation(t, Proposal{Type: ProposalTypeActionIntent, Justification: "because"}, ProposalRejected)
+}
+func TestValidatorRejectsEmptyJustification(t *testing.T) {
+	assertValidation(t, Proposal{Type: ProposalTypeActionIntent, Payload: map[string]any{"actions": []any{map[string]any{"type": "legacy_workflow_action"}}}}, ProposalRejected)
+}
+func TestValidatorRejectsMissingActions(t *testing.T) {
+	assertValidation(t, Proposal{Type: ProposalTypeActionIntent, Payload: map[string]any{"reason": "x"}, Justification: "because"}, ProposalRejected)
+}
+func TestValidatorRejectsUnsupportedActionType(t *testing.T) {
+	v := NewValidator()
+	status, reason, err := v.Validate(context.Background(), Proposal{Type: ProposalTypeActionIntent, Payload: map[string]any{"actions": []any{map[string]any{"type": "forbidden_action"}}}, Justification: "because"}, employee.DigitalEmployee{ID: "emp-1", AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	if err != nil || status != ProposalRejected || reason == "" {
+		t.Fatalf("status=%s reason=%q err=%v", status, reason, err)
+	}
+}
+func TestValidatorAcceptsValidProposal(t *testing.T) {
+	v := NewValidator()
+	status, reason, err := v.Validate(context.Background(), Proposal{Type: ProposalTypeActionIntent, Payload: map[string]any{"actions": []any{map[string]any{"type": "legacy_workflow_action"}}}, Justification: "because"}, employee.DigitalEmployee{ID: "emp-1", AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	if err != nil || status != ProposalValidated || reason != "" {
+		t.Fatalf("status=%s reason=%q err=%v", status, reason, err)
+	}
+}
+func assertValidation(t *testing.T, p Proposal, want ProposalStatus) {
+	t.Helper()
+	v := NewValidator()
+	status, reason, err := v.Validate(context.Background(), p, employee.DigitalEmployee{ID: "emp-1", AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	if err != nil || status != want || reason == "" {
+		t.Fatalf("status=%s reason=%q err=%v", status, reason, err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Introduce a minimal, deterministic Proposal artifact as the bounded intelligence layer so assigned actors can produce a structured proposal that is persisted and validated before any ActionPlan compilation. 
- Keep the LLM optional and the flow transport-free and governed, avoiding chat-first/ free-form autonomous execution and ensuring Proposal never bypasses existing ActionPlan validation or execution paths. 
- Provide an in-memory, thread-safe prototype to iterate on governance and integration without changing existing CRUD handlers or execution wiring.

### Description
- Add a new transport-free package `internal/proposal` containing types, an in-memory `Repository`, a deterministic `Validator`, a `CompilerAdapter` that bridges into `actionplan.Service`, and a `Service` implementing create/validate/compile lifecycle with event emission. 
- Wire proposal components into bootstrap so the app constructs and exposes `ProposalRepo`, `ProposalValidator`, `ProposalCompiler`, and `ProposalService` alongside existing action-plan services. 
- Add a minimal compatibility seam in the HTTP action flow that, on policy allow, deterministically selects an eligible digital employee, creates a `Proposal`, validates it, compiles it via the `CompilerAdapter` into an `ActionPlan`, and then continues the existing attach-and-execute path; policy deny/require-approval still stop before compilation. 
- Export a small actionplan execution metadata helper and add unit tests and test stubs to cover repository, validator, service behavior and the HTTP seam without introducing HTTP types into the proposal package.

### Testing
- Added unit tests for the proposal package: `repository_test.go`, `validator_test.go`, and `service_test.go`, which validate save/get/list semantics, deterministic validation rules, and the create/validate/compile lifecycle. 
- Extended HTTP tests to cover the compatibility seam including successful create/validate/compile continuation and rejected-proposal behavior. 
- Ran `go test ./internal/proposal ./internal/http ./internal/app` and then the full suite `go test ./...`, and all executable tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0ccaceb3c8324a946f39ff1bb9f75)