### PR TITLE
Add deterministic actor trust layer (internal/trust)

### DIFF
--- a/internal/trust/repository.go
+++ b/internal/trust/repository.go
@@ -1,0 +1,46 @@
+package trust
+
+import (
+	"context"
+	"sync"
+)
+
+type InMemoryRepository struct {
+	mu          sync.RWMutex
+	byActorID   map[string]TrustProfile
+	actorIDList []string
+}
+
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{byActorID: make(map[string]TrustProfile)}
+}
+
+func (r *InMemoryRepository) Save(_ context.Context, p TrustProfile) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.byActorID[p.ActorID]; !ok {
+		r.actorIDList = append(r.actorIDList, p.ActorID)
+	}
+	r.byActorID[p.ActorID] = p
+	return nil
+}
+
+func (r *InMemoryRepository) GetByActor(_ context.Context, actorID string) (TrustProfile, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.byActorID[actorID]
+	if !ok {
+		return TrustProfile{}, false, nil
+	}
+	return p, true, nil
+}
+
+func (r *InMemoryRepository) List(_ context.Context) ([]TrustProfile, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]TrustProfile, 0, len(r.actorIDList))
+	for _, actorID := range r.actorIDList {
+		out = append(out, r.byActorID[actorID])
+	}
+	return out, nil
+}

--- a/internal/trust/repository_test.go
+++ b/internal/trust/repository_test.go
@@ -1,0 +1,35 @@
+package trust
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryRepositorySaveGetList(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := NewInMemoryRepository()
+	first := TrustProfile{ActorID: "actor-1", TrustLevel: TrustLow, AutonomyTier: AutonomyRestricted, UpdatedAt: time.Unix(10, 0).UTC()}
+	second := TrustProfile{ActorID: "actor-2", TrustLevel: TrustMedium, AutonomyTier: AutonomySupervised, UpdatedAt: time.Unix(20, 0).UTC()}
+	if err := repo.Save(ctx, first); err != nil {
+		t.Fatalf("Save first error = %v", err)
+	}
+	if err := repo.Save(ctx, second); err != nil {
+		t.Fatalf("Save second error = %v", err)
+	}
+	got, ok, err := repo.GetByActor(ctx, "actor-1")
+	if err != nil {
+		t.Fatalf("GetByActor error = %v", err)
+	}
+	if !ok || got.ActorID != first.ActorID || !got.UpdatedAt.Equal(first.UpdatedAt) {
+		t.Fatalf("got=%#v ok=%v", got, ok)
+	}
+	listed, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List error = %v", err)
+	}
+	if len(listed) != 2 || listed[0].ActorID != "actor-1" || listed[1].ActorID != "actor-2" {
+		t.Fatalf("listed=%#v", listed)
+	}
+}

--- a/internal/trust/scorer.go
+++ b/internal/trust/scorer.go
@@ -1,0 +1,54 @@
+package trust
+
+import "time"
+
+type deterministicScorer struct {
+	now func() time.Time
+}
+
+func NewScorer() Scorer {
+	return NewScorerWithClock(func() time.Time { return time.Now().UTC() })
+}
+
+func NewScorerWithClock(now func() time.Time) Scorer {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &deterministicScorer{now: now}
+}
+
+func (s *deterministicScorer) Score(current TrustProfile, outcome ExecutionOutcome) TrustProfile {
+	next := current
+	if next.ActorID == "" {
+		next.ActorID = outcome.ActorID
+	}
+	if outcome.Succeeded {
+		next.CompletedExecutions++
+	}
+	if !outcome.Succeeded {
+		next.FailedExecutions++
+	}
+	if outcome.Compensated {
+		next.CompensatedExecutions++
+	}
+	if outcome.RequiredApproval {
+		next.ApprovalRequests++
+	}
+	if outcome.Approved {
+		next.ApprovedExecutions++
+	}
+
+	next.TrustLevel, next.AutonomyTier = deriveTrust(next)
+	next.UpdatedAt = s.now()
+	return next
+}
+
+func deriveTrust(profile TrustProfile) (TrustLevel, AutonomyTier) {
+	if profile.CompletedExecutions >= 10 && profile.FailedExecutions <= 1 && profile.CompensatedExecutions == 0 {
+		return TrustHigh, AutonomyStandard
+	}
+	if profile.CompletedExecutions >= 3 && profile.FailedExecutions == 0 {
+		return TrustMedium, AutonomySupervised
+	}
+	return TrustLow, AutonomyRestricted
+}

