### PR TITLE
Add deterministic competency/profile matching layer (internal/profile)

### DIFF
--- a/internal/employee/selector.go
+++ b/internal/employee/selector.go
@@ -23,6 +23,10 @@ func NewSelectorWithMatcher(directory Directory, matcher ActorMatcher) Selector 
 	return &deterministicSelector{directory: directory, matcher: matcher}
 }
 
+func NewSelectorWithActorMatcher(directory Directory, matcher ActorMatcher) Selector {
+	return NewSelectorWithMatcher(directory, matcher)
+}
+
 func (s *deterministicSelector) SelectForWorkItem(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan) (DigitalEmployee, string, error) {
 	if s.directory == nil {
 		return DigitalEmployee{}, "", fmt.Errorf("employee directory is nil")

--- a/internal/profile/matcher.go
+++ b/internal/profile/matcher.go
@@ -1,0 +1,162 @@
+package profile
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/capability"
+	"kalita/internal/employee"
+	"kalita/internal/workplan"
+)
+
+type deterministicMatcher struct {
+	requirements RequirementRepository
+	profiles     Repository
+	capabilities capability.CapabilityRepository
+	assignments  capability.ActorCapabilityRepository
+}
+
+func NewMatcher(requirements RequirementRepository, profiles Repository, capabilities capability.CapabilityRepository, assignments capability.ActorCapabilityRepository) Matcher {
+	return &deterministicMatcher{requirements: requirements, profiles: profiles, capabilities: capabilities, assignments: assignments}
+}
+
+func (m *deterministicMatcher) MatchActor(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, actors []employee.DigitalEmployee) (employee.DigitalEmployee, string, error) {
+	if m.requirements == nil {
+		return employee.DigitalEmployee{}, "", fmt.Errorf("requirement repository is nil")
+	}
+	if m.capabilities == nil {
+		return employee.DigitalEmployee{}, "", fmt.Errorf("capability repository is nil")
+	}
+	if m.assignments == nil {
+		return employee.DigitalEmployee{}, "", fmt.Errorf("actor capability repository is nil")
+	}
+	requirementsByAction, err := m.requirementsByAction(ctx)
+	if err != nil {
+		return employee.DigitalEmployee{}, "", err
+	}
+	complexity := len(plan.Actions)
+
+	var selected employee.DigitalEmployee
+	selectedPreferred := false
+	selectedFound := false
+	selectedReason := ""
+	for _, actor := range actors {
+		if !actor.Enabled || !containsString(actor.QueueMemberships, wi.QueueID) || !allowsAllActionTypes(actor, plan.Actions) {
+			continue
+		}
+		eligible, reason, preferred, err := m.evaluateActor(ctx, actor, wi, plan, complexity, requirementsByAction)
+		if err != nil {
+			return employee.DigitalEmployee{}, "", err
+		}
+		if !eligible {
+			continue
+		}
+		if !selectedFound || (preferred && !selectedPreferred) {
+			selected = actor
+			selectedPreferred = preferred
+			selectedFound = true
+			selectedReason = reason
+		}
+	}
+	if selectedFound {
+		return selected, selectedReason, nil
+	}
+	return employee.DigitalEmployee{}, "", fmt.Errorf("no eligible digital employee for queue %s and work item %s with required competencies", wi.QueueID, wi.ID)
+}
+
+func (m *deterministicMatcher) evaluateActor(ctx context.Context, actor employee.DigitalEmployee, wi workplan.WorkItem, plan actionplan.ActionPlan, complexity int, requirementsByAction map[actionplan.ActionType]CapabilityRequirement) (bool, string, bool, error) {
+	capabilitiesByCode, err := m.actorCapabilitiesByCode(ctx, actor.ID)
+	if err != nil {
+		return false, "", false, err
+	}
+	for _, action := range plan.Actions {
+		req, ok := requirementsByAction[action.Type]
+		if !ok {
+			return false, "", false, nil
+		}
+		for _, code := range req.CapabilityCodes {
+			level, ok := capabilitiesByCode[code]
+			if !ok || level < req.MinimumLevel {
+				return false, "", false, nil
+			}
+		}
+	}
+	preferred := false
+	reasonParts := []string{fmt.Sprintf("selected actor %s for queue %s by deterministic competency match", actor.ID, wi.QueueID)}
+	if m.profiles != nil {
+		profile, ok, err := m.profiles.GetProfileByActor(ctx, actor.ID)
+		if err != nil {
+			return false, "", false, err
+		}
+		if ok {
+			if profile.MaxComplexity > 0 && profile.MaxComplexity < complexity {
+				return false, "", false, nil
+			}
+			preferred = containsString(profile.PreferredWorkKinds, wi.Type)
+			reasonParts = append(reasonParts, fmt.Sprintf("profile %s supports complexity %d", profile.ID, complexity))
+			if preferred {
+				reasonParts = append(reasonParts, fmt.Sprintf("preferred work kind %s matched", wi.Type))
+			}
+		}
+	}
+	return true, strings.Join(reasonParts, "; "), preferred, nil
+}
+
+func (m *deterministicMatcher) requirementsByAction(ctx context.Context) (map[actionplan.ActionType]CapabilityRequirement, error) {
+	requirements, err := m.requirements.ListRequirements(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[actionplan.ActionType]CapabilityRequirement, len(requirements))
+	for _, req := range requirements {
+		out[req.ActionType] = req
+	}
+	return out, nil
+}
+
+func (m *deterministicMatcher) actorCapabilitiesByCode(ctx context.Context, actorID string) (map[string]int, error) {
+	assigned, err := m.assignments.ListByActor(ctx, actorID)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]int, len(assigned))
+	for _, assignment := range assigned {
+		capabilityDef, ok, err := m.capabilities.GetCapability(ctx, assignment.CapabilityID)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		level := capabilityDef.Level
+		if assignment.Level > level {
+			level = assignment.Level
+		}
+		out[capabilityDef.Code] = level
+	}
+	return out, nil
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func allowsAllActionTypes(actor employee.DigitalEmployee, actions []actionplan.Action) bool {
+	allowed := make(map[actionplan.ActionType]struct{}, len(actor.AllowedActionTypes))
+	for _, actionType := range actor.AllowedActionTypes {
+		allowed[actionType] = struct{}{}
+	}
+	for _, action := range actions {
+		if _, ok := allowed[action.Type]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/profile/matcher_test.go
+++ b/internal/profile/matcher_test.go
@@ -1,0 +1,91 @@
+package profile
+
+import (
+	"context"
+	"testing"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/capability"
+	"kalita/internal/employee"
+	"kalita/internal/workplan"
+)
+
+func TestMatcherRejectsActorBelowMinimumCapabilityLevel(t *testing.T) {
+	t.Parallel()
+	profiles := NewInMemoryRepository()
+	caps := capability.NewInMemoryRepository()
+	ctx := context.Background()
+	_ = profiles.SaveRequirement(ctx, CapabilityRequirement{ActionType: "legacy_workflow_action", CapabilityCodes: []string{"workflow.execute"}, MinimumLevel: 3})
+	_ = caps.SaveCapability(ctx, capability.Capability{ID: "cap-1", Code: "workflow.execute", Level: 1})
+	_ = caps.AssignCapability(ctx, capability.ActorCapability{ActorID: "emp-1", CapabilityID: "cap-1", Level: 2})
+	matcher := NewMatcher(profiles, profiles, caps, caps)
+	_, _, err := matcher.MatchActor(ctx, workplan.WorkItem{ID: "work-1", QueueID: "q-1", Type: "review"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, []employee.DigitalEmployee{{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}}})
+	if err == nil {
+		t.Fatal("expected error for actor below minimum capability level")
+	}
+}
+
+func TestMatcherRejectsActorWhoseMaxComplexityIsTooLow(t *testing.T) {
+	t.Parallel()
+	profiles := NewInMemoryRepository()
+	caps := capability.NewInMemoryRepository()
+	ctx := context.Background()
+	_ = profiles.SaveRequirement(ctx, CapabilityRequirement{ActionType: "legacy_workflow_action", CapabilityCodes: []string{"workflow.execute"}, MinimumLevel: 2})
+	_ = profiles.SaveProfile(ctx, CompetencyProfile{ID: "profile-1", ActorID: "emp-1", MaxComplexity: 1})
+	_ = caps.SaveCapability(ctx, capability.Capability{ID: "cap-1", Code: "workflow.execute", Level: 2})
+	_ = caps.AssignCapability(ctx, capability.ActorCapability{ActorID: "emp-1", CapabilityID: "cap-1", Level: 2})
+	matcher := NewMatcher(profiles, profiles, caps, caps)
+	plan := actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}, {ID: "a-2", Type: "legacy_workflow_action"}}}
+	_, _, err := matcher.MatchActor(ctx, workplan.WorkItem{ID: "work-1", QueueID: "q-1", Type: "review"}, plan, []employee.DigitalEmployee{{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}}})
+	if err == nil {
+		t.Fatal("expected error for actor below max complexity")
+	}
+}
+
+func TestMatcherPrefersActorWhoseProfileMatchesPreferredWorkKinds(t *testing.T) {
+	t.Parallel()
+	profiles := NewInMemoryRepository()
+	caps := capability.NewInMemoryRepository()
+	ctx := context.Background()
+	_ = profiles.SaveRequirement(ctx, CapabilityRequirement{ActionType: "legacy_workflow_action", CapabilityCodes: []string{"workflow.execute"}, MinimumLevel: 1})
+	_ = profiles.SaveProfile(ctx, CompetencyProfile{ID: "profile-1", ActorID: "emp-1", MaxComplexity: 3})
+	_ = profiles.SaveProfile(ctx, CompetencyProfile{ID: "profile-2", ActorID: "emp-2", MaxComplexity: 3, PreferredWorkKinds: []string{"review"}})
+	_ = caps.SaveCapability(ctx, capability.Capability{ID: "cap-1", Code: "workflow.execute", Level: 1})
+	_ = caps.AssignCapability(ctx, capability.ActorCapability{ActorID: "emp-1", CapabilityID: "cap-1", Level: 1})
+	_ = caps.AssignCapability(ctx, capability.ActorCapability{ActorID: "emp-2", CapabilityID: "cap-1", Level: 1})
+	matcher := NewMatcher(profiles, profiles, caps, caps)
+	actors := []employee.DigitalEmployee{
+		{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}},
+		{ID: "emp-2", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}},
+	}
+	actor, reason, err := matcher.MatchActor(ctx, workplan.WorkItem{ID: "work-1", QueueID: "q-1", Type: "review"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, actors)
+	if err != nil {
+		t.Fatalf("MatchActor error = %v", err)
+	}
+	if actor.ID != "emp-2" || reason == "" {
+		t.Fatalf("actor=%#v reason=%q", actor, reason)
+	}
+}
+
+func TestMatcherUsesDeterministicSelectionWhenMultipleActorsMatch(t *testing.T) {
+	t.Parallel()
+	profiles := NewInMemoryRepository()
+	caps := capability.NewInMemoryRepository()
+	ctx := context.Background()
+	_ = profiles.SaveRequirement(ctx, CapabilityRequirement{ActionType: "legacy_workflow_action", CapabilityCodes: []string{"workflow.execute"}, MinimumLevel: 1})
+	_ = caps.SaveCapability(ctx, capability.Capability{ID: "cap-1", Code: "workflow.execute", Level: 1})
+	_ = caps.AssignCapability(ctx, capability.ActorCapability{ActorID: "emp-1", CapabilityID: "cap-1", Level: 1})
+	_ = caps.AssignCapability(ctx, capability.ActorCapability{ActorID: "emp-2", CapabilityID: "cap-1", Level: 1})
+	matcher := NewMatcher(profiles, profiles, caps, caps)
+	actors := []employee.DigitalEmployee{
+		{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}},
+		{ID: "emp-2", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}},
+	}
+	actor, _, err := matcher.MatchActor(ctx, workplan.WorkItem{ID: "work-1", QueueID: "q-1", Type: "review"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, actors)
+	if err != nil {
+		t.Fatalf("MatchActor error = %v", err)
+	}
+	if actor.ID != "emp-1" {
+		t.Fatalf("selected actor = %#v", actor)
+	}
+}

