### PR TITLE
Add transport-free capability layer with in-memory repos and deterministic matcher

### DIFF
--- a/internal/capability/matcher.go
+++ b/internal/capability/matcher.go
@@ -1,0 +1,110 @@
+package capability
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/employee"
+	"kalita/internal/workplan"
+)
+
+type deterministicMatcher struct {
+	capabilities CapabilityRepository
+	assignments  ActorCapabilityRepository
+}
+
+func NewMatcher(capabilities CapabilityRepository, assignments ActorCapabilityRepository) Matcher {
+	return &deterministicMatcher{capabilities: capabilities, assignments: assignments}
+}
+
+func (m *deterministicMatcher) MatchActor(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, actors []employee.DigitalEmployee) (employee.DigitalEmployee, string, error) {
+	if m.capabilities == nil {
+		return employee.DigitalEmployee{}, "", fmt.Errorf("capability repository is nil")
+	}
+	if m.assignments == nil {
+		return employee.DigitalEmployee{}, "", fmt.Errorf("actor capability repository is nil")
+	}
+	requiredCodes := requiredCapabilityCodes(plan)
+	for _, actor := range actors {
+		if !actor.Enabled {
+			continue
+		}
+		if !containsString(actor.QueueMemberships, wi.QueueID) {
+			continue
+		}
+		if !allowsAllActionTypes(actor, plan.Actions) {
+			continue
+		}
+		matches, err := m.actorHasCapabilities(ctx, actor.ID, requiredCodes)
+		if err != nil {
+			return employee.DigitalEmployee{}, "", err
+		}
+		if !matches {
+			continue
+		}
+		reason := fmt.Sprintf("selected actor %s for queue %s by deterministic capability match", actor.ID, wi.QueueID)
+		return actor, reason, nil
+	}
+	return employee.DigitalEmployee{}, "", fmt.Errorf("no eligible digital employee for queue %s and work item %s with required capabilities", wi.QueueID, wi.ID)
+}
+
+func (m *deterministicMatcher) actorHasCapabilities(ctx context.Context, actorID string, requiredCodes []string) (bool, error) {
+	assigned, err := m.assignments.ListByActor(ctx, actorID)
+	if err != nil {
+		return false, err
+	}
+	codes := make(map[string]struct{}, len(assigned))
+	for _, assignment := range assigned {
+		capability, ok, err := m.capabilities.GetCapability(ctx, assignment.CapabilityID)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			continue
+		}
+		codes[capability.Code] = struct{}{}
+	}
+	for _, code := range requiredCodes {
+		if _, ok := codes[code]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func requiredCapabilityCodes(plan actionplan.ActionPlan) []string {
+	set := make(map[string]struct{}, len(plan.Actions))
+	for _, action := range plan.Actions {
+		set[string(action.Type)] = struct{}{}
+	}
+	codes := make([]string, 0, len(set))
+	for code := range set {
+		codes = append(codes, code)
+	}
+	sort.Strings(codes)
+	return codes
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func allowsAllActionTypes(actor employee.DigitalEmployee, actions []actionplan.Action) bool {
+	allowed := make(map[actionplan.ActionType]struct{}, len(actor.AllowedActionTypes))
+	for _, actionType := range actor.AllowedActionTypes {
+		allowed[actionType] = struct{}{}
+	}
+	for _, action := range actions {
+		if _, ok := allowed[action.Type]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/capability/matcher_test.go
+++ b/internal/capability/matcher_test.go
@@ -1,0 +1,55 @@
+package capability
+
+import (
+	"context"
+	"testing"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/employee"
+	"kalita/internal/workplan"
+)
+
+func TestMatcherSelectsActorWithRequiredCapability(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	_ = repo.SaveCapability(context.Background(), Capability{ID: "cap-1", Code: "legacy_workflow_action", Type: CapabilitySkill})
+	_ = repo.AssignCapability(context.Background(), ActorCapability{ActorID: "emp-1", CapabilityID: "cap-1", Level: 2})
+	matcher := NewMatcher(repo, repo)
+	actor, reason, err := matcher.MatchActor(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, []employee.DigitalEmployee{{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}}})
+	if err != nil {
+		t.Fatalf("MatchActor error = %v", err)
+	}
+	if actor.ID != "emp-1" || reason == "" {
+		t.Fatalf("actor=%#v reason=%q", actor, reason)
+	}
+}
+
+func TestMatcherRejectsActorWithoutRequiredCapability(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	matcher := NewMatcher(repo, repo)
+	_, _, err := matcher.MatchActor(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, []employee.DigitalEmployee{{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}}})
+	if err == nil {
+		t.Fatal("expected error for missing capability")
+	}
+}
+
+func TestMatcherUsesDeterministicSelectionOrder(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	_ = repo.SaveCapability(context.Background(), Capability{ID: "cap-1", Code: "legacy_workflow_action", Type: CapabilitySkill})
+	_ = repo.AssignCapability(context.Background(), ActorCapability{ActorID: "emp-1", CapabilityID: "cap-1", Level: 1})
+	_ = repo.AssignCapability(context.Background(), ActorCapability{ActorID: "emp-2", CapabilityID: "cap-1", Level: 1})
+	matcher := NewMatcher(repo, repo)
+	actors := []employee.DigitalEmployee{
+		{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}},
+		{ID: "emp-2", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}},
+	}
+	actor, _, err := matcher.MatchActor(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, actors)
+	if err != nil {
+		t.Fatalf("MatchActor error = %v", err)
+	}
+	if actor.ID != "emp-1" {
+		t.Fatalf("selected actor = %#v", actor)
+	}
+}

