### PR TITLE
Add deterministic coordination layer: CoordinationDecision + DefaultCoordinator

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.ProposalService, result.EmployeeDirectory, result.EmployeeService)
+	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.Coordinator, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.ProposalService, result.EmployeeDirectory, result.EmployeeService)
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -141,8 +141,6 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	assignmentRouter := workplan.NewRouter(queueRepo, defaultQueue.ID)
 	planner := workplan.NewPlanner(planRepo, eventLog, clock, ids)
 	coordinationRepo := workplan.NewInMemoryCoordinationRepository()
-	coordinator := workplan.NewCoordinator(coordinationRepo, eventLog, clock, ids)
-	workService := workplan.NewService(queueRepo, assignmentRouter, planner, coordinator, eventLog, clock, ids)
 	policyRepo := policy.NewInMemoryRepository()
 	policyEvaluator := policy.NewEvaluator()
 	policyService := policy.NewService(policyRepo, policyEvaluator, eventLog, clock, ids)
@@ -214,6 +212,8 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	if err := profileRepo.SaveProfile(context.Background(), profile.CompetencyProfile{ID: "profile-legacy-operator", ActorID: defaultEmployee.ID, Name: "Legacy Operator", MaxComplexity: 10, PreferredWorkKinds: []string{"workflow.action"}}); err != nil {
 		return nil, fmt.Errorf("seed competency profile: %w", err)
 	}
+	coordinator := workplan.NewCoordinator(coordinationRepo, eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, assignmentRouter, planner, coordinator, eventLog, clock, ids)
 	employeeSelector := employee.NewSelectorWithMatcher(employeeDirectory, profile.NewMatcher(profileRepo, profileRepo, capabilityRepo, capabilityRepo, trustService))
 	employeeService := employee.NewService(assignmentRepo, employeeSelector, executionRuntime, eventLog, clock, ids, trustService)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {

--- a/internal/executioncontrol/planner.go
+++ b/internal/executioncontrol/planner.go
@@ -13,78 +13,41 @@ const UIScopeMarker = "ui.operator"
 
 type DeterministicPlanner struct{}
 
-func NewPlanner() *DeterministicPlanner {
-	return &DeterministicPlanner{}
-}
+func NewPlanner() *DeterministicPlanner { return &DeterministicPlanner{} }
 
 func (p *DeterministicPlanner) PlanForPolicyDecision(_ context.Context, coordination workplan.CoordinationDecision, policyDecision policy.PolicyDecision) (ExecutionConstraints, error) {
 	if policyDecision.Outcome == policy.PolicyDeny {
 		return ExecutionConstraints{}, fmt.Errorf("execution constraints cannot be created for denied policy decision %s", policyDecision.ID)
 	}
+	constraints := ExecutionConstraints{CoordinationDecisionID: coordination.ID, PolicyDecisionID: policyDecision.ID, CaseID: coordination.CaseID, WorkItemID: coordination.WorkItemID, QueueID: coordination.QueueID, RiskLevel: RiskMedium, ExecutionMode: ExecutionModeDeterministicAPI, MaxSteps: 10, MaxDurationSec: 300, AllowedScopes: []string{"default"}, ForbiddenOps: []string{}, Reason: fmt.Sprintf("baseline execution constraints selected for coordination decision %s with policy outcome %s", coordination.DecisionType, policyDecision.Outcome)}
 
-	constraints := ExecutionConstraints{
-		CoordinationDecisionID: coordination.ID,
-		PolicyDecisionID:       policyDecision.ID,
-		CaseID:                 coordination.CaseID,
-		WorkItemID:             coordination.WorkItemID,
-		QueueID:                coordination.QueueID,
-		RiskLevel:              RiskMedium,
-		ExecutionMode:          ExecutionModeDeterministicAPI,
-		MaxTokens:              0,
-		MaxCost:                0,
-		MaxSteps:               10,
-		MaxDurationSec:         300,
-		AllowedScopes:          []string{"default"},
-		ForbiddenOps:           []string{},
-		Reason:                 fmt.Sprintf("baseline execution constraints selected for strategy %s with policy outcome %s", coordination.Strategy, policyDecision.Outcome),
-	}
-
-	switch coordination.Strategy {
-	case "ui_operator_mode":
-		constraints.ExecutionMode = ExecutionModeGuidedUIOperator
-		constraints.RiskLevel = RiskHigh
-		constraints.MaxSteps = 20
-		constraints.MaxDurationSec = 900
-		constraints.AllowedScopes = appendUnique(constraints.AllowedScopes, UIScopeMarker)
-		constraints.Reason = "ui operator strategy requires guided high-risk execution constraints with deterministic UI scope"
-	case "checkpointed_mode":
-		constraints.ExecutionMode = ExecutionModeCheckpointedAutonomy
-		constraints.RiskLevel = RiskHigh
-		constraints.MaxSteps = 5
-		constraints.MaxDurationSec = 300
-		constraints.Reason = "checkpointed strategy requires bounded high-risk autonomy with explicit checkpoints"
-	case "requires_manager_approval":
+	switch coordination.DecisionType {
+	case workplan.CoordinationDefer:
 		constraints.RiskLevel = RiskHigh
 		constraints.ExecutionMode = ExecutionModeApprovalEachStep
 		constraints.MaxSteps = 1
 		constraints.MaxDurationSec = 60
-		constraints.Reason = "restrictive execution constraints selected because manager approval is required before any execution step"
-	case workplan.DefaultCoordinationStrategy:
-		if policyDecision.Outcome == policy.PolicyAllow {
-			constraints.Reason = "baseline execution constraints selected for default queue selection after policy allow"
-		}
+		constraints.Reason = "restrictive execution constraints selected because coordination deferred automatic execution"
+	case workplan.CoordinationEscalate:
+		constraints.RiskLevel = RiskCritical
+		constraints.ExecutionMode = ExecutionModeApprovalEachStep
+		constraints.MaxSteps = 1
+		constraints.MaxDurationSec = 60
+		constraints.Reason = "restrictive execution constraints selected because coordination escalated the work item"
 	}
-
 	if policyDecision.Outcome == policy.PolicyRequireApproval {
 		constraints.RiskLevel = RiskHigh
 		constraints.ExecutionMode = ExecutionModeApprovalEachStep
 		constraints.MaxSteps = 1
 		constraints.MaxDurationSec = 60
-		constraints.Reason = restrictiveReason(coordination.Strategy)
+		constraints.Reason = restrictiveReason(coordination.DecisionType)
 	}
-
 	constraints.Reason = strings.TrimSpace(constraints.Reason)
-	if constraints.Reason == "" {
-		constraints.Reason = fmt.Sprintf("execution constraints selected for strategy %s with policy outcome %s", coordination.Strategy, policyDecision.Outcome)
-	}
 	return constraints, nil
 }
 
-func restrictiveReason(strategy string) string {
-	if strategy == "requires_manager_approval" {
-		return "restrictive execution constraints selected because manager approval is required before any execution step"
-	}
-	return fmt.Sprintf("restrictive execution constraints selected because policy requires approval before continuing strategy %s", strategy)
+func restrictiveReason(decisionType workplan.CoordinationDecisionType) string {
+	return fmt.Sprintf("restrictive execution constraints selected because policy requires approval before continuing coordination decision %s", decisionType)
 }
 
 func appendUnique(values []string, value string) []string {

--- a/internal/executioncontrol/planner_test.go
+++ b/internal/executioncontrol/planner_test.go
@@ -8,100 +8,58 @@ import (
 	"kalita/internal/workplan"
 )
 
-func TestDeterministicPlannerAllowDefaultQueueSelection(t *testing.T) {
+func TestDeterministicPlannerExecuteNowUsesBaselineConstraints(t *testing.T) {
 	t.Parallel()
 	planner := NewPlanner()
-	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: workplan.DefaultCoordinationStrategy}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow})
+	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", DecisionType: workplan.CoordinationExecuteNow}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow})
 	if err != nil {
 		t.Fatalf("PlanForPolicyDecision error = %v", err)
 	}
 	if constraints.ExecutionMode != ExecutionModeDeterministicAPI || constraints.RiskLevel != RiskMedium || constraints.MaxSteps != 10 || constraints.MaxDurationSec != 300 {
 		t.Fatalf("constraints = %#v", constraints)
 	}
-	if len(constraints.AllowedScopes) != 1 || constraints.AllowedScopes[0] != "default" {
-		t.Fatalf("AllowedScopes = %#v", constraints.AllowedScopes)
-	}
-	if constraints.Reason == "" {
-		t.Fatal("Reason is empty")
-	}
 }
 
-func TestDeterministicPlannerRequireApprovalRestrictive(t *testing.T) {
+func TestDeterministicPlannerRequireApprovalIsRestrictive(t *testing.T) {
 	t.Parallel()
 	planner := NewPlanner()
-	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: workplan.DefaultCoordinationStrategy}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyRequireApproval})
+	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", DecisionType: workplan.CoordinationExecuteNow}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyRequireApproval})
 	if err != nil {
 		t.Fatalf("PlanForPolicyDecision error = %v", err)
 	}
 	if constraints.ExecutionMode != ExecutionModeApprovalEachStep || constraints.RiskLevel != RiskHigh || constraints.MaxSteps != 1 || constraints.MaxDurationSec != 60 {
 		t.Fatalf("constraints = %#v", constraints)
 	}
-	if constraints.Reason == "" {
-		t.Fatal("Reason is empty")
-	}
 }
 