--- a/internal/profile/repository.go
+++ b/internal/profile/repository.go
@@ -1,0 +1,114 @@
+package profile
+
+import (
+	"context"
+	"sync"
+
+	"kalita/internal/actionplan"
+)
+
+type InMemoryRepository struct {
+	mu                   sync.RWMutex
+	profilesByID         map[string]CompetencyProfile
+	profileOrder         []string
+	profileByActor       map[string]string
+	requirementsByAction map[actionplan.ActionType]CapabilityRequirement
+	requirementOrder     []actionplan.ActionType
+}
+
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{
+		profilesByID:         make(map[string]CompetencyProfile),
+		profileByActor:       make(map[string]string),
+		requirementsByAction: make(map[actionplan.ActionType]CapabilityRequirement),
+	}
+}
+
+func (r *InMemoryRepository) SaveProfile(_ context.Context, p CompetencyProfile) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.profilesByID[p.ID]; ok {
+		if existing.ActorID != "" && existing.ActorID != p.ActorID {
+			delete(r.profileByActor, existing.ActorID)
+		}
+	} else {
+		r.profileOrder = append(r.profileOrder, p.ID)
+	}
+	r.profilesByID[p.ID] = cloneProfile(p)
+	if p.ActorID != "" {
+		r.profileByActor[p.ActorID] = p.ID
+	}
+	return nil
+}
+
+func (r *InMemoryRepository) GetProfile(_ context.Context, id string) (CompetencyProfile, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.profilesByID[id]
+	if !ok {
+		return CompetencyProfile{}, false, nil
+	}
+	return cloneProfile(p), true, nil
+}
+
+func (r *InMemoryRepository) GetProfileByActor(_ context.Context, actorID string) (CompetencyProfile, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	id, ok := r.profileByActor[actorID]
+	if !ok {
+		return CompetencyProfile{}, false, nil
+	}
+	p, ok := r.profilesByID[id]
+	if !ok {
+		return CompetencyProfile{}, false, nil
+	}
+	return cloneProfile(p), true, nil
+}
+
+func (r *InMemoryRepository) ListProfiles(_ context.Context) ([]CompetencyProfile, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]CompetencyProfile, 0, len(r.profileOrder))
+	for _, id := range r.profileOrder {
+		out = append(out, cloneProfile(r.profilesByID[id]))
+	}
+	return out, nil
+}
+
+func (r *InMemoryRepository) SaveRequirement(_ context.Context, req CapabilityRequirement) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.requirementsByAction[req.ActionType]; !ok {
+		r.requirementOrder = append(r.requirementOrder, req.ActionType)
+	}
+	r.requirementsByAction[req.ActionType] = cloneRequirement(req)
+	return nil
+}
+
+func (r *InMemoryRepository) ListRequirements(_ context.Context) ([]CapabilityRequirement, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]CapabilityRequirement, 0, len(r.requirementOrder))
+	for _, actionType := range r.requirementOrder {
+		out = append(out, cloneRequirement(r.requirementsByAction[actionType]))
+	}
+	return out, nil
+}
+
+func cloneProfile(p CompetencyProfile) CompetencyProfile {
+	out := p
+	out.PreferredWorkKinds = append([]string(nil), p.PreferredWorkKinds...)
+	if p.Metadata != nil {
+		out.Metadata = make(map[string]any, len(p.Metadata))
+		for k, v := range p.Metadata {
+			out.Metadata[k] = v
+		}
+	}
+	return out
+}
+
+func cloneRequirement(r CapabilityRequirement) CapabilityRequirement {
+	out := r
+	out.CapabilityCodes = append([]string(nil), r.CapabilityCodes...)
+	return out
+}