--- a/internal/trust/scorer_test.go
+++ b/internal/trust/scorer_test.go
@@ -1,0 +1,72 @@
+package trust
+
+import (
+	"testing"
+	"time"
+)
+
+func TestScorerInitialSuccessProgression(t *testing.T) {
+	t.Parallel()
+	base := time.Unix(100, 0).UTC()
+	scorer := NewScorerWithClock(func() time.Time { return base })
+	profile := TrustProfile{ActorID: "actor-1", TrustLevel: TrustLow, AutonomyTier: AutonomyRestricted}
+	for range 3 {
+		profile = scorer.Score(profile, ExecutionOutcome{ActorID: "actor-1", ExecutionID: "exec", Succeeded: true})
+	}
+	if profile.CompletedExecutions != 3 {
+		t.Fatalf("completed=%d", profile.CompletedExecutions)
+	}
+	if profile.TrustLevel != TrustMedium || profile.AutonomyTier != AutonomySupervised {
+		t.Fatalf("profile=%#v", profile)
+	}
+	for range 7 {
+		profile = scorer.Score(profile, ExecutionOutcome{ActorID: "actor-1", ExecutionID: "exec", Succeeded: true})
+	}
+	if profile.TrustLevel != TrustHigh || profile.AutonomyTier != AutonomyStandard {
+		t.Fatalf("profile=%#v", profile)
+	}
+	if !profile.UpdatedAt.Equal(base) {
+		t.Fatalf("updatedAt=%v", profile.UpdatedAt)
+	}
+}
+
+func TestScorerFailureDowngradesTrust(t *testing.T) {
+	t.Parallel()
+	scorer := NewScorerWithClock(func() time.Time { return time.Unix(200, 0).UTC() })
+	profile := TrustProfile{ActorID: "actor-1", CompletedExecutions: 3, TrustLevel: TrustMedium, AutonomyTier: AutonomySupervised}
+	profile = scorer.Score(profile, ExecutionOutcome{ActorID: "actor-1", ExecutionID: "exec-4", Succeeded: false})
+	if profile.FailedExecutions != 1 {
+		t.Fatalf("failed=%d", profile.FailedExecutions)
+	}
+	if profile.TrustLevel != TrustLow || profile.AutonomyTier != AutonomyRestricted {
+		t.Fatalf("profile=%#v", profile)
+	}
+}
+
+func TestScorerCompensationPreventsHighTrust(t *testing.T) {
+	t.Parallel()
+	scorer := NewScorerWithClock(func() time.Time { return time.Unix(300, 0).UTC() })
+	profile := TrustProfile{ActorID: "actor-1"}
+	for i := 0; i < 10; i++ {
+		outcome := ExecutionOutcome{ActorID: "actor-1", ExecutionID: "exec", Succeeded: true}
+		if i == 4 {
+			outcome.Compensated = true
+		}
+		profile = scorer.Score(profile, outcome)
+	}
+	if profile.CompletedExecutions != 10 || profile.CompensatedExecutions != 1 {
+		t.Fatalf("profile=%#v", profile)
+	}
+	if profile.TrustLevel != TrustMedium || profile.AutonomyTier != AutonomySupervised {
+		t.Fatalf("profile=%#v", profile)
+	}
+}
+
+func TestScorerUpdatesApprovalCounters(t *testing.T) {
+	t.Parallel()
+	scorer := NewScorerWithClock(func() time.Time { return time.Unix(400, 0).UTC() })
+	profile := scorer.Score(TrustProfile{ActorID: "actor-1"}, ExecutionOutcome{ActorID: "actor-1", ExecutionID: "exec-1", Succeeded: true, RequiredApproval: true, Approved: true})
+	if profile.ApprovalRequests != 1 || profile.ApprovedExecutions != 1 {
+		t.Fatalf("profile=%#v", profile)
+	}
+}