-func TestDeterministicPlannerUIOperatorMode(t *testing.T) {
+func TestDeterministicPlannerDeferIsRestrictive(t *testing.T) {
 	t.Parallel()
 	planner := NewPlanner()
-	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: "ui_operator_mode"}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow})
+	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", DecisionType: workplan.CoordinationDefer}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow})
 	if err != nil {
 		t.Fatalf("PlanForPolicyDecision error = %v", err)
 	}
-	if constraints.ExecutionMode != ExecutionModeGuidedUIOperator || constraints.RiskLevel != RiskHigh || constraints.MaxSteps != 20 || constraints.MaxDurationSec != 900 {
+	if constraints.ExecutionMode != ExecutionModeApprovalEachStep || constraints.RiskLevel != RiskHigh {
 		t.Fatalf("constraints = %#v", constraints)
-	}
-	if len(constraints.AllowedScopes) != 2 || constraints.AllowedScopes[1] != UIScopeMarker {
-		t.Fatalf("AllowedScopes = %#v", constraints.AllowedScopes)
-	}
-	if constraints.Reason == "" {
-		t.Fatal("Reason is empty")
 	}
 }
 
-func TestDeterministicPlannerCheckpointedMode(t *testing.T) {
+func TestDeterministicPlannerEscalateRaisesCriticalRisk(t *testing.T) {
 	t.Parallel()
 	planner := NewPlanner()
-	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: "checkpointed_mode"}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow})
+	constraints, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", DecisionType: workplan.CoordinationEscalate}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow})
 	if err != nil {
 		t.Fatalf("PlanForPolicyDecision error = %v", err)
 	}
-	if constraints.ExecutionMode != ExecutionModeCheckpointedAutonomy || constraints.RiskLevel != RiskHigh || constraints.MaxSteps != 5 || constraints.MaxDurationSec != 300 {
+	if constraints.ExecutionMode != ExecutionModeApprovalEachStep || constraints.RiskLevel != RiskCritical {
 		t.Fatalf("constraints = %#v", constraints)
-	}
-	if constraints.Reason == "" {
-		t.Fatal("Reason is empty")
 	}
 }
 
 func TestDeterministicPlannerDenyReturnsError(t *testing.T) {
 	t.Parallel()
 	planner := NewPlanner()
-	if _, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", Strategy: workplan.DefaultCoordinationStrategy}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyDeny}); err == nil {
+	if _, err := planner.PlanForPolicyDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", DecisionType: workplan.CoordinationExecuteNow}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyDeny}); err == nil {
 		t.Fatal("expected error for deny outcome")
-	}
-}
-
-func TestDeterministicPlannerAllBranchesReturnReason(t *testing.T) {
-	t.Parallel()
-	planner := NewPlanner()
-	cases := []struct {
-		coordination workplan.CoordinationDecision
-		decision     policy.PolicyDecision
-	}{
-		{coordination: workplan.CoordinationDecision{ID: "coord-1", Strategy: workplan.DefaultCoordinationStrategy}, decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow}},
-		{coordination: workplan.CoordinationDecision{ID: "coord-2", Strategy: "requires_manager_approval"}, decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyAllow}},
-		{coordination: workplan.CoordinationDecision{ID: "coord-3", Strategy: "ui_operator_mode"}, decision: policy.PolicyDecision{ID: "pol-3", Outcome: policy.PolicyAllow}},
-		{coordination: workplan.CoordinationDecision{ID: "coord-4", Strategy: "checkpointed_mode"}, decision: policy.PolicyDecision{ID: "pol-4", Outcome: policy.PolicyAllow}},
-		{coordination: workplan.CoordinationDecision{ID: "coord-5", Strategy: workplan.DefaultCoordinationStrategy}, decision: policy.PolicyDecision{ID: "pol-5", Outcome: policy.PolicyRequireApproval}},
-	}
-	for _, tc := range cases {
-		constraints, err := planner.PlanForPolicyDecision(context.Background(), tc.coordination, tc.decision)
-		if err != nil {
-			t.Fatalf("PlanForPolicyDecision(%s,%s) error = %v", tc.coordination.Strategy, tc.decision.Outcome, err)
-		}
-		if constraints.Reason == "" {
-			t.Fatalf("Reason empty for strategy=%s outcome=%s", tc.coordination.Strategy, tc.decision.Outcome)
-		}
 	}
 }

--- a/internal/executioncontrol/service_test.go
+++ b/internal/executioncontrol/service_test.go
@@ -32,7 +32,7 @@ func TestServiceCreateAndRecordCreatesConstraintsAndEvent(t *testing.T) {
 	log := eventcore.NewInMemoryEventLog()
 	service := NewService(repo, NewPlanner(), log, fakeClock{now: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}, &fakeIDs{ids: []string{"constraints-1", "event-1"}})
 	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cause-1"})
-	coordination := workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Strategy: workplan.DefaultCoordinationStrategy}
+	coordination := workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", DecisionType: workplan.CoordinationExecuteNow}
 	decision := policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow}
 
 	constraints, err := service.CreateAndRecord(ctx, coordination, decision)