--- a/internal/profile/repository_test.go
+++ b/internal/profile/repository_test.go
@@ -1,0 +1,57 @@
+package profile
+
+import (
+	"context"
+	"testing"
+
+	"kalita/internal/actionplan"
+)
+
+func TestInMemoryRepositorySaveGetAndListProfiles(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	ctx := context.Background()
+	if err := repo.SaveProfile(ctx, CompetencyProfile{ID: "profile-1", ActorID: "emp-1", Name: "Careful", MaxComplexity: 3, PreferredWorkKinds: []string{"review"}, Metadata: map[string]any{"mode": "deterministic"}}); err != nil {
+		t.Fatalf("SaveProfile error = %v", err)
+	}
+	if err := repo.SaveProfile(ctx, CompetencyProfile{ID: "profile-2", ActorID: "emp-2", Name: "Fast", MaxComplexity: 5}); err != nil {
+		t.Fatalf("SaveProfile error = %v", err)
+	}
+	profile, ok, err := repo.GetProfile(ctx, "profile-1")
+	if err != nil || !ok {
+		t.Fatalf("GetProfile ok=%v err=%v", ok, err)
+	}
+	if profile.ActorID != "emp-1" || profile.Metadata["mode"] != "deterministic" {
+		t.Fatalf("GetProfile = %#v", profile)
+	}
+	byActor, ok, err := repo.GetProfileByActor(ctx, "emp-2")
+	if err != nil || !ok || byActor.ID != "profile-2" {
+		t.Fatalf("GetProfileByActor profile=%#v ok=%v err=%v", byActor, ok, err)
+	}
+	profiles, err := repo.ListProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListProfiles error = %v", err)
+	}
+	if len(profiles) != 2 || profiles[0].ID != "profile-1" || profiles[1].ID != "profile-2" {
+		t.Fatalf("ListProfiles = %#v", profiles)
+	}
+}
+
+func TestInMemoryRepositorySaveAndListRequirements(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	ctx := context.Background()
+	if err := repo.SaveRequirement(ctx, CapabilityRequirement{ActionType: actionplan.ActionType("legacy_workflow_action"), CapabilityCodes: []string{"workflow.execute"}, MinimumLevel: 2}); err != nil {
+		t.Fatalf("SaveRequirement error = %v", err)
+	}
+	if err := repo.SaveRequirement(ctx, CapabilityRequirement{ActionType: actionplan.ActionType("approval_action"), CapabilityCodes: []string{"approval.review"}, MinimumLevel: 1}); err != nil {
+		t.Fatalf("SaveRequirement error = %v", err)
+	}
+	requirements, err := repo.ListRequirements(ctx)
+	if err != nil {
+		t.Fatalf("ListRequirements error = %v", err)
+	}
+	if len(requirements) != 2 || requirements[0].ActionType != "legacy_workflow_action" || requirements[1].ActionType != "approval_action" {
+		t.Fatalf("ListRequirements = %#v", requirements)
+	}
+}

