### PR TITLE
Deterministic actor selection and trust-aware execution constraints

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -8,6 +8,7 @@ import (
 
 	"kalita/internal/actionplan"
 	"kalita/internal/blob"
+	"kalita/internal/capability"
 	"kalita/internal/caseruntime"
 	"kalita/internal/catalog"
 	"kalita/internal/command"
@@ -18,6 +19,7 @@ import (
 	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
 	"kalita/internal/postgres"
+	"kalita/internal/profile"
 	"kalita/internal/proposal"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
@@ -179,11 +181,11 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	executionRuntime := executionruntime.NewService(executionRunner)
 	employeeDirectory := employee.NewInMemoryDirectory()
 	assignmentRepo := employee.NewInMemoryAssignmentRepository()
-	employeeSelector := employee.NewSelector(employeeDirectory)
-	employeeService := employee.NewService(assignmentRepo, employeeSelector, executionRuntime, eventLog, clock, ids)
 	trustRepo := trust.NewInMemoryRepository()
 	trustScorer := trust.NewDeterministicScorer(clock.Now)
 	trustService := trust.NewService(trustRepo, trustScorer)
+	capabilityRepo := capability.NewInMemoryRepository()
+	profileRepo := profile.NewInMemoryRepository()
 	defaultEmployee := employee.DigitalEmployee{
 		ID:                  "employee-legacy-operator",
 		Code:                "legacy_operator_default",
@@ -200,6 +202,20 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	if err := employeeDirectory.SaveEmployee(context.Background(), defaultEmployee); err != nil {
 		return nil, fmt.Errorf("seed default employee: %w", err)
 	}
+	if err := capabilityRepo.SaveCapability(context.Background(), capability.Capability{ID: "cap-legacy-workflow", Code: "workflow.execute", Type: capability.CapabilitySkill, Level: 1}); err != nil {
+		return nil, fmt.Errorf("seed workflow capability: %w", err)
+	}
+	if err := capabilityRepo.AssignCapability(context.Background(), capability.ActorCapability{ActorID: defaultEmployee.ID, CapabilityID: "cap-legacy-workflow", Level: 1}); err != nil {
+		return nil, fmt.Errorf("assign workflow capability: %w", err)
+	}
+	if err := profileRepo.SaveRequirement(context.Background(), profile.CapabilityRequirement{ActionType: "legacy_workflow_action", CapabilityCodes: []string{"workflow.execute"}, MinimumLevel: 1}); err != nil {
+		return nil, fmt.Errorf("seed capability requirement: %w", err)
+	}
+	if err := profileRepo.SaveProfile(context.Background(), profile.CompetencyProfile{ID: "profile-legacy-operator", ActorID: defaultEmployee.ID, Name: "Legacy Operator", MaxComplexity: 10, PreferredWorkKinds: []string{"workflow.action"}}); err != nil {
+		return nil, fmt.Errorf("seed competency profile: %w", err)
+	}
+	employeeSelector := employee.NewSelectorWithMatcher(employeeDirectory, profile.NewMatcher(profileRepo, profileRepo, capabilityRepo, capabilityRepo, trustService))
+	employeeService := employee.NewService(assignmentRepo, employeeSelector, executionRuntime, eventLog, clock, ids, trustService)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}

--- a/internal/employee/service.go
+++ b/internal/employee/service.go
@@ -8,6 +8,7 @@ import (
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
 	"kalita/internal/executionruntime"
+	"kalita/internal/trust"
 	"kalita/internal/workplan"
 )
 
@@ -15,19 +16,24 @@ type employeeService struct {
 	assignments AssignmentRepository
 	selector    Selector
 	runtime     executionruntime.Service
+	trust       trust.Service
 	log         eventcore.EventLog
 	clock       eventcore.Clock
 	ids         eventcore.IDGenerator
 }
 
-func NewService(assignments AssignmentRepository, selector Selector, runtime executionruntime.Service, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) Service {
+func NewService(assignments AssignmentRepository, selector Selector, runtime executionruntime.Service, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator, trustServices ...trust.Service) Service {
 	if clock == nil {
 		clock = eventcore.RealClock{}
 	}
 	if ids == nil {
 		ids = eventcore.NewULIDGenerator()
 	}
-	return &employeeService{assignments: assignments, selector: selector, runtime: runtime, log: log, clock: clock, ids: ids}
+	var trustService trust.Service
+	if len(trustServices) > 0 {
+		trustService = trustServices[0]
+	}
+	return &employeeService{assignments: assignments, selector: selector, runtime: runtime, trust: trustService, log: log, clock: clock, ids: ids}
 }
 
 func (s *employeeService) AssignAndStartExecution(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, metadata RunMetadata) (Assignment, executionruntime.ExecutionSession, error) {
@@ -52,6 +58,23 @@ func (s *employeeService) AssignAndStartExecution(ctx context.Context, wi workpl
 	if s.log != nil {
 		meta := executionruntime.ExecutionMetadataFromContext(ctx)
 		if err := s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{ID: s.ids.NewID(), ExecutionID: meta.ExecutionID, CaseID: metadata.CaseID, Step: "employee_assigned", Status: "assigned", OccurredAt: now, CorrelationID: meta.CorrelationID, CausationID: meta.CausationID, Payload: map[string]any{"employee_id": employee.ID, "work_item_id": wi.ID, "case_id": metadata.CaseID, "queue_id": metadata.QueueID, "assignment_id": assignment.ID}}); err != nil {
+			return Assignment{}, executionruntime.ExecutionSession{}, err
+		}
+	}
+	trustProfile := trust.DefaultTrustProfile(employee.ID, now)
+	if s.trust != nil {
+		profile, ok, err := s.trust.GetTrustProfile(ctx, employee.ID)
+		if err != nil {
+			return Assignment{}, executionruntime.ExecutionSession{}, err
+		}
+		if ok {
+			trustProfile = profile
+		}
+	}
+	constraints, adjustmentReason := executioncontrol.AdjustForTrust(constraints, trustProfile)
+	if s.log != nil {
+		meta := executionruntime.ExecutionMetadataFromContext(ctx)
+		if err := s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{ID: s.ids.NewID(), ExecutionID: meta.ExecutionID, CaseID: metadata.CaseID, Step: "execution_mode_adjusted_by_trust", Status: string(trustProfile.TrustLevel), OccurredAt: s.clock.Now(), CorrelationID: meta.CorrelationID, CausationID: meta.CausationID, Payload: map[string]any{"employee_id": employee.ID, "work_item_id": wi.ID, "execution_mode": constraints.ExecutionMode, "max_steps": constraints.MaxSteps, "max_duration_sec": constraints.MaxDurationSec, "trust_level": trustProfile.TrustLevel, "reason": adjustmentReason}}); err != nil {
 			return Assignment{}, executionruntime.ExecutionSession{}, err
 		}
 	}

--- a/internal/employee/service_test.go
+++ b/internal/employee/service_test.go
@@ -9,6 +9,7 @@ import (
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
 	"kalita/internal/executionruntime"
+	"kalita/internal/trust"
 	"kalita/internal/workplan"
 )
 
@@ -16,10 +17,12 @@ type staticExecutionRuntime struct {
 	session executionruntime.ExecutionSession
 	err     error
 	calls   int
+	last    executioncontrol.ExecutionConstraints
 }
 
-func (s *staticExecutionRuntime) StartExecution(context.Context, actionplan.ActionPlan, executioncontrol.ExecutionConstraints, executionruntime.RunMetadata) (executionruntime.ExecutionSession, error) {
+func (s *staticExecutionRuntime) StartExecution(_ context.Context, _ actionplan.ActionPlan, constraints executioncontrol.ExecutionConstraints, _ executionruntime.RunMetadata) (executionruntime.ExecutionSession, error) {
 	s.calls++
+	s.last = constraints
 	return s.session, s.err
 }
 
@@ -30,7 +33,7 @@ func TestEmployeeServiceAssignsEmitsEventAndStartsExecution(t *testing.T) {
 	assignments := NewInMemoryAssignmentRepository()
 	eventLog := eventcore.NewInMemoryEventLog()
 	clock := fakeClock{now: time.Date(2026, 3, 22, 19, 0, 0, 0, time.UTC)}
-	ids := &fakeIDGenerator{ids: []string{"assignment-1", "event-1"}}
+	ids := &fakeIDGenerator{ids: []string{"assignment-1", "event-1", "event-2"}}
 	runtimeSvc := &staticExecutionRuntime{session: executionruntime.ExecutionSession{ID: "session-1", Status: executionruntime.ExecutionSessionSucceeded}}
 	service := NewService(assignments, NewSelector(directory), runtimeSvc, eventLog, clock, ids)
 	ctx := executionruntime.ContextWithExecution(context.Background(), executionruntime.ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
@@ -49,11 +52,14 @@ func TestEmployeeServiceAssignsEmitsEventAndStartsExecution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListByCorrelation error = %v", err)
 	}
-	if len(execEvents) != 1 || execEvents[0].Step != "employee_assigned" || execEvents[0].Status != "assigned" {
+	if len(execEvents) != 2 || execEvents[0].Step != "employee_assigned" || execEvents[0].Status != "assigned" || execEvents[1].Step != "execution_mode_adjusted_by_trust" {
 		t.Fatalf("execEvents = %#v", execEvents)
 	}
 	if execEvents[0].Payload["assignment_id"] != "assignment-1" {
 		t.Fatalf("payload = %#v", execEvents[0].Payload)
+	}
+	if runtimeSvc.last.ExecutionMode != executioncontrol.ExecutionModeApprovalEachStep || runtimeSvc.last.MaxSteps != 1 {
+		t.Fatalf("runtime constraints = %#v", runtimeSvc.last)
 	}
 }
 
@@ -63,6 +69,25 @@ func TestEmployeeServiceFailsWhenNoEligibleEmployeeExists(t *testing.T) {
 	_, _, err := service.AssignAndStartExecution(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, executioncontrol.ExecutionConstraints{ID: "constraints-1"}, RunMetadata{CaseID: "case-1", QueueID: "q-1"})
 	if err == nil {
 		t.Fatal("expected error when no eligible employee exists")
+	}
+}
+
+func TestEmployeeServiceKeepsLowTrustActorSelectableButConstrained(t *testing.T) {
+	t.Parallel()
+	directory := NewInMemoryDirectory()
+	_ = directory.SaveEmployee(context.Background(), DigitalEmployee{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
+	assignments := NewInMemoryAssignmentRepository()
+	runtimeSvc := &staticExecutionRuntime{session: executionruntime.ExecutionSession{ID: "session-1"}}
+	trustRepo := trust.NewInMemoryRepository()
+	_ = trustRepo.Save(context.Background(), trust.TrustProfile{ActorID: "emp-1", TrustLevel: trust.TrustLow})
+	service := NewService(assignments, NewSelector(directory), runtimeSvc, eventcore.NewInMemoryEventLog(), fakeClock{now: time.Date(2026, 3, 22, 19, 0, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"assignment-1", "event-1", "event-2"}}, trust.NewService(trustRepo, trust.NewScorerWithClock(nil)))
+
+	_, _, err := service.AssignAndStartExecution(context.Background(), workplan.WorkItem{ID: "work-1", QueueID: "q-1"}, actionplan.ActionPlan{ID: "plan-1", Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, executioncontrol.ExecutionConstraints{ID: "constraints-1", ExecutionMode: executioncontrol.ExecutionModeDeterministicAPI, MaxSteps: 10, MaxDurationSec: 300}, RunMetadata{CaseID: "case-1", QueueID: "q-1"})
+	if err != nil {
+		t.Fatalf("AssignAndStartExecution error = %v", err)
+	}
+	if runtimeSvc.last.ExecutionMode != executioncontrol.ExecutionModeApprovalEachStep || runtimeSvc.last.MaxSteps != 1 || runtimeSvc.last.MaxDurationSec != 60 {
+		t.Fatalf("runtime constraints = %#v", runtimeSvc.last)
 	}
 }
 

--- a/internal/executioncontrol/service_test.go
+++ b/internal/executioncontrol/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"kalita/internal/eventcore"
 	"kalita/internal/policy"
+	"kalita/internal/trust"
 	"kalita/internal/workplan"
 )
 
@@ -74,5 +75,26 @@ func TestServiceDeniedPolicyDoesNotCreateConstraints(t *testing.T) {
 	}
 	if len(items) != 0 {
 		t.Fatalf("items = %#v", items)
+	}
+}
+
+func TestAdjustForTrustAppliesDeterministicExecutionModes(t *testing.T) {
+	t.Parallel()
+
+	base := ExecutionConstraints{ID: "constraints-1", ExecutionMode: ExecutionModeDeterministicAPI, MaxSteps: 10, MaxDurationSec: 300, Reason: "baseline"}
+
+	low, _ := AdjustForTrust(base, trust.TrustProfile{ActorID: "emp-low", TrustLevel: trust.TrustLow})
+	if low.ExecutionMode != ExecutionModeApprovalEachStep || low.MaxSteps != 1 || low.MaxDurationSec != 60 {
+		t.Fatalf("low = %#v", low)
+	}
+
+	medium, _ := AdjustForTrust(base, trust.TrustProfile{ActorID: "emp-medium", TrustLevel: trust.TrustMedium})
+	if medium.ExecutionMode != ExecutionModeSupervised || medium.MaxSteps != 5 || medium.MaxDurationSec != 180 {
+		t.Fatalf("medium = %#v", medium)
+	}
+
+	high, _ := AdjustForTrust(base, trust.TrustProfile{ActorID: "emp-high", TrustLevel: trust.TrustHigh})
+	if high.ExecutionMode != ExecutionModeStandard || high.MaxSteps != 10 || high.MaxDurationSec != 300 {
+		t.Fatalf("high = %#v", high)
 	}
 }

--- a/internal/executioncontrol/types.go
+++ b/internal/executioncontrol/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"kalita/internal/policy"
+	"kalita/internal/trust"
 	"kalita/internal/workplan"
 )
 
@@ -24,6 +25,8 @@ const (
 	ExecutionModeGuidedUIOperator     ExecutionMode = "guided_ui_operator"
 	ExecutionModeCheckpointedAutonomy ExecutionMode = "checkpointed_autonomy"
 	ExecutionModeApprovalEachStep     ExecutionMode = "approval_each_step"
+	ExecutionModeSupervised           ExecutionMode = "supervised"
+	ExecutionModeStandard             ExecutionMode = "standard"
 )
 
 type ExecutionConstraints struct {
@@ -63,4 +66,45 @@ type ConstraintsPlanner interface {
 
 type ConstraintsService interface {
 	CreateAndRecord(ctx context.Context, coordination workplan.CoordinationDecision, policyDecision policy.PolicyDecision) (ExecutionConstraints, error)
+}
+
+func AdjustForTrust(base ExecutionConstraints, profile trust.TrustProfile) (ExecutionConstraints, string) {
+	adjusted := base
+
+	switch profile.TrustLevel {
+	case trust.TrustHigh:
+		adjusted.ExecutionMode = ExecutionModeStandard
+		if adjusted.MaxSteps < 10 {
+			adjusted.MaxSteps = 10
+		}
+		if adjusted.MaxDurationSec < 300 {
+			adjusted.MaxDurationSec = 300
+		}
+	case trust.TrustMedium:
+		adjusted.ExecutionMode = ExecutionModeSupervised
+		if adjusted.MaxSteps > 5 || adjusted.MaxSteps == 0 {
+			adjusted.MaxSteps = 5
+		}
+		if adjusted.MaxDurationSec > 180 || adjusted.MaxDurationSec == 0 {
+			adjusted.MaxDurationSec = 180
+		}
+	case trust.TrustLow:
+		if adjusted.ExecutionMode != ExecutionModeGuidedUIOperator {
+			adjusted.ExecutionMode = ExecutionModeApprovalEachStep
+		}
+		adjusted.MaxSteps = 1
+		adjusted.MaxDurationSec = 60
+	default:
+		adjusted.ExecutionMode = ExecutionModeApprovalEachStep
+		adjusted.MaxSteps = 1
+		adjusted.MaxDurationSec = 60
+		profile.TrustLevel = trust.TrustLow
+	}
+
+	reason := "execution constraints adjusted deterministically by trust profile"
+	if base.Reason != "" {
+		reason = base.Reason + "; " + reason
+	}
+	adjusted.Reason = reason
+	return adjusted, reason
 }

--- a/internal/profile/matcher.go
+++ b/internal/profile/matcher.go
@@ -8,6 +8,7 @@ import (
 	"kalita/internal/actionplan"
 	"kalita/internal/capability"
 	"kalita/internal/employee"
+	"kalita/internal/trust"
 	"kalita/internal/workplan"
 )
 
@@ -16,10 +17,23 @@ type deterministicMatcher struct {
 	profiles     Repository
 	capabilities capability.CapabilityRepository
 	assignments  capability.ActorCapabilityRepository
+	trust        trust.Service
 }
 
-func NewMatcher(requirements RequirementRepository, profiles Repository, capabilities capability.CapabilityRepository, assignments capability.ActorCapabilityRepository) Matcher {
-	return &deterministicMatcher{requirements: requirements, profiles: profiles, capabilities: capabilities, assignments: assignments}
+type evaluatedActor struct {
+	actor      employee.DigitalEmployee
+	reason     string
+	preferred  bool
+	trustLevel trust.TrustLevel
+	index      int
+}
+
+func NewMatcher(requirements RequirementRepository, profiles Repository, capabilities capability.CapabilityRepository, assignments capability.ActorCapabilityRepository, trustServices ...trust.Service) Matcher {
+	var trustService trust.Service
+	if len(trustServices) > 0 {
+		trustService = trustServices[0]
+	}
+	return &deterministicMatcher{requirements: requirements, profiles: profiles, capabilities: capabilities, assignments: assignments, trust: trustService}
 }
 
 func (m *deterministicMatcher) MatchActor(ctx context.Context, wi workplan.WorkItem, plan actionplan.ActionPlan, actors []employee.DigitalEmployee) (employee.DigitalEmployee, string, error) {
@@ -38,61 +52,78 @@ func (m *deterministicMatcher) MatchActor(ctx context.Context, wi workplan.WorkI
 	}
 	complexity := len(plan.Actions)
 
-	var selected employee.DigitalEmployee
-	selectedPreferred := false
-	selectedFound := false
-	selectedReason := ""
-	for _, actor := range actors {
-		if !actor.Enabled || !containsString(actor.QueueMemberships, wi.QueueID) || !allowsAllActionTypes(actor, plan.Actions) {
+	rejected := make([]string, 0, len(actors))
+	eligibleActors := make([]evaluatedActor, 0, len(actors))
+	for idx, actor := range actors {
+		if !actor.Enabled {
+			rejected = append(rejected, fmt.Sprintf("%s rejected: disabled", actor.ID))
 			continue
 		}
-		eligible, reason, preferred, err := m.evaluateActor(ctx, actor, wi, plan, complexity, requirementsByAction)
+		if !containsString(actor.QueueMemberships, wi.QueueID) {
+			rejected = append(rejected, fmt.Sprintf("%s rejected: not in queue %s", actor.ID, wi.QueueID))
+			continue
+		}
+		if !allowsAllActionTypes(actor, plan.Actions) {
+			rejected = append(rejected, fmt.Sprintf("%s rejected: action types not allowed", actor.ID))
+			continue
+		}
+		eligible, reason, preferred, trustLevel, err := m.evaluateActor(ctx, actor, wi, plan, complexity, requirementsByAction)
 		if err != nil {
 			return employee.DigitalEmployee{}, "", err
 		}
 		if !eligible {
+			rejected = append(rejected, fmt.Sprintf("%s rejected: %s", actor.ID, reason))
 			continue
 		}
-		if !selectedFound || (preferred && !selectedPreferred) {
-			selected = actor
-			selectedPreferred = preferred
-			selectedFound = true
-			selectedReason = reason
-		}
+		eligibleActors = append(eligibleActors, evaluatedActor{actor: actor, reason: reason, preferred: preferred, trustLevel: trustLevel, index: idx})
 	}
-	if selectedFound {
-		return selected, selectedReason, nil
+	if len(eligibleActors) > 0 {
+		selected := eligibleActors[0]
+		for _, candidate := range eligibleActors[1:] {
+			if outranks(candidate, selected) {
+				rejected = append(rejected, fmt.Sprintf("%s eligible but not selected: lower priority than %s", selected.actor.ID, candidate.actor.ID))
+				selected = candidate
+				continue
+			}
+			rejected = append(rejected, fmt.Sprintf("%s eligible but not selected: lower priority than %s", candidate.actor.ID, selected.actor.ID))
+		}
+		reason := selected.reason
+		if len(rejected) > 0 {
+			reason += "; others not chosen: " + strings.Join(rejected, "; ")
+		}
+		return selected.actor, reason, nil
 	}
 	return employee.DigitalEmployee{}, "", fmt.Errorf("no eligible digital employee for queue %s and work item %s with required competencies", wi.QueueID, wi.ID)
 }
 
-func (m *deterministicMatcher) evaluateActor(ctx context.Context, actor employee.DigitalEmployee, wi workplan.WorkItem, plan actionplan.ActionPlan, complexity int, requirementsByAction map[actionplan.ActionType]CapabilityRequirement) (bool, string, bool, error) {
+func (m *deterministicMatcher) evaluateActor(ctx context.Context, actor employee.DigitalEmployee, wi workplan.WorkItem, plan actionplan.ActionPlan, complexity int, requirementsByAction map[actionplan.ActionType]CapabilityRequirement) (bool, string, bool, trust.TrustLevel, error) {
 	capabilitiesByCode, err := m.actorCapabilitiesByCode(ctx, actor.ID)
 	if err != nil {
-		return false, "", false, err
+		return false, "", false, trust.TrustLow, err
 	}
 	for _, action := range plan.Actions {
 		req, ok := requirementsByAction[action.Type]
 		if !ok {
-			return false, "", false, nil
+			return false, fmt.Sprintf("missing capability requirements for action type %s", action.Type), false, trust.TrustLow, nil
 		}
 		for _, code := range req.CapabilityCodes {
 			level, ok := capabilitiesByCode[code]
 			if !ok || level < req.MinimumLevel {
-				return false, "", false, nil
+				return false, fmt.Sprintf("capability %s requires level %d", code, req.MinimumLevel), false, trust.TrustLow, nil
 			}
 		}
 	}
 	preferred := false
-	reasonParts := []string{fmt.Sprintf("selected actor %s for queue %s by deterministic competency match", actor.ID, wi.QueueID)}
+	trustLevel := trust.TrustLow
+	reasonParts := []string{fmt.Sprintf("selected actor %s for queue %s by deterministic capability/profile/trust match", actor.ID, wi.QueueID)}
 	if m.profiles != nil {
 		profile, ok, err := m.profiles.GetProfileByActor(ctx, actor.ID)
 		if err != nil {
-			return false, "", false, err
+			return false, "", false, trust.TrustLow, err
 		}
 		if ok {
 			if profile.MaxComplexity > 0 && profile.MaxComplexity < complexity {
-				return false, "", false, nil
+				return false, fmt.Sprintf("profile %s max complexity %d below required complexity %d", profile.ID, profile.MaxComplexity, complexity), false, trust.TrustLow, nil
 			}
 			preferred = containsString(profile.PreferredWorkKinds, wi.Type)
 			reasonParts = append(reasonParts, fmt.Sprintf("profile %s supports complexity %d", profile.ID, complexity))
@@ -101,7 +132,38 @@ func (m *deterministicMatcher) evaluateActor(ctx context.Context, actor employee
 			}
 		}
 	}
-	return true, strings.Join(reasonParts, "; "), preferred, nil
+	if m.trust != nil {
+		profile, ok, err := m.trust.GetTrustProfile(ctx, actor.ID)
+		if err != nil {
+			return false, "", false, trust.TrustLow, err
+		}
+		if ok {
+			trustLevel = profile.TrustLevel
+		}
+	}
+	reasonParts = append(reasonParts, fmt.Sprintf("trust level %s applied", trustLevel))
+	return true, strings.Join(reasonParts, "; "), preferred, trustLevel, nil
+}
+
+func outranks(left, right evaluatedActor) bool {
+	if trustRank(left.trustLevel) != trustRank(right.trustLevel) {
+		return trustRank(left.trustLevel) > trustRank(right.trustLevel)
+	}
+	if left.preferred != right.preferred {
+		return left.preferred
+	}
+	return left.index < right.index
+}
+
+func trustRank(level trust.TrustLevel) int {
+	switch level {
+	case trust.TrustHigh:
+		return 3
+	case trust.TrustMedium:
+		return 2
+	default:
+		return 1
+	}
 }
 
 func (m *deterministicMatcher) requirementsByAction(ctx context.Context) (map[actionplan.ActionType]CapabilityRequirement, error) {

--- a/internal/profile/matcher_test.go
+++ b/internal/profile/matcher_test.go
@@ -2,11 +2,13 @@ package profile
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"kalita/internal/actionplan"
 	"kalita/internal/capability"
 	"kalita/internal/employee"
+	"kalita/internal/trust"
 	"kalita/internal/workplan"
 )
 
@@ -87,5 +89,37 @@ func TestMatcherUsesDeterministicSelectionWhenMultipleActorsMatch(t *testing.T) 
 	}
 	if actor.ID != "emp-1" {
 		t.Fatalf("selected actor = %#v", actor)
+	}
+}
+
+func TestMatcherPrefersHigherTrustBeforeProfilePreference(t *testing.T) {
+	t.Parallel()
+	profiles := NewInMemoryRepository()
+	caps := capability.NewInMemoryRepository()
+	trustRepo := trust.NewInMemoryRepository()
+	trustService := trust.NewService(trustRepo, trust.NewScorerWithClock(nil))
+	ctx := context.Background()
+	_ = profiles.SaveRequirement(ctx, CapabilityRequirement{ActionType: "legacy_workflow_action", CapabilityCodes: []string{"workflow.execute"}, MinimumLevel: 1})
+	_ = profiles.SaveProfile(ctx, CompetencyProfile{ID: "profile-1", ActorID: "emp-1", MaxComplexity: 3, PreferredWorkKinds: []string{"review"}})
+	_ = profiles.SaveProfile(ctx, CompetencyProfile{ID: "profile-2", ActorID: "emp-2", MaxComplexity: 3})
+	_ = caps.SaveCapability(ctx, capability.Capability{ID: "cap-1", Code: "workflow.execute", Level: 1})
+	_ = caps.AssignCapability(ctx, capability.ActorCapability{ActorID: "emp-1", CapabilityID: "cap-1", Level: 1})
+	_ = caps.AssignCapability(ctx, capability.ActorCapability{ActorID: "emp-2", CapabilityID: "cap-1", Level: 1})
+	_ = trustRepo.Save(ctx, trust.TrustProfile{ActorID: "emp-1", TrustLevel: trust.TrustMedium})
+	_ = trustRepo.Save(ctx, trust.TrustProfile{ActorID: "emp-2", TrustLevel: trust.TrustHigh})
+	matcher := NewMatcher(profiles, profiles, caps, caps, trustService)
+	actors := []employee.DigitalEmployee{
+		{ID: "emp-1", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}},
+		{ID: "emp-2", Enabled: true, QueueMemberships: []string{"q-1"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}},
+	}
+	actor, reason, err := matcher.MatchActor(ctx, workplan.WorkItem{ID: "work-1", QueueID: "q-1", Type: "review"}, actionplan.ActionPlan{Actions: []actionplan.Action{{ID: "a-1", Type: "legacy_workflow_action"}}}, actors)
+	if err != nil {
+		t.Fatalf("MatchActor error = %v", err)
+	}
+	if actor.ID != "emp-2" {
+		t.Fatalf("selected actor = %#v", actor)
+	}
+	if !strings.Contains(reason, "trust level high applied") || !strings.Contains(reason, "others not chosen") {
+		t.Fatalf("reason = %q", reason)
 	}
 }

--- a/internal/trust/service.go
+++ b/internal/trust/service.go
@@ -3,6 +3,7 @@ package trust
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 type trustService struct {


### PR DESCRIPTION
### Motivation
- Connect the existing `Capability`, `Profile`, and `Trust` layers into a deterministic, governed actor selection pipeline and make execution behavior trust-aware.
- Ensure selection decisions are explainable and deterministic (no randomness or LLMs) and that trust affects execution constraints without replacing existing planner logic.

### Description
- Implemented a deterministic matcher in `internal/profile/matcher.go` that applies hard filters (enabled, queue membership, allowed action types), enforces capability requirements, enforces `MaxComplexity`, treats `PreferredWorkKinds` as a soft preference, integrates `trust.Service`, and ranks eligible actors deterministically by trust (`High > Medium > Low`), profile preference, then stable input order; selection reasons include why chosen and why others were rejected.
- Added `AdjustForTrust` to `internal/executioncontrol/types.go`, introduced `ExecutionModeSupervised` and `ExecutionModeStandard`, and defined deterministic adjustment rules: `TrustLow` → approval/guided mode with `MaxSteps=1`/`MaxDurationSec=60`, `TrustMedium` → supervised with moderate limits, `TrustHigh` → standard with broader limits; this extends (does not replace) planner output.
- Integrated trust adjustment into assignment/start flow in `internal/employee/service.go` by loading the selected actor's `TrustProfile` after selection and before execution start, applying `AdjustForTrust`, and emitting the `execution_mode_adjusted_by_trust` execution event with the adjustment details.
- Wired bootstrap in `internal/app/bootstrap.go` to seed a minimal capability and competency profile for the default employee and to construct `employee.Selector` with the governed matcher and pass `trust.Service` into `employee.Service` so the behavior is usable out of the box.

### Testing
- Added tests: `internal/profile/matcher_test.go` (capability rejection, max complexity, deterministic selection, preference vs trust), `internal/executioncontrol/service_test.go` (deterministic trust → constraints mapping), and `internal/employee/service_test.go` (assignment event + trust-adjusted constraints + low-trust selectable but constrained).
- Ran automated tests: `go test ./internal/profile ./internal/employee ./internal/executioncontrol` and `go test ./internal/app -run TestBootstrapProvidesEventCenterCaseRuntimeWorkplanPolicyExecutionControlAndEmployeeLayer -v`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0fc0d3e0c832488c3ee8a6c8e0733)