@@ -65,7 +65,7 @@ func TestServiceDeniedPolicyDoesNotCreateConstraints(t *testing.T) {
 	t.Parallel()
 	repo := NewInMemoryConstraintsRepository()
 	service := NewService(repo, NewPlanner(), nil, fakeClock{now: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}, &fakeIDs{ids: []string{"constraints-1"}})
-	_, err := service.CreateAndRecord(context.Background(), workplan.CoordinationDecision{ID: "coord-1", Strategy: workplan.DefaultCoordinationStrategy}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyDeny})
+	_, err := service.CreateAndRecord(context.Background(), workplan.CoordinationDecision{ID: "coord-1", DecisionType: workplan.CoordinationExecuteNow}, policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyDeny})
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -30,11 +30,11 @@ type actionRequest struct {
 }
 
 func ActionHandler(storage *runtime.Storage) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return ActionHandlerWithServices(storage, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func ActionHandlerWithCommandBus(storage *runtime.Storage, commandBus command.CommandBus) gin.HandlerFunc {
-	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil, nil, nil, nil, nil, nil)
+	return ActionHandlerWithServices(storage, commandBus, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 type commandCaseResolver interface {
@@ -44,6 +44,10 @@ type commandCaseResolver interface {
 type workItemIntakeService interface {
 	IntakeCommand(ctx context.Context, resolved caseruntime.ResolutionResult) (workplan.IntakeResult, error)
 	AttachActionPlan(ctx context.Context, workItemID string, plan actionplan.ActionPlan) (workplan.WorkItem, error)
+}
+
+type coordinator interface {
+	Decide(ctx context.Context, wi workplan.WorkItem, coordinationContext workplan.CoordinationContext) (workplan.CoordinationDecision, error)
 }
 
 type policyService interface {
@@ -68,7 +72,7 @@ type proposalService interface {
 	CompileProposal(ctx context.Context, proposalID string) (proposal.Proposal, actionplan.ActionPlan, error)
 }
 
-func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, proposalService proposalService, employeeDirectory employee.Directory, employeeServices ...employeeService) gin.HandlerFunc {
+func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.CommandBus, caseService commandCaseResolver, workService workItemIntakeService, coordinator coordinator, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, proposalService proposalService, employeeDirectory employee.Directory, employeeServices ...employeeService) gin.HandlerFunc {
 	var employeeService employeeService
 	if len(employeeServices) > 0 {
 		employeeService = employeeServices[0]
@@ -171,13 +175,29 @@ func ActionHandlerWithServices(storage *runtime.Storage, commandBus command.Comm
 								}}})
 								return
 							}
-							if _, err := workService.AttachActionPlan(c.Request.Context(), intakeResult.WorkItem.ID, plan); err != nil {
+							updatedWorkItem, err := workService.AttachActionPlan(c.Request.Context(), intakeResult.WorkItem.ID, plan)
+							if err != nil {
 								c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{
 									Code:    validation.ErrTypeMismatch,
 									Field:   "action",
 									Message: err.Error(),
 								}}})
 								return
+							}
+							intakeResult.WorkItem = updatedWorkItem
+							if coordinator != nil {
+								coordinationCtx := workplan.ContextWithPlanningExecution(c.Request.Context(), workplan.PlanningExecutionContext{ExecutionID: intakeResult.Command.ExecutionID, CorrelationID: intakeResult.Command.CorrelationID, CausationID: intakeResult.Command.ID})
+								decision, err := coordinator.Decide(coordinationCtx, updatedWorkItem, workplan.CoordinationContext{})
+								if err != nil {
+									c.JSON(http.StatusBadRequest, gin.H{"errors": []validation.FieldError{{Code: validation.ErrTypeMismatch, Field: "action", Message: err.Error()}}})
+									return
+								}
+								intakeResult.CoordinationDecision = decision
+								switch decision.DecisionType {
+								case workplan.CoordinationDefer, workplan.CoordinationEscalate, workplan.CoordinationBlock:
+									c.JSON(http.StatusAccepted, gin.H{"coordination_decision": decision})
+									return
+								}
 							}
 							if employeeService != nil {
 								runtimeCtx := executionruntime.ContextWithExecution(c.Request.Context(), executionruntime.ExecutionContext{ExecutionID: intakeResult.Command.ExecutionID, CorrelationID: intakeResult.Command.CorrelationID, CausationID: intakeResult.Command.ID})

--- a/internal/http/actions_test.go
+++ b/internal/http/actions_test.go
@@ -266,7 +266,7 @@ func (p failingPlanner) EnsurePlanForWorkItem(context.Context, workplan.WorkQueu
 
 type failingCoordinator struct{ err error }
 
-func (f failingCoordinator) CoordinateWorkItem(context.Context, workplan.WorkItem) (workplan.CoordinationDecision, error) {
+func (f failingCoordinator) Decide(context.Context, workplan.WorkItem, workplan.CoordinationContext) (workplan.CoordinationDecision, error) {
 	return workplan.CoordinationDecision{}, f.err
 }
 
@@ -396,7 +396,7 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, coordinator, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -444,7 +444,7 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	if executionEvents[3].Step != "daily_plan_intake" || executionEvents[3].Status != "attached" {
 		t.Fatalf("fourth execution event = %#v", executionEvents[3])
 	}
-	if executionEvents[4].Step != "coordination_decision" || executionEvents[4].Status != "selected" {
+	if executionEvents[4].Step != "coordination_decision_made" || executionEvents[4].Status != string(workplan.CoordinationExecuteNow) {
 		t.Fatalf("fifth execution event = %#v", executionEvents[4])
 	}
 	workItems, err := queueRepo.ListWorkItemsByCase(context.Background(), "case-1")
@@ -465,7 +465,7 @@ func TestActionHandlerResolvesCaseBeforeLegacyFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListByWorkItem error = %v", err)
 	}
-	if len(decisions) != 1 || decisions[0].Outcome != workplan.CoordinationSelected {
+	if len(decisions) != 1 || decisions[0].DecisionType != workplan.CoordinationExecuteNow {
 		t.Fatalf("coordination decisions = %#v", decisions)
 	}
 	if got := storage.Data["test.WorkflowTask"][rec.ID].Data["status"]; got != "Draft" {
@@ -479,7 +479,7 @@ func TestActionHandlerReturnsValidationErrorWhenCaseResolutionFails(t *testing.T
 
 	storage, rec := testHTTPWorkflowStorage()
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil, nil, nil, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, staticCommandBus{cmd: eventcore.Command{ID: "cmd-1", CorrelationID: "corr-1", ExecutionID: "exec-1", Type: "workflow.action", TargetRef: "test.WorkflowTask/" + rec.ID}}, failingCaseService{err: errors.New("case resolution failed")}, nil, nil, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -508,7 +508,7 @@ func TestActionHandlerReturnsValidationErrorWhenWorkItemIntakeFails(t *testing.T
 	caseRepo := caseruntime.NewInMemoryCaseRepository()
 	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}, nil, nil, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, failingWorkService{err: errors.New("work intake failed")}, nil, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -544,7 +544,7 @@ func TestActionHandlerReturnsValidationErrorWhenCoordinationFails(t *testing.T) 
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, failingCoordinator{err: errors.New("coordination failed")}, eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -579,7 +579,7 @@ func TestActionHandlerPolicyAllowContinuesLegacyFlow(t *testing.T) {
 	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{
 		decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"},
 	}, nil, nil, nil, nil))
 
@@ -614,7 +614,7 @@ func TestActionHandlerPolicyAllowCreatesAndAttachesActionPlanBeforeLegacyFlow(t 
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 	actionPlanSvc := &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "legacy workflow action approved for execution", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, nil, actionPlanSvc, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, nil, actionPlanSvc, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -657,7 +657,7 @@ func TestActionHandlerPolicyRequireApprovalStopsBeforeLegacyFlow(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{
 		decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"},
 		approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending},
 	}, nil, nil, nil, nil))
@@ -696,7 +696,7 @@ func TestActionHandlerPolicyDenyStopsBeforeLegacyFlow(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, nil, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -756,7 +756,7 @@ func TestActionHandlerPolicyAllowAssignsEmployeeAndStartsExecutionSession(t *tes
 	actionPlanSvc := &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "legacy workflow action approved for execution", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}
 	employeeSvc := &staticEmployeeService{assignment: employee.Assignment{ID: "assignment-1", EmployeeID: "employee-1"}, session: executionruntime.ExecutionSession{ID: "session-1", Status: executionruntime.ExecutionSessionSucceeded}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, actionPlanSvc, nil, nil, employeeSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, actionPlanSvc, nil, nil, employeeSvc))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -798,7 +798,7 @@ func TestActionHandlerNoEligibleEmployeeReturnsValidationError(t *testing.T) {
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 	employeeSvc := &staticEmployeeService{err: errors.New("no eligible digital employee")}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "ready", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}, nil, nil, employeeSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{plan: actionplan.ActionPlan{ID: "action-plan-1", Reason: "ready", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action", Params: map[string]any{"entity": "test.WorkflowTask", "record_id": rec.ID, "action": "submit"}, Reversibility: actionplan.ReversibilityIrreversible, Idempotency: actionplan.IdempotencyConditional, CreatedAt: clock.now}}, CreatedAt: clock.now}}, nil, nil, employeeSvc))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -923,7 +923,7 @@ func TestActionHandlerReturnsValidationErrorWhenDailyPlanAttachmentFails(t *test
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), failingPlanner{err: errors.New("daily plan failed")}, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, nil, nil, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -960,7 +960,7 @@ func TestActionHandlerPolicyAllowCreatesConstraintsBeforeLegacyFlow(t *testing.T
 	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -997,7 +997,7 @@ func TestActionHandlerPolicyRequireApprovalRecordsConstraintsAndStopsBeforeLegac
 	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"}, approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending}}, constraintsSvc, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "policy-1", Outcome: policy.PolicyRequireApproval, Reason: "manager approval required"}, approval: &policy.ApprovalRequest{ID: "approval-1", Status: policy.ApprovalPending}}, constraintsSvc, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -1036,7 +1036,7 @@ func TestActionHandlerPolicyDenyDoesNotCreateConstraintsAndStopsBeforeLegacyFlow
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, "default-intake"), planner, workplan.NewCoordinator(workplan.NewInMemoryCoordinationRepository(), eventLog, clock, ids), eventLog, clock, ids)
 	constraintsSvc := &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, constraintsSvc, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-2", Outcome: policy.PolicyDeny, Reason: "blocked by policy"}}, constraintsSvc, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -1073,7 +1073,7 @@ func TestActionHandlerConstraintCreationFailureReturnsValidationError(t *testing
 	constraintsSvc := &staticConstraintsService{err: errors.New("constraints failed")}
 
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil, nil, nil))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, constraintsSvc, nil, nil, nil))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -1114,7 +1114,7 @@ func TestActionHandlerPolicyAllowCreatesProposalValidatesCompilesThenContinues(t
 	proposalSvc := &staticProposalService{plan: actionplan.ActionPlan{ID: "action-plan-1", Actions: []actionplan.Action{{ID: "action-1", Type: "legacy_workflow_action"}}}}
 	employeeSvc := &staticEmployeeService{assignment: employee.Assignment{ID: "assignment-1", EmployeeID: "employee-1"}, session: executionruntime.ExecutionSession{ID: "session-1", Status: executionruntime.ExecutionSessionSucceeded}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{}, proposalSvc, directory, employeeSvc))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, &staticConstraintsService{constraints: executioncontrol.ExecutionConstraints{ID: "constraints-1"}}, &staticActionPlanService{}, proposalSvc, directory, employeeSvc))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)