--- a/internal/trust/service.go
+++ b/internal/trust/service.go
@@ -1,0 +1,50 @@
+package trust
+
+import (
+	"context"
+	"fmt"
+)
+
+type trustService struct {
+	repository Repository
+	scorer     Scorer
+}
+
+func NewService(repository Repository, scorer Scorer) Service {
+	if scorer == nil {
+		scorer = NewScorer()
+	}
+	return &trustService{repository: repository, scorer: scorer}
+}
+
+func (s *trustService) RecordOutcome(ctx context.Context, outcome ExecutionOutcome) (TrustProfile, error) {
+	if s.repository == nil {
+		return TrustProfile{}, fmt.Errorf("trust repository is nil")
+	}
+	if s.scorer == nil {
+		return TrustProfile{}, fmt.Errorf("trust scorer is nil")
+	}
+	current, ok, err := s.repository.GetByActor(ctx, outcome.ActorID)
+	if err != nil {
+		return TrustProfile{}, err
+	}
+	if !ok {
+		current = TrustProfile{
+			ActorID:      outcome.ActorID,
+			TrustLevel:   TrustLow,
+			AutonomyTier: AutonomyRestricted,
+		}
+	}
+	updated := s.scorer.Score(current, outcome)
+	if err := s.repository.Save(ctx, updated); err != nil {
+		return TrustProfile{}, err
+	}
+	return updated, nil
+}
+
+func (s *trustService) GetTrustProfile(ctx context.Context, actorID string) (TrustProfile, bool, error) {
+	if s.repository == nil {
+		return TrustProfile{}, false, nil
+	}
+	return s.repository.GetByActor(ctx, actorID)
+}

--- a/internal/trust/service_test.go
+++ b/internal/trust/service_test.go
@@ -1,0 +1,58 @@
+package trust
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestServiceCreatesDefaultProfileOnFirstOutcome(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := NewInMemoryRepository()
+	service := NewService(repo, NewScorerWithClock(func() time.Time { return time.Unix(500, 0).UTC() }))
+	profile, err := service.RecordOutcome(ctx, ExecutionOutcome{ActorID: "actor-1", ExecutionID: "exec-1", Succeeded: true})
+	if err != nil {
+		t.Fatalf("RecordOutcome error = %v", err)
+	}
+	if profile.ActorID != "actor-1" || profile.CompletedExecutions != 1 {
+		t.Fatalf("profile=%#v", profile)
+	}
+	if profile.TrustLevel != TrustLow || profile.AutonomyTier != AutonomyRestricted {
+		t.Fatalf("profile=%#v", profile)
+	}
+}
+
+func TestServiceUpdatesExistingProfileDeterministically(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := NewInMemoryRepository()
+	scorer := NewScorerWithClock(func() time.Time { return time.Unix(600, 0).UTC() })
+	service := NewService(repo, scorer)
+	outcomes := []ExecutionOutcome{
+		{ActorID: "actor-1", ExecutionID: "exec-1", Succeeded: true},
+		{ActorID: "actor-1", ExecutionID: "exec-2", Succeeded: true, RequiredApproval: true, Approved: true},
+		{ActorID: "actor-1", ExecutionID: "exec-3", Succeeded: true},
+	}
+	var profile TrustProfile
+	var err error
+	for _, outcome := range outcomes {
+		profile, err = service.RecordOutcome(ctx, outcome)
+		if err != nil {
+			t.Fatalf("RecordOutcome error = %v", err)
+		}
+	}
+	if profile.CompletedExecutions != 3 || profile.ApprovalRequests != 1 || profile.ApprovedExecutions != 1 {
+		t.Fatalf("profile=%#v", profile)
+	}
+	if profile.TrustLevel != TrustMedium || profile.AutonomyTier != AutonomySupervised {
+		t.Fatalf("profile=%#v", profile)
+	}
+	persisted, ok, err := service.GetTrustProfile(ctx, "actor-1")
+	if err != nil {
+		t.Fatalf("GetTrustProfile error = %v", err)
+	}
+	if !ok || persisted != profile {
+		t.Fatalf("persisted=%#v ok=%v profile=%#v", persisted, ok, profile)
+	}
+}