--- a/internal/profile/service.go
+++ b/internal/profile/service.go
@@ -1,0 +1,18 @@
+package profile
+
+import "context"
+
+type profileService struct {
+	repository Repository
+}
+
+func NewService(repository Repository) Service {
+	return &profileService{repository: repository}
+}
+
+func (s *profileService) GetActorProfile(ctx context.Context, actorID string) (CompetencyProfile, bool, error) {
+	if s.repository == nil {
+		return CompetencyProfile{}, false, nil
+	}
+	return s.repository.GetProfileByActor(ctx, actorID)
+}

--- a/internal/profile/service_test.go
+++ b/internal/profile/service_test.go
@@ -1,0 +1,21 @@
+package profile
+
+import (
+	"context"
+	"testing"
+)
+
+func TestServiceReturnsActorProfile(t *testing.T) {
+	t.Parallel()
+	repo := NewInMemoryRepository()
+	ctx := context.Background()
+	_ = repo.SaveProfile(ctx, CompetencyProfile{ID: "profile-1", ActorID: "emp-1", Name: "Balanced", MaxComplexity: 2})
+	service := NewService(repo)
+	profile, ok, err := service.GetActorProfile(ctx, "emp-1")
+	if err != nil {
+		t.Fatalf("GetActorProfile error = %v", err)
+	}
+	if !ok || profile.ID != "profile-1" {
+		t.Fatalf("profile=%#v ok=%v", profile, ok)
+	}
+}

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -1,0 +1,56 @@
+package profile
+
+import (
+	"context"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/employee"
+	"kalita/internal/workplan"
+)
+
+type ExecutionStyle string
+
+const (
+	ExecutionStyleCareful     ExecutionStyle = "careful"
+	ExecutionStyleFast        ExecutionStyle = "fast"
+	ExecutionStyleBalanced    ExecutionStyle = "balanced"
+	ExecutionStyleStrict      ExecutionStyle = "strict"
+	ExecutionStyleExploratory ExecutionStyle = "exploratory"
+)
+
+type CompetencyProfile struct {
+	ID                 string
+	ActorID            string
+	Name               string
+	ExecutionStyle     ExecutionStyle
+	MaxComplexity      int
+	MaxRiskLevel       string
+	PreferredWorkKinds []string
+	Metadata           map[string]any
+}
+
+type CapabilityRequirement struct {
+	ActionType      actionplan.ActionType
+	CapabilityCodes []string
+	MinimumLevel    int
+}
+
+type Repository interface {
+	SaveProfile(ctx context.Context, p CompetencyProfile) error
+	GetProfile(ctx context.Context, id string) (CompetencyProfile, bool, error)
+	GetProfileByActor(ctx context.Context, actorID string) (CompetencyProfile, bool, error)
+	ListProfiles(ctx context.Context) ([]CompetencyProfile, error)
+}
+
+type RequirementRepository interface {
+	SaveRequirement(ctx context.Context, r CapabilityRequirement) error
+	ListRequirements(ctx context.Context) ([]CapabilityRequirement, error)
+}
+
+type Matcher interface {
+	MatchActor(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, actors []employee.DigitalEmployee) (employee.DigitalEmployee, string, error)
+}
+
+type Service interface {
+	GetActorProfile(ctx context.Context, actorID string) (CompetencyProfile, bool, error)
+}