@@ -1155,7 +1155,7 @@ func TestActionHandlerInvalidProposalReturnsValidationStyleError(t *testing.T) {
 	_ = directory.SaveEmployee(context.Background(), employee.DigitalEmployee{ID: "employee-1", Enabled: true, QueueMemberships: []string{"default-intake"}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}})
 	proposalSvc := &staticProposalService{proposal: proposal.Proposal{ID: "proposal-1", Status: proposal.ProposalRejected, RejectionReason: "proposal rejected by deterministic validator"}}
 	router := gin.New()
-	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, nil, &staticActionPlanService{}, proposalSvc, directory))
+	router.POST("/api/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, nil, staticPolicyService{decision: policy.PolicyDecision{ID: "pol-1", Outcome: policy.PolicyAllow, Reason: "allowed"}}, nil, &staticActionPlanService{}, proposalSvc, directory))
 
 	body := map[string]any{"record_version": 3}
 	raw, _ := json.Marshal(body)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -13,14 +13,14 @@ import (
 )
 
 func RunServer(addr string, storage *runtime.Storage) {
-	RunServerWithServices(addr, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+	RunServerWithServices(addr, storage, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus command.CommandBus) {
-	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil, nil, nil, nil)
+	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
-func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, proposalService proposalService, employeeDirectory employee.Directory, employeeServices ...employeeService) {
+func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, coordinator coordinator, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, proposalService proposalService, employeeDirectory employee.Directory, employeeServices ...employeeService) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -40,7 +40,7 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
-		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, policyService, constraintsService, actionPlanService, proposalService, employeeDirectory, employeeServices...))
+		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, coordinator, policyService, constraintsService, actionPlanService, proposalService, employeeDirectory, employeeServices...))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action/requests", CreateActionRequestHandler(storage))
 		apiGroup.GET("/_action_requests/:request_id", GetActionRequestHandler(storage))
 		r.GET("/api/core/attachment/:id/download", DownloadAttachmentHandler(storage))

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -14,14 +14,14 @@ func NewEvaluator() *DeterministicEvaluator {
 }
 
 func (e *DeterministicEvaluator) EvaluateCoordinationDecision(_ context.Context, d workplan.CoordinationDecision) (PolicyOutcome, string, error) {
-	switch d.Strategy {
-	case "requires_manager_approval":
-		return PolicyRequireApproval, fmt.Sprintf("strategy %s requires manager approval before execution", d.Strategy), nil
-	case "blocked_strategy":
-		return PolicyDeny, fmt.Sprintf("strategy %s is blocked from execution", d.Strategy), nil
+	switch d.DecisionType {
+	case workplan.CoordinationExecuteNow:
+		return PolicyAllow, fmt.Sprintf("coordination decision %s authorized execution for work item %s", d.ID, d.WorkItemID), nil
+	case workplan.CoordinationDefer:
+		return PolicyRequireApproval, fmt.Sprintf("coordination decision %s deferred work item %s pending approval or rescheduling", d.ID, d.WorkItemID), nil
+	case workplan.CoordinationEscalate, workplan.CoordinationBlock:
+		return PolicyDeny, fmt.Sprintf("coordination decision %s blocked automatic execution for work item %s", d.ID, d.WorkItemID), nil
+	default:
+		return PolicyDeny, fmt.Sprintf("coordination decision %s has unsupported decision type %q", d.ID, d.DecisionType), nil
 	}
-	if d.Outcome == workplan.CoordinationSelected {
-		return PolicyAllow, fmt.Sprintf("coordination decision %s selected work item %s for execution", d.ID, d.WorkItemID), nil
-	}
-	return PolicyAllow, fmt.Sprintf("coordination strategy %s allowed by default for work item %s", d.Strategy, d.WorkItemID), nil
 }

--- a/internal/policy/evaluator_test.go
+++ b/internal/policy/evaluator_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestDeterministicEvaluatorSelectedAllows(t *testing.T) {
 	e := NewEvaluator()
-	outcome, reason, err := e.EvaluateCoordinationDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "wi-1", Outcome: workplan.CoordinationSelected, Strategy: workplan.DefaultCoordinationStrategy})
+	outcome, reason, err := e.EvaluateCoordinationDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "wi-1", DecisionType: workplan.CoordinationExecuteNow, Priority: workplan.CoordinationPriorityExecuteNow})
 	if err != nil {
 		t.Fatalf("EvaluateCoordinationDecision error = %v", err)
 	}