--- a/internal/capability/repository.go
+++ b/internal/capability/repository.go
@@ -1,0 +1,88 @@
+package capability
+
+import (
+	"context"
+	"sync"
+)
+
+type InMemoryCapabilityRepository struct {
+	mu         sync.RWMutex
+	byID       map[string]Capability
+	order      []string
+	actorByID  map[string][]ActorCapability
+	actorOrder map[string][]string
+}
+
+func NewInMemoryRepository() *InMemoryCapabilityRepository {
+	return &InMemoryCapabilityRepository{
+		byID:       map[string]Capability{},
+		actorByID:  map[string][]ActorCapability{},
+		actorOrder: map[string][]string{},
+	}
+}
+
+func (r *InMemoryCapabilityRepository) SaveCapability(_ context.Context, c Capability) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.byID[c.ID]; !ok {
+		r.order = append(r.order, c.ID)
+	}
+	r.byID[c.ID] = cloneCapability(c)
+	return nil
+}
+
+func (r *InMemoryCapabilityRepository) GetCapability(_ context.Context, id string) (Capability, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.byID[id]
+	if !ok {
+		return Capability{}, false, nil
+	}
+	return cloneCapability(c), true, nil
+}
+
+func (r *InMemoryCapabilityRepository) ListCapabilities(_ context.Context) ([]Capability, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Capability, 0, len(r.order))
+	for _, id := range r.order {
+		out = append(out, cloneCapability(r.byID[id]))
+	}
+	return out, nil
+}
+
+func (r *InMemoryCapabilityRepository) AssignCapability(_ context.Context, ac ActorCapability) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	assignments := r.actorByID[ac.ActorID]
+	for i := range assignments {
+		if assignments[i].CapabilityID == ac.CapabilityID {
+			assignments[i] = ac
+			r.actorByID[ac.ActorID] = assignments
+			return nil
+		}
+	}
+	r.actorByID[ac.ActorID] = append(assignments, ac)
+	r.actorOrder[ac.ActorID] = append(r.actorOrder[ac.ActorID], ac.CapabilityID)
+	return nil
+}
+
+func (r *InMemoryCapabilityRepository) ListByActor(_ context.Context, actorID string) ([]ActorCapability, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	assignments := r.actorByID[actorID]
+	out := make([]ActorCapability, len(assignments))
+	copy(out, assignments)
+	return out, nil
+}
+
+func cloneCapability(c Capability) Capability {
+	out := c
+	if c.Metadata != nil {
+		out.Metadata = make(map[string]any, len(c.Metadata))
+		for k, v := range c.Metadata {
+			out.Metadata[k] = v
+		}
+	}
+	return out
+}