### PR DESCRIPTION
### Motivation
- Enable actor selection to consider how an actor tends to work (competency/profile) in addition to raw capabilities. 
- Keep the model transport-free, deterministic, domain-agnostic, and in-memory so it can be safely composed with existing layers. 
- Provide a clear seam so profile-aware matchers can be wired in later without changing existing runtime wiring. 

### Description
- Add a new `internal/profile` package with types, in-memory repositories, a deterministic matcher, and a small service API (`types.go`, `repository.go`, `matcher.go`, `service.go`).
- Implement a thread-safe in-memory `Repository` that preserves insertion order and supports `Save/Get/List` for profiles and capability requirements, with defensive cloning for slices/maps.
- Implement the deterministic matcher that: enforces prior eligibility gates (`Enabled`, queue membership, allowed action types), resolves capability requirements via `RequirementRepository` (uses `CapabilityCodes` + `MinimumLevel`), rejects actors below required capability levels, enforces a deterministic complexity score (`complexity = len(plan.Actions)`) against `CompetencyProfile.MaxComplexity`, prefers actors whose `PreferredWorkKinds` match the `WorkItem.Type`, and breaks ties deterministically by iteration order while returning a non-empty reason.
- Add `NewSelectorWithActorMatcher` alias in the employee selector to expose the actor matcher seam without changing existing wiring.
- Add unit tests for repository behavior, requirement persistence, matcher cases (minimum capability level, max complexity, preferred work kinds, deterministic tie-breaking), and the profile service.

### Testing
- Ran `go test ./internal/profile` and the package unit tests passed. 
- Ran `go test ./internal/employee ./internal/capability` and those unit tests passed. 
- Ran `go test ./internal/app` (no lightweight tests to run); the heavier `TestBootstrap` integration run timed out in this environment (`timeout` exit in CI session), but unit-level tests for the touched packages succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d52a1a288324a03cad02543856fc)