@@ -23,7 +23,7 @@ func TestDeterministicEvaluatorSelectedAllows(t *testing.T) {
 
 func TestDeterministicEvaluatorRequiresApprovalStrategy(t *testing.T) {
 	e := NewEvaluator()
-	outcome, reason, err := e.EvaluateCoordinationDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "wi-1", Outcome: workplan.CoordinationSelected, Strategy: "requires_manager_approval"})
+	outcome, reason, err := e.EvaluateCoordinationDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "wi-1", DecisionType: workplan.CoordinationDefer, Priority: workplan.CoordinationPriorityDefer})
 	if err != nil {
 		t.Fatalf("EvaluateCoordinationDecision error = %v", err)
 	}
@@ -37,7 +37,7 @@ func TestDeterministicEvaluatorRequiresApprovalStrategy(t *testing.T) {
 
 func TestDeterministicEvaluatorBlockedStrategyDenies(t *testing.T) {
 	e := NewEvaluator()
-	outcome, reason, err := e.EvaluateCoordinationDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "wi-1", Outcome: workplan.CoordinationSelected, Strategy: "blocked_strategy"})
+	outcome, reason, err := e.EvaluateCoordinationDecision(context.Background(), workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "wi-1", DecisionType: workplan.CoordinationBlock, Priority: workplan.CoordinationPriorityBlock})
 	if err != nil {
 		t.Fatalf("EvaluateCoordinationDecision error = %v", err)
 	}