--- a/internal/trust/types.go
+++ b/internal/trust/types.go
@@ -1,0 +1,58 @@
+package trust
+
+import (
+	"context"
+	"time"
+)
+
+type TrustLevel string
+
+const (
+	TrustLow    TrustLevel = "low"
+	TrustMedium TrustLevel = "medium"
+	TrustHigh   TrustLevel = "high"
+)
+
+type AutonomyTier string
+
+const (
+	AutonomyRestricted AutonomyTier = "restricted"
+	AutonomySupervised AutonomyTier = "supervised"
+	AutonomyStandard   AutonomyTier = "standard"
+)
+
+type TrustProfile struct {
+	ActorID               string
+	CompletedExecutions   int
+	FailedExecutions      int
+	CompensatedExecutions int
+	ApprovalRequests      int
+	ApprovedExecutions    int
+	TrustLevel            TrustLevel
+	AutonomyTier          AutonomyTier
+	UpdatedAt             time.Time
+}
+
+type ExecutionOutcome struct {
+	ActorID          string
+	ExecutionID      string
+	Succeeded        bool
+	Compensated      bool
+	RequiredApproval bool
+	Approved         bool
+}
+
+type Repository interface {
+	Save(ctx context.Context, p TrustProfile) error
+	GetByActor(ctx context.Context, actorID string) (TrustProfile, bool, error)
+	List(ctx context.Context) ([]TrustProfile, error)
+}
+
+type Scorer interface {
+	Score(current TrustProfile, outcome ExecutionOutcome) TrustProfile
+}
+
+type Service interface {
+	RecordOutcome(ctx context.Context, outcome ExecutionOutcome) (TrustProfile, error)
+	GetTrustProfile(ctx context.Context, actorID string) (TrustProfile, bool, error)
+}


### PR DESCRIPTION
### Motivation
- Introduce a transport-free, in-memory Experience/Trust layer to record actor execution history and derive deterministic trust profiles for future matching and autonomy decisions.
- Keep the model domain-agnostic, explainable, and deterministic while avoiding LLM logic, runtime rewiring, and external persistence in this slice.

### Description
- Add a new package `internal/trust` with `types.go`, `repository.go`, `scorer.go`, and `service.go` to model `TrustProfile`, `ExecutionOutcome`, repository/scorer/service interfaces, and constructors like `NewInMemoryRepository` and `NewService`.
- Implement a thread-safe, in-memory `InMemoryRepository` that preserves first-insertion listing order and exposes `Save`, `GetByActor`, and `List` methods.
- Implement a deterministic scorer (`NewScorerWithClock`) that increments counters from `ExecutionOutcome` and derives `TrustLevel`/`AutonomyTier` via explicit rules (`low/restricted` baseline; `medium/supervised` after >=3 clean completions; `high/standard` after >=10 completions with <=1 failure and no compensations). 
- Implement `trustService` that loads-or-creates a default profile, applies the scorer, and persists updates through the repository seam without changing `executionruntime` or policy wiring.

### Testing
- Added unit tests `internal/trust/repository_test.go`, `internal/trust/scorer_test.go`, and `internal/trust/service_test.go` exercising repository ordering, deterministic scoring (success progression, failure downgrade, compensation blocking high trust, approval counters), and service behavior.
- Ran `go test ./internal/trust` as well as `go test ./internal/profile ./internal/capability ./internal/employee` and the focused test suites succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0da01d36083249f96178aae590936)