--- a/internal/capability/repository_test.go
+++ b/internal/capability/repository_test.go
@@ -1,0 +1,51 @@
+package capability
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInMemoryRepositorySaveGetListCapabilities(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	capA := Capability{ID: "cap-1", Code: "review", Type: CapabilitySkill, Level: 2, Metadata: map[string]any{"scope": "generic"}}
+	capB := Capability{ID: "cap-2", Code: "approve", Type: CapabilityTool, Level: 1}
+	if err := repo.SaveCapability(context.Background(), capA); err != nil {
+		t.Fatalf("SaveCapability(capA) error = %v", err)
+	}
+	if err := repo.SaveCapability(context.Background(), capB); err != nil {
+		t.Fatalf("SaveCapability(capB) error = %v", err)
+	}
+	got, ok, err := repo.GetCapability(context.Background(), "cap-1")
+	if err != nil || !ok {
+		t.Fatalf("GetCapability ok=%v err=%v", ok, err)
+	}
+	if got.Code != capA.Code || got.Metadata["scope"] != "generic" {
+		t.Fatalf("GetCapability = %#v", got)
+	}
+	list, err := repo.ListCapabilities(context.Background())
+	if err != nil {
+		t.Fatalf("ListCapabilities error = %v", err)
+	}
+	if len(list) != 2 || list[0].ID != "cap-1" || list[1].ID != "cap-2" {
+		t.Fatalf("ListCapabilities = %#v", list)
+	}
+}
+
+func TestInMemoryRepositoryAssignCapabilityPreservesOrder(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	if err := repo.AssignCapability(context.Background(), ActorCapability{ActorID: "emp-1", CapabilityID: "cap-1", Level: 1}); err != nil {
+		t.Fatalf("AssignCapability(cap-1) error = %v", err)
+	}
+	if err := repo.AssignCapability(context.Background(), ActorCapability{ActorID: "emp-1", CapabilityID: "cap-2", Level: 3}); err != nil {
+		t.Fatalf("AssignCapability(cap-2) error = %v", err)
+	}
+	assigned, err := repo.ListByActor(context.Background(), "emp-1")
+	if err != nil {
+		t.Fatalf("ListByActor error = %v", err)
+	}
+	if len(assigned) != 2 || assigned[0].CapabilityID != "cap-1" || assigned[1].CapabilityID != "cap-2" {
+		t.Fatalf("ListByActor = %#v", assigned)
+	}
+}

--- a/internal/capability/service.go
+++ b/internal/capability/service.go
@@ -1,0 +1,34 @@
+package capability
+
+import "context"
+
+type capabilityService struct {
+	capabilities CapabilityRepository
+	assignments  ActorCapabilityRepository
+}
+
+func NewService(capabilities CapabilityRepository, assignments ActorCapabilityRepository) Service {
+	return &capabilityService{capabilities: capabilities, assignments: assignments}
+}
+
+func (s *capabilityService) GetActorCapabilities(ctx context.Context, actorID string) ([]Capability, error) {
+	assigned, err := s.assignments.ListByActor(ctx, actorID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Capability, 0, len(assigned))
+	for _, assignment := range assigned {
+		capability, ok, err := s.capabilities.GetCapability(ctx, assignment.CapabilityID)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if assignment.Level > 0 {
+			capability.Level = assignment.Level
+		}
+		out = append(out, capability)
+	}
+	return out, nil
+}