--- a/internal/policy/service_test.go
+++ b/internal/policy/service_test.go
@@ -27,7 +27,7 @@ func TestPolicyServiceAllowCreatesDecisionAndEvent(t *testing.T) {
 	ids := &fakeIDGenerator{ids: []string{"policy-1", "event-1"}}
 	service := NewService(repo, NewEvaluator(), log, clock, ids)
 	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
-	decision, approval, err := service.EvaluateAndRecord(ctx, workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", Outcome: workplan.CoordinationSelected, Strategy: workplan.DefaultCoordinationStrategy})
+	decision, approval, err := service.EvaluateAndRecord(ctx, workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", DecisionType: workplan.CoordinationExecuteNow, Priority: workplan.CoordinationPriorityExecuteNow})
 	if err != nil {
 		t.Fatalf("EvaluateAndRecord error = %v", err)
 	}
@@ -54,7 +54,7 @@ func TestPolicyServiceRequireApprovalCreatesDecisionApprovalAndEvents(t *testing
 	ids := &fakeIDGenerator{ids: []string{"policy-1", "event-1", "approval-1", "event-2"}}
 	service := NewService(repo, NewEvaluator(), log, clock, ids)
 	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
-	decision, approval, err := service.EvaluateAndRecord(ctx, workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", Outcome: workplan.CoordinationSelected, Strategy: "requires_manager_approval"})
+	decision, approval, err := service.EvaluateAndRecord(ctx, workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", DecisionType: workplan.CoordinationDefer, Priority: workplan.CoordinationPriorityDefer})
 	if err != nil {
 		t.Fatalf("EvaluateAndRecord error = %v", err)
 	}
@@ -81,7 +81,7 @@ func TestPolicyServiceDenyCreatesDecisionAndEventWithoutApproval(t *testing.T) {
 	ids := &fakeIDGenerator{ids: []string{"policy-1", "event-1"}}
 	service := NewService(repo, NewEvaluator(), log, clock, ids)
 	ctx := ContextWithExecution(context.Background(), ExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
-	decision, approval, err := service.EvaluateAndRecord(ctx, workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", Outcome: workplan.CoordinationSelected, Strategy: "blocked_strategy"})
+	decision, approval, err := service.EvaluateAndRecord(ctx, workplan.CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", DecisionType: workplan.CoordinationBlock, Priority: workplan.CoordinationPriorityBlock})
 	if err != nil {
 		t.Fatalf("EvaluateAndRecord error = %v", err)
 	}

--- a/internal/workplan/coordination.go
+++ b/internal/workplan/coordination.go
@@ -5,25 +5,52 @@ import (
 	"time"
 )
 
-type CoordinationOutcome string
+type CoordinationDecisionType string
 
 const (
-	CoordinationSelected  CoordinationOutcome = "selected"
-	CoordinationDeferred  CoordinationOutcome = "deferred"
-	CoordinationBlocked   CoordinationOutcome = "blocked"
-	CoordinationEscalated CoordinationOutcome = "escalated"
+	CoordinationExecuteNow CoordinationDecisionType = "execute_now"
+	CoordinationDefer      CoordinationDecisionType = "defer"
+	CoordinationEscalate   CoordinationDecisionType = "escalate"
+	CoordinationBlock      CoordinationDecisionType = "block"
+)
+
+const (
+	CoordinationPriorityBlock      = 1
+	CoordinationPriorityDefer      = 2
+	CoordinationPriorityExecuteNow = 3
+	CoordinationPriorityEscalate   = 4
 )
 
 type CoordinationDecision struct {
-	ID         string
-	CaseID     string
-	WorkItemID string
-	QueueID    string
-	Strategy   string
-	SelectedBy string
-	Outcome    CoordinationOutcome
-	Reason     string
-	CreatedAt  time.Time
+	ID           string
+	WorkItemID   string
+	CaseID       string
+	QueueID      string
+	DecisionType CoordinationDecisionType
+	Priority     int
+	Reason       string
+	CreatedAt    time.Time
+}
+
+type CoordinationActor struct {
+	ID                 string
+	Enabled            bool
+	QueueMemberships   []string
+	AllowedActionTypes []string
+}
+
+type CoordinationActorProfile struct {
+	ActorID        string
+	MaxComplexity  int
+	TrustLevel     string
+	TrustAvailable bool
+}
+
+type CoordinationContext struct {
+	ActionTypes []string
+	Complexity  int
+	Actors      []CoordinationActor
+	Profiles    map[string]CoordinationActorProfile
 }
 
 type CoordinationRepository interface {
@@ -35,5 +62,5 @@ type CoordinationRepository interface {
 }
 
 type Coordinator interface {
-	CoordinateWorkItem(ctx context.Context, wi WorkItem) (CoordinationDecision, error)
+	Decide(ctx context.Context, wi WorkItem, coordinationContext CoordinationContext) (CoordinationDecision, error)
 }

--- a/internal/workplan/coordination_repository_test.go
+++ b/internal/workplan/coordination_repository_test.go
@@ -9,7 +9,7 @@ import (
 func TestInMemoryCoordinationRepositorySaveAndGetDecision(t *testing.T) {
 	t.Parallel()
 	repo := NewInMemoryCoordinationRepository()
-	decision := CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", QueueID: "queue-1", Strategy: DefaultCoordinationStrategy, SelectedBy: "system", Outcome: CoordinationSelected, Reason: "selected", CreatedAt: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}
+	decision := CoordinationDecision{ID: "coord-1", CaseID: "case-1", WorkItemID: "wi-1", DecisionType: CoordinationExecuteNow, Priority: CoordinationPriorityExecuteNow, Reason: "selected", CreatedAt: time.Date(2026, 3, 22, 16, 0, 0, 0, time.UTC)}
 	if err := repo.SaveDecision(context.Background(), decision); err != nil {
 		t.Fatalf("SaveDecision error = %v", err)
 	}

--- a/internal/workplan/coordination_service.go
+++ b/internal/workplan/coordination_service.go
@@ -3,69 +3,126 @@ package workplan
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"kalita/internal/eventcore"
 )
 
-const DefaultCoordinationStrategy = "default_queue_selection"
-
-type CoordinationService struct {
+type DefaultCoordinator struct {
 	repo  CoordinationRepository
 	log   eventcore.EventLog
 	clock eventcore.Clock
 	ids   eventcore.IDGenerator
 }
 
-func NewCoordinator(repo CoordinationRepository, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *CoordinationService {
+func NewCoordinator(repo CoordinationRepository, log eventcore.EventLog, clock eventcore.Clock, ids eventcore.IDGenerator) *DefaultCoordinator {
 	if clock == nil {
 		clock = eventcore.RealClock{}
 	}
 	if ids == nil {
 		ids = eventcore.NewULIDGenerator()
 	}
-	return &CoordinationService{repo: repo, log: log, clock: clock, ids: ids}
+	return &DefaultCoordinator{repo: repo, log: log, clock: clock, ids: ids}
 }
 
-func (s *CoordinationService) CoordinateWorkItem(ctx context.Context, wi WorkItem) (CoordinationDecision, error) {
+func (s *DefaultCoordinator) Decide(ctx context.Context, wi WorkItem, coordinationContext CoordinationContext) (CoordinationDecision, error) {
 	if s.repo == nil {
 		return CoordinationDecision{}, fmt.Errorf("coordination repository is nil")
 	}
 	now := s.clock.Now()
-	decision := CoordinationDecision{
-		ID:         s.ids.NewID(),
-		CaseID:     wi.CaseID,
-		WorkItemID: wi.ID,
-		QueueID:    wi.QueueID,
-		Strategy:   DefaultCoordinationStrategy,
-		SelectedBy: "system",
-		Outcome:    CoordinationSelected,
-		Reason:     fmt.Sprintf("strategy %s selected work item %s from queue %s", DefaultCoordinationStrategy, wi.ID, wi.QueueID),
-		CreatedAt:  now,
-	}
+	decisionType, reason := s.evaluate(wi, coordinationContext)
+	decision := CoordinationDecision{ID: s.ids.NewID(), WorkItemID: wi.ID, CaseID: wi.CaseID, QueueID: wi.QueueID, DecisionType: decisionType, Priority: coordinationPriority(decisionType), Reason: reason, CreatedAt: now}
 	if err := s.repo.SaveDecision(ctx, decision); err != nil {
 		return CoordinationDecision{}, err
 	}
 	if s.log != nil {
 		meta := planningExecutionFromContext(ctx)
-		if err := s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{
-			ID:            s.ids.NewID(),
-			ExecutionID:   meta.ExecutionID,
-			CaseID:        wi.CaseID,
-			Step:          "coordination_decision",
-			Status:        string(decision.Outcome),
-			OccurredAt:    now,
-			CorrelationID: meta.CorrelationID,
-			CausationID:   meta.CausationID,
-			Payload: map[string]any{
-				"case_id":                  wi.CaseID,
-				"queue_id":                 wi.QueueID,
-				"work_item_id":             wi.ID,
-				"coordination_decision_id": decision.ID,
-				"strategy":                 decision.Strategy,
-			},
-		}); err != nil {
+		if err := s.log.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{ID: s.ids.NewID(), ExecutionID: meta.ExecutionID, CaseID: wi.CaseID, Step: "coordination_decision_made", Status: string(decision.DecisionType), OccurredAt: now, CorrelationID: meta.CorrelationID, CausationID: meta.CausationID, Payload: map[string]any{"case_id": wi.CaseID, "queue_id": wi.QueueID, "work_item_id": wi.ID, "coordination_decision_id": decision.ID, "decision_type": decision.DecisionType, "reason": decision.Reason, "priority": decision.Priority}}); err != nil {
 			return CoordinationDecision{}, err
 		}
 	}
 	return decision, nil
+}
+
+func (s *DefaultCoordinator) evaluate(wi WorkItem, coordinationContext CoordinationContext) (CoordinationDecisionType, string) {
+	if wi.Status == string(WorkItemDone) {
+		return CoordinationBlock, fmt.Sprintf("work item %s already executed", wi.ID)
+	}
+	if coordinationContext.Complexity == 0 {
+		coordinationContext.Complexity = len(coordinationContext.ActionTypes)
+	}
+	if len(coordinationContext.Actors) == 0 {
+		return CoordinationExecuteNow, "coordination context not yet enriched with actors; continue to downstream eligibility checks"
+	}
+	eligibleActors := make([]string, 0)
+	highTrustActors := make([]string, 0)
+	lowTrustActors := make([]string, 0)
+	complexityLimited := false
+	for _, actor := range coordinationContext.Actors {
+		if !actor.Enabled || !containsString(actor.QueueMemberships, wi.QueueID) {
+			continue
+		}
+		if len(coordinationContext.ActionTypes) > 0 && !allowsAllActionTypes(actor, coordinationContext.ActionTypes) {
+			continue
+		}
+		if profile, ok := coordinationContext.Profiles[actor.ID]; ok && profile.MaxComplexity > 0 && coordinationContext.Complexity > profile.MaxComplexity {
+			complexityLimited = true
+			continue
+		}
+		eligibleActors = append(eligibleActors, actor.ID)
+		trustLevel := "low"
+		if profile, ok := coordinationContext.Profiles[actor.ID]; ok && profile.TrustAvailable {
+			trustLevel = profile.TrustLevel
+		}
+		if trustLevel == "high" {
+			highTrustActors = append(highTrustActors, actor.ID)
+		} else {
+			lowTrustActors = append(lowTrustActors, actor.ID)
+		}
+	}
+	if len(eligibleActors) == 0 {
+		if complexityLimited {
+			return CoordinationEscalate, fmt.Sprintf("work item complexity %d exceeds available actor profiles", coordinationContext.Complexity)
+		}
+		return CoordinationBlock, fmt.Sprintf("no eligible actor available for queue %s", wi.QueueID)
+	}
+	if len(highTrustActors) > 0 {
+		return CoordinationExecuteNow, fmt.Sprintf("high-trust actor available: %s", strings.Join(highTrustActors, ","))
+	}
+	return CoordinationDefer, fmt.Sprintf("only low-trust actors available: %s; defer until stronger trust or supervised release", strings.Join(lowTrustActors, ","))
+}
+
+func coordinationPriority(decisionType CoordinationDecisionType) int {
+	switch decisionType {
+	case CoordinationEscalate:
+		return CoordinationPriorityEscalate
+	case CoordinationExecuteNow:
+		return CoordinationPriorityExecuteNow
+	case CoordinationDefer:
+		return CoordinationPriorityDefer
+	default:
+		return CoordinationPriorityBlock
+	}
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func allowsAllActionTypes(actor CoordinationActor, actions []string) bool {
+	allowed := make(map[string]struct{}, len(actor.AllowedActionTypes))
+	for _, actionType := range actor.AllowedActionTypes {
+		allowed[actionType] = struct{}{}
+	}
+	for _, action := range actions {
+		if _, ok := allowed[action]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/workplan/coordination_service_test.go
+++ b/internal/workplan/coordination_service_test.go
@@ -8,45 +8,69 @@ import (
 	"kalita/internal/eventcore"
 )
 
-func TestCoordinatorCreatesSelectedDecisionAndExecutionEventDeterministically(t *testing.T) {
+func TestCoordinatorExecutesNowForHighTrustActor(t *testing.T) {
 	t.Parallel()
 	repo := NewInMemoryCoordinationRepository()
 	log := eventcore.NewInMemoryEventLog()
 	clock := fakeClock{now: time.Date(2026, 3, 22, 16, 30, 0, 0, time.UTC)}
 	ids := &fakeIDGenerator{ids: []string{"coord-1", "coord-event-1"}}
 	coordinator := NewCoordinator(repo, log, clock, ids)
-	wi := WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1"}
+	wi := WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1", Status: string(WorkItemOpen)}
 	ctx := ContextWithPlanningExecution(context.Background(), PlanningExecutionContext{ExecutionID: "exec-1", CorrelationID: "corr-1", CausationID: "cmd-1"})
 
-	decision, err := coordinator.CoordinateWorkItem(ctx, wi)
+	decision, err := coordinator.Decide(ctx, wi, CoordinationContext{ActionTypes: []string{"legacy_workflow_action"}, Complexity: 1, Actors: []CoordinationActor{{ID: "emp-1", Enabled: true, QueueMemberships: []string{"queue-1"}, AllowedActionTypes: []string{"legacy_workflow_action"}}}, Profiles: map[string]CoordinationActorProfile{"emp-1": {ActorID: "emp-1", MaxComplexity: 3, TrustLevel: "high", TrustAvailable: true}}})
 	if err != nil {
-		t.Fatalf("CoordinateWorkItem error = %v", err)
+		t.Fatalf("Decide error = %v", err)
 	}
-	if decision.ID != "coord-1" || decision.Strategy != DefaultCoordinationStrategy || decision.SelectedBy != "system" || decision.Outcome != CoordinationSelected {
+	if decision.DecisionType != CoordinationExecuteNow || decision.Priority != CoordinationPriorityExecuteNow {
 		t.Fatalf("decision = %#v", decision)
-	}
-	if decision.Reason == "" || !decision.CreatedAt.Equal(clock.now) {
-		t.Fatalf("decision = %#v", decision)
-	}
-	stored, ok, err := repo.GetDecision(context.Background(), "coord-1")
-	if err != nil || !ok {
-		t.Fatalf("GetDecision = %#v ok=%v err=%v", stored, ok, err)
-	}
-	if stored != decision {
-		t.Fatalf("stored = %#v, want %#v", stored, decision)
 	}
 	_, executionEvents, err := log.ListByCorrelation(context.Background(), "corr-1")
+	if err != nil || len(executionEvents) != 1 {
+		t.Fatalf("events err=%v len=%d", err, len(executionEvents))
+	}
+	if executionEvents[0].Step != "coordination_decision_made" || executionEvents[0].Status != string(CoordinationExecuteNow) {
+		t.Fatalf("execution event = %#v", executionEvents[0])
+	}
+}
+
+func TestCoordinatorDefersForOnlyLowTrustActors(t *testing.T) {
+	t.Parallel()
+	decision, err := NewCoordinator(NewInMemoryCoordinationRepository(), nil, fakeClock{now: time.Date(2026, 3, 22, 16, 30, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"coord-1"}}).Decide(context.Background(), WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1", Status: string(WorkItemOpen)}, CoordinationContext{ActionTypes: []string{"legacy_workflow_action"}, Complexity: 1, Actors: []CoordinationActor{{ID: "emp-1", Enabled: true, QueueMemberships: []string{"queue-1"}, AllowedActionTypes: []string{"legacy_workflow_action"}}}, Profiles: map[string]CoordinationActorProfile{"emp-1": {ActorID: "emp-1", MaxComplexity: 2, TrustLevel: "low", TrustAvailable: true}}})
+	if err != nil || decision.DecisionType != CoordinationDefer {
+		t.Fatalf("decision=%#v err=%v", decision, err)
+	}
+}
+
+func TestCoordinatorBlocksWhenNoEligibleActorExists(t *testing.T) {
+	t.Parallel()
+	decision, err := NewCoordinator(NewInMemoryCoordinationRepository(), nil, fakeClock{now: time.Date(2026, 3, 22, 16, 30, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"coord-1"}}).Decide(context.Background(), WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1", Status: string(WorkItemOpen)}, CoordinationContext{ActionTypes: []string{"legacy_workflow_action"}, Complexity: 1, Actors: []CoordinationActor{{ID: "emp-1", Enabled: false, QueueMemberships: []string{"queue-1"}, AllowedActionTypes: []string{"legacy_workflow_action"}}}})
+	if err != nil || decision.DecisionType != CoordinationBlock {
+		t.Fatalf("decision=%#v err=%v", decision, err)
+	}
+}
+
+func TestCoordinatorEscalatesWhenComplexityExceedsAvailableProfiles(t *testing.T) {
+	t.Parallel()
+	decision, err := NewCoordinator(NewInMemoryCoordinationRepository(), nil, fakeClock{now: time.Date(2026, 3, 22, 16, 30, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"coord-1"}}).Decide(context.Background(), WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1", Status: string(WorkItemOpen)}, CoordinationContext{ActionTypes: []string{"legacy_workflow_action", "legacy_workflow_action"}, Complexity: 2, Actors: []CoordinationActor{{ID: "emp-1", Enabled: true, QueueMemberships: []string{"queue-1"}, AllowedActionTypes: []string{"legacy_workflow_action"}}}, Profiles: map[string]CoordinationActorProfile{"emp-1": {ActorID: "emp-1", MaxComplexity: 1, TrustLevel: "high", TrustAvailable: true}}})
+	if err != nil || decision.DecisionType != CoordinationEscalate {
+		t.Fatalf("decision=%#v err=%v", decision, err)
+	}
+}
+
+func TestCoordinatorIsDeterministic(t *testing.T) {
+	t.Parallel()
+	coordinationContext := CoordinationContext{ActionTypes: []string{"legacy_workflow_action"}, Complexity: 1, Actors: []CoordinationActor{{ID: "emp-1", Enabled: true, QueueMemberships: []string{"queue-1"}, AllowedActionTypes: []string{"legacy_workflow_action"}}}, Profiles: map[string]CoordinationActorProfile{"emp-1": {ActorID: "emp-1", MaxComplexity: 2, TrustLevel: "high", TrustAvailable: true}}}
+	coordinator := NewCoordinator(NewInMemoryCoordinationRepository(), nil, fakeClock{now: time.Date(2026, 3, 22, 16, 30, 0, 0, time.UTC)}, &fakeIDGenerator{ids: []string{"coord-1", "coord-2"}})
+	first, err := coordinator.Decide(context.Background(), WorkItem{ID: "wi-1", CaseID: "case-1", QueueID: "queue-1", Status: string(WorkItemOpen)}, coordinationContext)
 	if err != nil {
-		t.Fatalf("ListByCorrelation error = %v", err)
+		t.Fatalf("first Decide error = %v", err)
 	}
-	if len(executionEvents) != 1 {
-		t.Fatalf("execution events len = %d", len(executionEvents))
+	second, err := coordinator.Decide(context.Background(), WorkItem{ID: "wi-2", CaseID: "case-2", QueueID: "queue-1", Status: string(WorkItemOpen)}, coordinationContext)
+	if err != nil {
+		t.Fatalf("second Decide error = %v", err)
 	}
-	got := executionEvents[0]
-	if got.ID != "coord-event-1" || got.Step != "coordination_decision" || got.Status != "selected" || got.ExecutionID != "exec-1" || got.CausationID != "cmd-1" {
-		t.Fatalf("execution event = %#v", got)
-	}
-	if got.Payload["coordination_decision_id"] != "coord-1" || got.Payload["strategy"] != DefaultCoordinationStrategy {
-		t.Fatalf("payload = %#v", got.Payload)
+	if first.DecisionType != second.DecisionType || first.Priority != second.Priority || first.Reason != second.Reason {
+		t.Fatalf("first=%#v second=%#v", first, second)
 	}
 }

--- a/internal/workplan/service.go
+++ b/internal/workplan/service.go
@@ -112,7 +112,7 @@ func (s *Service) IntakeCommand(ctx context.Context, resolved caseruntime.Resolu
 		CorrelationID: resolved.Command.CorrelationID,
 		CausationID:   resolved.Command.ID,
 	})
-	decision, err := s.coordinator.CoordinateWorkItem(coordinationCtx, workItem)
+	decision, err := s.coordinator.Decide(coordinationCtx, workItem, CoordinationContext{})
 	if err != nil {
 		return IntakeResult{}, err
 	}

--- a/internal/workplan/service_test.go
+++ b/internal/workplan/service_test.go
@@ -53,7 +53,7 @@ func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) 
 	if result.WorkItem.PlanID != "plan-1" {
 		t.Fatalf("plan id = %q", result.WorkItem.PlanID)
 	}
-	if result.CoordinationDecision.ID != "coord-1" || result.CoordinationDecision.Outcome != CoordinationSelected {
+	if result.CoordinationDecision.ID != "coord-1" || result.CoordinationDecision.DecisionType != CoordinationExecuteNow {
 		t.Fatalf("coordination decision = %#v", result.CoordinationDecision)
 	}
 	if !result.WorkItem.CreatedAt.Equal(clock.now) || !result.WorkItem.UpdatedAt.Equal(clock.now) {
@@ -72,10 +72,10 @@ func TestServiceCreatesWorkItemAndExecutionEventDeterministically(t *testing.T) 
 	if executionEvents[1].Step != "daily_plan_intake" || executionEvents[1].Status != "attached" {
 		t.Fatalf("second execution event = %#v", executionEvents[1])
 	}
-	if executionEvents[2].Step != "coordination_decision" || executionEvents[2].Status != "selected" {
+	if executionEvents[2].Step != "coordination_decision_made" || executionEvents[2].Status != string(CoordinationExecuteNow) {
 		t.Fatalf("third execution event = %#v", executionEvents[2])
 	}
-	if executionEvents[2].Payload["case_id"] != "case-1" || executionEvents[2].Payload["queue_id"] != "queue-1" || executionEvents[2].Payload["work_item_id"] != "work-1" || executionEvents[2].Payload["coordination_decision_id"] != "coord-1" || executionEvents[2].Payload["strategy"] != DefaultCoordinationStrategy {
+	if executionEvents[2].Payload["case_id"] != "case-1" || executionEvents[2].Payload["queue_id"] != "queue-1" || executionEvents[2].Payload["work_item_id"] != "work-1" || executionEvents[2].Payload["coordination_decision_id"] != "coord-1" || executionEvents[2].Payload["decision_type"] != CoordinationExecuteNow {
 		t.Fatalf("execution event payload = %#v", executionEvents[2].Payload)
 	}
 }


### PR DESCRIPTION
### Motivation
- Introduce a transport-free coordination layer that decides WHAT to do with a `WorkItem` (execute now, defer, escalate, block) so the runtime can gate execution before actor assignment. 
- Provide a deterministic, non-ML, non-random digital-manager implementation that reasons over action complexity, actor eligibility, profiles and trust.
- Persist coordination outcomes and emit events so downstream policy and execution planning can react to an explicit readiness decision.

### Description
- Add the `CoordinationDecision` model and related types (`CoordinationDecisionType`, priorities, `CoordinationContext`, `CoordinationActor`, `CoordinationActorProfile`) and an in-memory coordination repository API (`CoordinationRepository`). (`internal/workplan/coordination.go`, `internal/workplan/coordination_repository.go` and tests).
- Implement a deterministic `DefaultCoordinator` with `Decide(ctx, wi, coordinationContext)` rules that: blocks executed items, escalates on complexity overflow, selects `execute_now` when high-trust actors exist, defers when only low-trust actors exist, and blocks when no eligible actor exists; decisions are saved and the service emits a `coordination_decision_made` execution event containing `decision_type`, `reason`, and `priority`. (`internal/workplan/coordination_service.go`).
- Integrate coordination into intake and HTTP flow: `Service.IntakeCommand` now calls `coordinator.Decide(...)` after plan attachment; the HTTP handler runs coordination again after action-plan attachment and halts automatic assignment/execution for `defer`, `escalate`, and `block`. Router and bootstrap wiring pass the coordinator into the HTTP and server setup. (`internal/workplan/service.go`, `internal/http/actions.go`, `internal/http/router.go`, `cmd/server/main.go`, `internal/app/bootstrap.go`).
- Align downstream governance: policy evaluator now maps `CoordinationDecision.DecisionType` into `PolicyDecision` outcomes and the execution-constraints planner uses `DecisionType` to pick restrictive execution modes for deferred/escalated items. (`internal/policy/evaluator.go`, `internal/executioncontrol/planner.go`).
- Add and update unit tests for coordinator behavior and integration points (`internal/workplan/coordination_service_test.go`, `internal/workplan/coordination_repository_test.go`, updates across `internal/http`, `internal/policy`, `internal/executioncontrol`, and workplan tests).

### Testing
- Ran targeted package tests and integration-style HTTP tests: `go test -vet=off ./internal/workplan ./internal/policy ./internal/executioncontrol ./internal/http ./cmd/server` and supporting package runs in CI-like flow; tests completed successfully for the updated packages.
- New coordinator-focused tests added and executed: `TestCoordinatorExecutesNowForHighTrustActor`, `TestCoordinatorDefersForOnlyLowTrustActors`, `TestCoordinatorBlocksWhenNoEligibleActorExists`, `TestCoordinatorEscalatesWhenComplexityExceedsAvailableProfiles`, and `TestCoordinatorIsDeterministic`, and they passed.
- End-to-end handler/unit tests exercising intake → coordination → policy → constraints → assignment paths were run and passed (HTTP handler tests updated to expect `coordination_decision_made` events and `DecisionType` semantics).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c103746eac8324a803964d63d61e6d)