--- a/internal/capability/service_test.go
+++ b/internal/capability/service_test.go
@@ -1,0 +1,23 @@
+package capability
+
+import (
+	"context"
+	"testing"
+)
+
+func TestServiceReturnsActorCapabilities(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	_ = repo.SaveCapability(context.Background(), Capability{ID: "cap-1", Code: "legacy_workflow_action", Type: CapabilitySkill, Level: 1})
+	_ = repo.SaveCapability(context.Background(), Capability{ID: "cap-2", Code: "approval_tool", Type: CapabilityTool, Level: 1})
+	_ = repo.AssignCapability(context.Background(), ActorCapability{ActorID: "emp-1", CapabilityID: "cap-1", Level: 3})
+	_ = repo.AssignCapability(context.Background(), ActorCapability{ActorID: "emp-1", CapabilityID: "cap-2", Level: 2})
+	service := NewService(repo, repo)
+	caps, err := service.GetActorCapabilities(context.Background(), "emp-1")
+	if err != nil {
+		t.Fatalf("GetActorCapabilities error = %v", err)
+	}
+	if len(caps) != 2 || caps[0].Code != "legacy_workflow_action" || caps[0].Level != 3 || caps[1].Code != "approval_tool" {
+		t.Fatalf("GetActorCapabilities = %#v", caps)
+	}
+}

--- a/internal/capability/types.go
+++ b/internal/capability/types.go
@@ -1,0 +1,54 @@
+package capability
+
+import (
+	"context"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/employee"
+	"kalita/internal/workplan"
+)
+
+type CapabilityType string
+
+const (
+	CapabilitySkill CapabilityType = "skill"
+	CapabilityTool  CapabilityType = "tool"
+)
+
+type Capability struct {
+	ID       string
+	Code     string
+	Type     CapabilityType
+	Level    int
+	Metadata map[string]any
+}
+
+type ActorCapability struct {
+	ActorID      string
+	CapabilityID string
+	Level        int
+}
+
+type CapabilityRepository interface {
+	SaveCapability(ctx context.Context, c Capability) error
+	GetCapability(ctx context.Context, id string) (Capability, bool, error)
+	ListCapabilities(ctx context.Context) ([]Capability, error)
+}
+
+type ActorCapabilityRepository interface {
+	AssignCapability(ctx context.Context, ac ActorCapability) error
+	ListByActor(ctx context.Context, actorID string) ([]ActorCapability, error)
+}
+
+type Matcher interface {
+	MatchActor(
+		ctx context.Context,
+		wi workplan.WorkItem,
+		plan actionplan.ActionPlan,
+		actors []employee.DigitalEmployee,
+	) (employee.DigitalEmployee, string, error)
+}
+
+type Service interface {
+	GetActorCapabilities(ctx context.Context, actorID string) ([]Capability, error)
+}

--- a/internal/employee/selector.go
+++ b/internal/employee/selector.go
@@ -8,9 +8,20 @@ import (
 	"kalita/internal/workplan"
 )
 
-type deterministicSelector struct{ directory Directory }
+type ActorMatcher interface {
+	MatchActor(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, actors []DigitalEmployee) (DigitalEmployee, string, error)
+}
+
+type deterministicSelector struct {
+	directory Directory
+	matcher   ActorMatcher
+}
 
 func NewSelector(directory Directory) Selector { return &deterministicSelector{directory: directory} }
+
+func NewSelectorWithMatcher(directory Directory, matcher ActorMatcher) Selector {
+	return &deterministicSelector{directory: directory, matcher: matcher}
+}
 
 func (s *deterministicSelector) SelectForWorkItem(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan) (DigitalEmployee, string, error) {
 	if s.directory == nil {
@@ -19,6 +30,9 @@ func (s *deterministicSelector) SelectForWorkItem(ctx context.Context, wi workpl
 	employees, err := s.directory.ListEmployeesByQueue(ctx, wi.QueueID)
 	if err != nil {
 		return DigitalEmployee{}, "", err
+	}
+	if s.matcher != nil {
+		return s.matcher.MatchActor(ctx, wi, plan, employees)
 	}
 	for _, employee := range employees {
 		if !employee.Enabled {

--- a/internal/employee/selector_test.go
+++ b/internal/employee/selector_test.go
@@ -59,3 +59,30 @@ func TestSelectorUsesDeterministicInsertionOrder(t *testing.T) {
 		t.Fatalf("selected employee = %#v", emp)
 	}
 }
+
+type stubActorMatcher struct {
+	actor  DigitalEmployee
+	reason string
+	err    error
+	calls  int
+}
+
+func (s *stubActorMatcher) MatchActor(context.Context, workplan.WorkItem, actionplan.ActionPlan, []DigitalEmployee) (DigitalEmployee, string, error) {
+	s.calls++
+	return s.actor, s.reason, s.err
+}
+
+func TestSelectorWithMatcherDelegatesToCapabilityMatcher(t *testing.T) {
+	t.Parallel()
+	directory := NewInMemoryDirectory()
+	_ = directory.SaveEmployee(context.Background(), DigitalEmployee{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	matcher := &stubActorMatcher{actor: DigitalEmployee{ID: "emp-1"}, reason: "matched via capabilities"}
+	selector := NewSelectorWithMatcher(directory, matcher)
+	emp, reason, err := selector.SelectForWorkItem(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}})
+	if err != nil {
+		t.Fatalf("SelectForWorkItem error = %v", err)
+	}
+	if matcher.calls != 1 || emp.ID != "emp-1" || reason != "matched via capabilities" {
+		t.Fatalf("calls=%d emp=%#v reason=%q", matcher.calls, emp, reason)
+	}
+}


### PR DESCRIPTION
### Motivation
- Introduce a transport-free Capability layer so actors are described by structured capabilities (skills/tools) separate from their identity. 
- Keep matching deterministic and transport-free, enabling future deterministic capability-aware selection without LLMs or domain adapters. 
- Preserve existing execution/selection behavior while adding a seam for capability-based selection. 

### Description
- Add new package `internal/capability` that defines `Capability`, `ActorCapability`, repository/service/matcher interfaces, and concrete in-memory, thread-safe implementations. 
- Implement `InMemoryCapabilityRepository` with insertion-order preservation, capability CRUD, actor-capability assignment, and defensive cloning. 
- Implement a deterministic matcher (`NewMatcher`) that enforces existing eligibility rules (`enabled`, queue membership, allowed action types) and requires capabilities by mapping action types to capability codes; it returns a non-empty reason and picks the first matching actor deterministically. 
- Add `capability` service (`NewService`) to resolve an actor's effective capabilities (including actor-level level overrides). 
- Extend `employee` selector with an optional matcher seam (`NewSelectorWithMatcher`) so the legacy selector stays unchanged and future capability-aware selection can be wired in without changing runtime flows. 
- Add unit tests covering capability repository (`repository_test.go`), matcher (`matcher_test.go`), service (`service_test.go`), and selector delegation (`selector_test.go`). 

### Testing
- Ran `go test -count=1 ./internal/capability ./internal/employee` and all tests in those packages passed. 
- Added and ran unit tests: `TestInMemoryRepositorySaveGetListCapabilities`, `TestInMemoryRepositoryAssignCapabilityPreservesOrder`, `TestMatcherSelectsActorWithRequiredCapability`, `TestMatcherRejectsActorWithoutRequiredCapability`, `TestMatcherUsesDeterministicSelectionOrder`, `TestServiceReturnsActorCapabilities`, and `TestSelectorWithMatcherDelegatesToCapabilityMatcher`, all of which passed. 
- Attempted `go test ./internal/app` bootstrap test but it did not complete within the local run window and was not included in the validated set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d30a67bc8324bb85e61dcac10826)