### PR TITLE
Add operator control plane read models and /api/operator endpoints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,5 +18,5 @@ func main() {
 
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.Coordinator, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.ProposalService, result.EmployeeDirectory, result.EmployeeService)
+	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.Coordinator, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.ProposalService, result.EmployeeDirectory, result.ControlPlane, result.EmployeeService)
 }

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"kalita/internal/catalog"
 	"kalita/internal/command"
 	"kalita/internal/config"
+	"kalita/internal/controlplane"
 	"kalita/internal/employee"
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
@@ -68,6 +69,7 @@ type BootstrapResult struct {
 	ActionExecutor     executionruntime.ActionExecutor
 	ExecutionRunner    executionruntime.Runner
 	ExecutionRuntime   executionruntime.Service
+	ControlPlane       controlplane.Service
 	Config             config.Config
 }
 
@@ -216,6 +218,7 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	workService := workplan.NewService(queueRepo, assignmentRouter, planner, coordinator, eventLog, clock, ids)
 	employeeSelector := employee.NewSelectorWithMatcher(employeeDirectory, profile.NewMatcher(profileRepo, profileRepo, capabilityRepo, capabilityRepo, trustService))
 	employeeService := employee.NewService(assignmentRepo, employeeSelector, executionRuntime, eventLog, clock, ids, trustService)
+	controlPlaneService := controlplane.NewService(caseRepo, queueRepo, coordinationRepo, policyRepo, proposalRepo, employeeDirectory, trustRepo, profileRepo, capabilityRepo, executionRepo, executionWAL)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
@@ -261,6 +264,7 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		ActionExecutor:     actionExecutor,
 		ExecutionRunner:    executionRunner,
 		ExecutionRuntime:   executionRuntime,
+		ControlPlane:       controlPlaneService,
 		Config:             cfg,
 	}, nil
 }

--- a/internal/caseruntime/repository.go
+++ b/internal/caseruntime/repository.go
@@ -54,6 +54,16 @@ func (r *InMemoryCaseRepository) GetByID(_ context.Context, id string) (Case, bo
 	return cloneCase(c), true, nil
 }
 
+func (r *InMemoryCaseRepository) List(_ context.Context) ([]Case, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Case, 0, len(r.byID))
+	for _, c := range r.byID {
+		out = append(out, cloneCase(c))
+	}
+	return out, nil
+}
+
 func (r *InMemoryCaseRepository) FindByCorrelation(ctx context.Context, correlationID string) (Case, bool, error) {
 	if correlationID == "" {
 		return Case{}, false, nil

--- a/internal/caseruntime/types.go
+++ b/internal/caseruntime/types.go
@@ -31,6 +31,7 @@ type Case struct {
 type CaseRepository interface {
 	Save(ctx context.Context, c Case) error
 	GetByID(ctx context.Context, id string) (Case, bool, error)
+	List(ctx context.Context) ([]Case, error)
 	FindByCorrelation(ctx context.Context, correlationID string) (Case, bool, error)
 	FindBySubjectRef(ctx context.Context, subjectRef string) (Case, bool, error)
 }

--- a/internal/controlplane/queries.go
+++ b/internal/controlplane/queries.go
@@ -1,0 +1,17 @@
+package controlplane
+
+import "context"
+
+type Service interface {
+	GetCaseOverview(ctx context.Context, caseID string) (CaseOverview, error)
+	ListCases(ctx context.Context) ([]CaseOverview, error)
+
+	GetWorkItemOverview(ctx context.Context, workItemID string) (WorkItemOverview, error)
+	ListWorkItems(ctx context.Context) ([]WorkItemOverview, error)
+
+	GetActorOverview(ctx context.Context, actorID string) (ActorOverview, error)
+	ListActors(ctx context.Context) ([]ActorOverview, error)
+
+	GetApprovalInbox(ctx context.Context) ([]ApprovalInboxItem, error)
+	GetBlockedOrDeferredWork(ctx context.Context) ([]WorkItemOverview, error)
+}

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -1,0 +1,359 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"kalita/internal/capability"
+	"kalita/internal/caseruntime"
+	"kalita/internal/employee"
+	"kalita/internal/executionruntime"
+	"kalita/internal/policy"
+	"kalita/internal/profile"
+	"kalita/internal/proposal"
+	"kalita/internal/trust"
+	"kalita/internal/workplan"
+)
+
+const maxRecentExecutionArtifacts = 5
+
+type CaseLister interface {
+	List(ctx context.Context) ([]caseruntime.Case, error)
+}
+type WorkItemLister interface {
+	ListWorkItems(ctx context.Context) ([]workplan.WorkItem, error)
+}
+type ApprovalRequestLister interface {
+	ListApprovalRequests(ctx context.Context) ([]policy.ApprovalRequest, error)
+}
+
+type service struct {
+	cases        caseruntime.CaseRepository
+	caseLister   CaseLister
+	workItems    workplan.QueueRepository
+	workLister   WorkItemLister
+	coordination workplan.CoordinationRepository
+	policies     policy.PolicyRepository
+	approvals    ApprovalRequestLister
+	proposals    proposal.Repository
+	actors       employee.Directory
+	trust        trust.Repository
+	profiles     profile.Repository
+	capabilities capability.InMemoryCapabilityRepository
+	executions   executionruntime.ExecutionRepository
+	wal          executionruntime.WAL
+}
+
+func NewService(
+	cases caseruntime.CaseRepository,
+	workItems workplan.QueueRepository,
+	coordination workplan.CoordinationRepository,
+	policies policy.PolicyRepository,
+	proposals proposal.Repository,
+	actors employee.Directory,
+	trustRepo trust.Repository,
+	profiles profile.Repository,
+	capRepo *capability.InMemoryCapabilityRepository,
+	executions executionruntime.ExecutionRepository,
+	wal executionruntime.WAL,
+) Service {
+	var caseLister CaseLister
+	if l, ok := cases.(CaseLister); ok {
+		caseLister = l
+	}
+	var workLister WorkItemLister
+	if l, ok := workItems.(WorkItemLister); ok {
+		workLister = l
+	}
+	var approvals ApprovalRequestLister
+	if l, ok := policies.(ApprovalRequestLister); ok {
+		approvals = l
+	}
+	return &service{cases: cases, caseLister: caseLister, workItems: workItems, workLister: workLister, coordination: coordination, policies: policies, approvals: approvals, proposals: proposals, actors: actors, trust: trustRepo, profiles: profiles, capabilities: *capRepo, executions: executions, wal: wal}
+}
+
+func (s *service) GetCaseOverview(ctx context.Context, caseID string) (CaseOverview, error) {
+	c, ok, err := s.cases.GetByID(ctx, caseID)
+	if err != nil {
+		return CaseOverview{}, err
+	}
+	if !ok {
+		return CaseOverview{}, fmt.Errorf("case %s not found", caseID)
+	}
+	return mapCase(c), nil
+}
+
+func (s *service) ListCases(ctx context.Context) ([]CaseOverview, error) {
+	if s.caseLister == nil {
+		return nil, fmt.Errorf("case listing is not supported")
+	}
+	cases, err := s.caseLister.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CaseOverview, 0, len(cases))
+	for _, c := range cases {
+		out = append(out, mapCase(c))
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].OpenedAt.Before(out[j].OpenedAt) })
+	return out, nil
+}
+
+func (s *service) GetWorkItemOverview(ctx context.Context, workItemID string) (WorkItemOverview, error) {
+	wi, ok, err := s.workItems.GetWorkItem(ctx, workItemID)
+	if err != nil {
+		return WorkItemOverview{}, err
+	}
+	if !ok {
+		return WorkItemOverview{}, fmt.Errorf("work item %s not found", workItemID)
+	}
+	return s.buildWorkItemOverview(ctx, wi)
+}
+
+func (s *service) ListWorkItems(ctx context.Context) ([]WorkItemOverview, error) {
+	if s.workLister == nil {
+		return nil, fmt.Errorf("work item listing is not supported")
+	}
+	items, err := s.workLister.ListWorkItems(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]WorkItemOverview, 0, len(items))
+	for _, wi := range items {
+		overview, err := s.buildWorkItemOverview(ctx, wi)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, overview)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	return out, nil
+}
+
+func (s *service) GetActorOverview(ctx context.Context, actorID string) (ActorOverview, error) {
+	a, ok, err := s.actors.GetEmployee(ctx, actorID)
+	if err != nil {
+		return ActorOverview{}, err
+	}
+	if !ok {
+		return ActorOverview{}, fmt.Errorf("actor %s not found", actorID)
+	}
+	return s.buildActorOverview(ctx, a)
+}
+
+func (s *service) ListActors(ctx context.Context) ([]ActorOverview, error) {
+	actors, err := s.actors.ListEmployees(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ActorOverview, 0, len(actors))
+	for _, a := range actors {
+		overview, err := s.buildActorOverview(ctx, a)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, overview)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].ActorID < out[j].ActorID })
+	return out, nil
+}
+
+func (s *service) GetApprovalInbox(ctx context.Context) ([]ApprovalInboxItem, error) {
+	if s.approvals == nil {
+		return nil, fmt.Errorf("approval listing is not supported")
+	}
+	requests, err := s.approvals.ListApprovalRequests(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ApprovalInboxItem, 0, len(requests))
+	for _, req := range requests {
+		coord, _ := s.latestCoordination(ctx, req.WorkItemID)
+		policyOverview, _ := s.latestPolicyApproval(ctx, coord)
+		out = append(out, ApprovalInboxItem{ApprovalRequestID: req.ID, Status: string(req.Status), RequestedFromRole: req.RequestedFromRole, CaseID: req.CaseID, WorkItemID: req.WorkItemID, QueueID: req.QueueID, CreatedAt: req.CreatedAt, ResolvedAt: req.ResolvedAt, ResolutionNote: req.ResolutionNote, Coordination: coord, PolicyApproval: policyOverview})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].CreatedAt.After(out[j].CreatedAt) })
+	return out, nil
+}
+
+func (s *service) GetBlockedOrDeferredWork(ctx context.Context) ([]WorkItemOverview, error) {
+	items, err := s.ListWorkItems(ctx)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]WorkItemOverview, 0)
+	for _, item := range items {
+		if item.Coordination.DecisionType == string(workplan.CoordinationBlock) || item.Coordination.DecisionType == string(workplan.CoordinationDefer) || item.PolicyApproval.Outcome == string(policy.PolicyRequireApproval) || item.PolicyApproval.ApprovalRequestStatus == string(policy.ApprovalPending) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered, nil
+}
+
+func (s *service) buildWorkItemOverview(ctx context.Context, wi workplan.WorkItem) (WorkItemOverview, error) {
+	coord, coordDecision := s.latestCoordination(ctx, wi.ID)
+	policyOverview, _ := s.latestPolicyApproval(ctx, coord)
+	proposalOverview, _ := s.latestProposal(ctx, wi.ID)
+	execOverview, _ := s.latestExecution(ctx, wi.ID)
+	assigned := wi.AssignedEmployeeID
+	if assigned == "" && proposalOverview.ActorID != "" {
+		assigned = proposalOverview.ActorID
+	}
+	if assigned == "" {
+		if execOverview.SessionID != "" {
+			assigned = wi.AssignedEmployeeID
+		}
+	}
+	_ = coordDecision
+	return WorkItemOverview{WorkItemID: wi.ID, CaseID: wi.CaseID, QueueID: wi.QueueID, Type: wi.Type, Status: wi.Status, Priority: wi.Priority, AssignedEmployeeID: assigned, PlanID: wi.PlanID, CreatedAt: wi.CreatedAt, UpdatedAt: wi.UpdatedAt, Coordination: coord, PolicyApproval: policyOverview, Proposal: proposalOverview, Execution: execOverview}, nil
+}
+
+func (s *service) buildActorOverview(ctx context.Context, actor employee.DigitalEmployee) (ActorOverview, error) {
+	overview := ActorOverview{ActorID: actor.ID, Role: actor.Role, Enabled: actor.Enabled, QueueMemberships: append([]string(nil), actor.QueueMemberships...)}
+	if p, ok, err := s.trust.GetByActor(ctx, actor.ID); err != nil {
+		return ActorOverview{}, err
+	} else if ok {
+		overview.TrustLevel = string(p.TrustLevel)
+		overview.AutonomyTier = string(p.AutonomyTier)
+	}
+	if prof, ok, err := s.profiles.GetProfileByActor(ctx, actor.ID); err != nil {
+		return ActorOverview{}, err
+	} else if ok {
+		overview.ProfileSummary = profileSummary(prof)
+	}
+	caps, err := s.capabilities.ListByActor(ctx, actor.ID)
+	if err != nil {
+		return ActorOverview{}, err
+	}
+	allCaps, err := s.capabilities.ListCapabilities(ctx)
+	if err != nil {
+		return ActorOverview{}, err
+	}
+	capByID := make(map[string]capability.Capability, len(allCaps))
+	for _, c := range allCaps {
+		capByID[c.ID] = c
+	}
+	parts := make([]string, 0, len(caps))
+	for _, ac := range caps {
+		code := ac.CapabilityID
+		if c, ok := capByID[ac.CapabilityID]; ok {
+			code = c.Code
+		}
+		parts = append(parts, fmt.Sprintf("%s@L%d", code, ac.Level))
+	}
+	sort.Strings(parts)
+	overview.CapabilitySummary = strings.Join(parts, ", ")
+	return overview, nil
+}
+
+func (s *service) latestCoordination(ctx context.Context, workItemID string) (CoordinationOverview, *workplan.CoordinationDecision) {
+	decisions, err := s.coordination.ListByWorkItem(ctx, workItemID)
+	if err != nil || len(decisions) == 0 {
+		return CoordinationOverview{}, nil
+	}
+	latest := latestBy(decisions, func(d workplan.CoordinationDecision) string { return d.ID }, func(d workplan.CoordinationDecision) int64 { return d.CreatedAt.UnixNano() })
+	return CoordinationOverview{DecisionID: latest.ID, DecisionType: string(latest.DecisionType), Priority: latest.Priority, Reason: latest.Reason, CreatedAt: latest.CreatedAt}, &latest
+}
+
+func (s *service) latestPolicyApproval(ctx context.Context, coord CoordinationOverview) (PolicyApprovalOverview, *policy.PolicyDecision) {
+	if coord.DecisionID == "" {
+		return PolicyApprovalOverview{}, nil
+	}
+	decisions, err := s.policies.ListByCoordinationDecision(ctx, coord.DecisionID)
+	if err != nil || len(decisions) == 0 {
+		return PolicyApprovalOverview{}, nil
+	}
+	latestDecision := latestBy(decisions, func(d policy.PolicyDecision) string { return d.ID }, func(d policy.PolicyDecision) int64 { return d.CreatedAt.UnixNano() })
+	overview := PolicyApprovalOverview{PolicyDecisionID: latestDecision.ID, Outcome: string(latestDecision.Outcome), Reason: latestDecision.Reason, CreatedAt: latestDecision.CreatedAt}
+	approvals, err := s.policies.ListApprovalRequestsByCoordinationDecision(ctx, coord.DecisionID)
+	if err == nil && len(approvals) > 0 {
+		latestApproval := latestBy(approvals, func(a policy.ApprovalRequest) string { return a.ID }, func(a policy.ApprovalRequest) int64 { return a.CreatedAt.UnixNano() })
+		overview.ApprovalRequestID = latestApproval.ID
+		overview.ApprovalRequestStatus = string(latestApproval.Status)
+		overview.RequestedFromRole = latestApproval.RequestedFromRole
+		overview.ApprovalRequestedAt = latestApproval.CreatedAt
+		overview.ApprovalResolvedAt = latestApproval.ResolvedAt
+		overview.ResolutionNote = latestApproval.ResolutionNote
+	}
+	return overview, &latestDecision
+}
+
+func (s *service) latestProposal(ctx context.Context, workItemID string) (ProposalOverview, *proposal.Proposal) {
+	proposals, err := s.proposals.ListByWorkItem(ctx, workItemID)
+	if err != nil || len(proposals) == 0 {
+		return ProposalOverview{}, nil
+	}
+	latest := latestBy(proposals, func(p proposal.Proposal) string { return p.ID }, func(p proposal.Proposal) int64 { return p.CreatedAt.UnixNano() })
+	return ProposalOverview{ProposalID: latest.ID, Type: string(latest.Type), Status: string(latest.Status), ActorID: latest.ActorID, Justification: latest.Justification, ActionPlanID: latest.ActionPlanID, CreatedAt: latest.CreatedAt, UpdatedAt: latest.UpdatedAt}, &latest
+}
+
+func (s *service) latestExecution(ctx context.Context, workItemID string) (ExecutionOverview, *executionruntime.ExecutionSession) {
+	sessions, err := s.executions.ListSessionsByWorkItem(ctx, workItemID)
+	if err != nil || len(sessions) == 0 {
+		return ExecutionOverview{}, nil
+	}
+	latest := latestBy(sessions, func(es executionruntime.ExecutionSession) string { return es.ID }, func(es executionruntime.ExecutionSession) int64 { return es.CreatedAt.UnixNano() })
+	overview := ExecutionOverview{SessionID: latest.ID, Status: string(latest.Status), CurrentStepIndex: latest.CurrentStepIndex, FailureReason: latest.FailureReason, CreatedAt: latest.CreatedAt, UpdatedAt: latest.UpdatedAt}
+	steps, err := s.executions.ListStepsBySession(ctx, latest.ID)
+	if err == nil && len(steps) > 0 {
+		sort.SliceStable(steps, func(i, j int) bool {
+			if steps[i].StepIndex == steps[j].StepIndex {
+				return steps[i].ID > steps[j].ID
+			}
+			return steps[i].StepIndex > steps[j].StepIndex
+		})
+		for i, step := range steps {
+			if i >= maxRecentExecutionArtifacts {
+				break
+			}
+			overview.RecentStepExecutions = append(overview.RecentStepExecutions, StepExecutionOverview{StepExecutionID: step.ID, ActionID: step.ActionID, StepIndex: step.StepIndex, Status: string(step.Status), StartedAt: step.StartedAt, FinishedAt: step.FinishedAt, FailureReason: step.FailureReason})
+		}
+	}
+	records, err := s.wal.ListBySession(ctx, latest.ID)
+	if err == nil && len(records) > 0 {
+		sort.SliceStable(records, func(i, j int) bool {
+			if records[i].CreatedAt.Equal(records[j].CreatedAt) {
+				return records[i].ID > records[j].ID
+			}
+			return records[i].CreatedAt.After(records[j].CreatedAt)
+		})
+		for i, record := range records {
+			if i >= maxRecentExecutionArtifacts {
+				break
+			}
+			overview.RecentWALRecords = append(overview.RecentWALRecords, WALRecordOverview{WALRecordID: record.ID, StepExecutionID: record.StepExecutionID, ActionID: record.ActionID, Type: string(record.Type), CreatedAt: record.CreatedAt})
+		}
+	}
+	return overview, &latest
+}
+
+func mapCase(c caseruntime.Case) CaseOverview {
+	return CaseOverview{CaseID: c.ID, Kind: c.Kind, Status: c.Status, CorrelationID: c.CorrelationID, SubjectRef: c.SubjectRef, OpenedAt: c.OpenedAt, UpdatedAt: c.UpdatedAt}
+}
+
+func profileSummary(p profile.CompetencyProfile) string {
+	parts := []string{p.Name}
+	if p.ExecutionStyle != "" {
+		parts = append(parts, fmt.Sprintf("style=%s", p.ExecutionStyle))
+	}
+	if p.MaxComplexity > 0 {
+		parts = append(parts, fmt.Sprintf("max_complexity=%d", p.MaxComplexity))
+	}
+	if len(p.PreferredWorkKinds) > 0 {
+		parts = append(parts, fmt.Sprintf("prefers=%s", strings.Join(p.PreferredWorkKinds, "/")))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// latestBy chooses the artifact with the greatest CreatedAt-style timestamp; ties are broken by lexical ID order so results stay deterministic.
+func latestBy[T any](items []T, id func(T) string, ts func(T) int64) T {
+	latest := items[0]
+	for _, item := range items[1:] {
+		if ts(item) > ts(latest) || (ts(item) == ts(latest) && id(item) > id(latest)) {
+			latest = item
+		}
+	}
+	return latest
+}

--- a/internal/controlplane/service_test.go
+++ b/internal/controlplane/service_test.go
@@ -1,0 +1,142 @@
+package controlplane
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"kalita/internal/capability"
+	"kalita/internal/caseruntime"
+	"kalita/internal/employee"
+	"kalita/internal/executionruntime"
+	"kalita/internal/policy"
+	"kalita/internal/profile"
+	"kalita/internal/proposal"
+	"kalita/internal/trust"
+	"kalita/internal/workplan"
+)
+
+func TestCaseOverviewAggregation(t *testing.T) {
+	t.Parallel()
+	svc := seededService(t)
+	overview, err := svc.GetCaseOverview(context.Background(), "case-1")
+	if err != nil {
+		t.Fatalf("GetCaseOverview error = %v", err)
+	}
+	if overview.Kind != "workflow.action" || overview.CorrelationID != "corr-1" || overview.SubjectRef != "subject-1" {
+		t.Fatalf("overview = %#v", overview)
+	}
+}
+
+func TestWorkItemOverviewAggregationUsesLatestArtifacts(t *testing.T) {
+	t.Parallel()
+	svc := seededService(t)
+	overview, err := svc.GetWorkItemOverview(context.Background(), "work-1")
+	if err != nil {
+		t.Fatalf("GetWorkItemOverview error = %v", err)
+	}
+	if overview.Coordination.DecisionType != string(workplan.CoordinationDefer) {
+		t.Fatalf("coordination = %#v", overview.Coordination)
+	}
+	if overview.PolicyApproval.Outcome != string(policy.PolicyRequireApproval) || overview.PolicyApproval.ApprovalRequestStatus != string(policy.ApprovalPending) {
+		t.Fatalf("policy = %#v", overview.PolicyApproval)
+	}
+	if overview.Proposal.ProposalID != "proposal-2" || overview.Proposal.ActionPlanID != "plan-compiled" {
+		t.Fatalf("proposal = %#v", overview.Proposal)
+	}
+	if overview.Execution.SessionID != "exec-2" || overview.Execution.FailureReason != "operator waiting" {
+		t.Fatalf("execution = %#v", overview.Execution)
+	}
+	if len(overview.Execution.RecentStepExecutions) == 0 || overview.Execution.RecentStepExecutions[0].StepExecutionID != "step-2" {
+		t.Fatalf("steps = %#v", overview.Execution.RecentStepExecutions)
+	}
+	if len(overview.Execution.RecentWALRecords) == 0 || overview.Execution.RecentWALRecords[0].WALRecordID != "wal-2" {
+		t.Fatalf("wal = %#v", overview.Execution.RecentWALRecords)
+	}
+}
+
+func TestActorOverviewAggregationSummarizesTrustProfileAndCapabilities(t *testing.T) {
+	t.Parallel()
+	svc := seededService(t)
+	overview, err := svc.GetActorOverview(context.Background(), "actor-1")
+	if err != nil {
+		t.Fatalf("GetActorOverview error = %v", err)
+	}
+	if overview.TrustLevel != string(trust.TrustHigh) || overview.AutonomyTier != string(trust.AutonomyStandard) {
+		t.Fatalf("overview = %#v", overview)
+	}
+	if overview.ProfileSummary == "" || overview.CapabilitySummary != "workflow.execute@L2" {
+		t.Fatalf("overview = %#v", overview)
+	}
+}
+
+func TestApprovalInboxContents(t *testing.T) {
+	t.Parallel()
+	svc := seededService(t)
+	items, err := svc.GetApprovalInbox(context.Background())
+	if err != nil {
+		t.Fatalf("GetApprovalInbox error = %v", err)
+	}
+	if len(items) != 1 || items[0].ApprovalRequestID != "approval-1" || items[0].Status != string(policy.ApprovalPending) {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
+func TestBlockedOrDeferredWorkListing(t *testing.T) {
+	t.Parallel()
+	svc := seededService(t)
+	items, err := svc.GetBlockedOrDeferredWork(context.Background())
+	if err != nil {
+		t.Fatalf("GetBlockedOrDeferredWork error = %v", err)
+	}
+	if len(items) != 1 || items[0].WorkItemID != "work-1" {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
+func seededService(t *testing.T) Service {
+	t.Helper()
+	ctx := context.Background()
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	coordRepo := workplan.NewInMemoryCoordinationRepository()
+	policyRepo := policy.NewInMemoryRepository()
+	proposalRepo := proposal.NewInMemoryRepository()
+	directory := employee.NewInMemoryDirectory()
+	trustRepo := trust.NewInMemoryRepository()
+	profileRepo := profile.NewInMemoryRepository()
+	capRepo := capability.NewInMemoryRepository()
+	execRepo := executionruntime.NewInMemoryExecutionRepository()
+	wal := executionruntime.NewInMemoryWAL()
+
+	base := time.Date(2026, 3, 23, 10, 0, 0, 0, time.UTC)
+	must(t, caseRepo.Save(ctx, caseruntime.Case{ID: "case-1", Kind: "workflow.action", Status: "open", CorrelationID: "corr-1", SubjectRef: "subject-1", OpenedAt: base, UpdatedAt: base.Add(10 * time.Minute)}))
+	must(t, queueRepo.SaveQueue(ctx, workplan.WorkQueue{ID: "queue-1", Name: "Ops"}))
+	must(t, queueRepo.SaveWorkItem(ctx, workplan.WorkItem{ID: "work-1", CaseID: "case-1", QueueID: "queue-1", Type: "workflow.action", Status: "open", Priority: "high", AssignedEmployeeID: "actor-1", PlanID: "plan-1", CreatedAt: base.Add(1 * time.Minute), UpdatedAt: base.Add(12 * time.Minute)}))
+	must(t, coordRepo.SaveDecision(ctx, workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "work-1", CaseID: "case-1", QueueID: "queue-1", DecisionType: workplan.CoordinationExecuteNow, Priority: 3, Reason: "initial", CreatedAt: base.Add(2 * time.Minute)}))
+	must(t, coordRepo.SaveDecision(ctx, workplan.CoordinationDecision{ID: "coord-2", WorkItemID: "work-1", CaseID: "case-1", QueueID: "queue-1", DecisionType: workplan.CoordinationDefer, Priority: 2, Reason: "waiting for approval", CreatedAt: base.Add(3 * time.Minute)}))
+	must(t, policyRepo.SaveDecision(ctx, policy.PolicyDecision{ID: "policy-1", CoordinationDecisionID: "coord-2", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Outcome: policy.PolicyRequireApproval, Reason: "high risk", CreatedAt: base.Add(4 * time.Minute)}))
+	must(t, policyRepo.SaveApprovalRequest(ctx, policy.ApprovalRequest{ID: "approval-1", CoordinationDecisionID: "coord-2", PolicyDecisionID: "policy-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Status: policy.ApprovalPending, RequestedFromRole: "manager", CreatedAt: base.Add(5 * time.Minute)}))
+	must(t, proposalRepo.Save(ctx, proposal.Proposal{ID: "proposal-1", Type: proposal.ProposalTypeActionIntent, Status: proposal.ProposalValidated, ActorID: "actor-1", CaseID: "case-1", WorkItemID: "work-1", Justification: "first", CreatedAt: base.Add(6 * time.Minute), UpdatedAt: base.Add(6 * time.Minute)}))
+	must(t, proposalRepo.Save(ctx, proposal.Proposal{ID: "proposal-2", Type: proposal.ProposalTypeActionIntent, Status: proposal.ProposalCompiled, ActorID: "actor-1", CaseID: "case-1", WorkItemID: "work-1", Justification: "latest", ActionPlanID: "plan-compiled", CreatedAt: base.Add(7 * time.Minute), UpdatedAt: base.Add(8 * time.Minute)}))
+	must(t, directory.SaveEmployee(ctx, employee.DigitalEmployee{ID: "actor-1", Role: "operator", Enabled: true, QueueMemberships: []string{"queue-1"}}))
+	must(t, trustRepo.Save(ctx, trust.TrustProfile{ActorID: "actor-1", TrustLevel: trust.TrustHigh, AutonomyTier: trust.AutonomyStandard, UpdatedAt: base.Add(9 * time.Minute)}))
+	must(t, profileRepo.SaveProfile(ctx, profile.CompetencyProfile{ID: "profile-1", ActorID: "actor-1", Name: "Primary Operator", ExecutionStyle: profile.ExecutionStyleBalanced, MaxComplexity: 5, PreferredWorkKinds: []string{"workflow.action"}}))
+	must(t, capRepo.SaveCapability(ctx, capability.Capability{ID: "cap-1", Code: "workflow.execute", Level: 2}))
+	must(t, capRepo.AssignCapability(ctx, capability.ActorCapability{ActorID: "actor-1", CapabilityID: "cap-1", Level: 2}))
+	must(t, execRepo.SaveSession(ctx, executionruntime.ExecutionSession{ID: "exec-1", WorkItemID: "work-1", Status: executionruntime.ExecutionSessionSucceeded, CurrentStepIndex: 1, CreatedAt: base.Add(9 * time.Minute), UpdatedAt: base.Add(10 * time.Minute)}))
+	must(t, execRepo.SaveSession(ctx, executionruntime.ExecutionSession{ID: "exec-2", WorkItemID: "work-1", Status: executionruntime.ExecutionSessionFailed, CurrentStepIndex: 2, FailureReason: "operator waiting", CreatedAt: base.Add(11 * time.Minute), UpdatedAt: base.Add(12 * time.Minute)}))
+	must(t, execRepo.SaveStep(ctx, executionruntime.StepExecution{ID: "step-1", ExecutionSessionID: "exec-2", ActionID: "action-1", StepIndex: 0, Status: executionruntime.StepSucceeded}))
+	must(t, execRepo.SaveStep(ctx, executionruntime.StepExecution{ID: "step-2", ExecutionSessionID: "exec-2", ActionID: "action-2", StepIndex: 1, Status: executionruntime.StepFailed, FailureReason: "operator waiting"}))
+	must(t, wal.Append(ctx, executionruntime.WALRecord{ID: "wal-1", ExecutionSessionID: "exec-2", ActionID: "action-1", Type: executionruntime.WALStepIntent, CreatedAt: base.Add(11 * time.Minute)}))
+	must(t, wal.Append(ctx, executionruntime.WALRecord{ID: "wal-2", ExecutionSessionID: "exec-2", ActionID: "action-2", Type: executionruntime.WALStepResult, CreatedAt: base.Add(12 * time.Minute)}))
+
+	return NewService(caseRepo, queueRepo, coordRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, execRepo, wal)
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/controlplane/viewmodels.go
+++ b/internal/controlplane/viewmodels.go
@@ -1,0 +1,116 @@
+package controlplane
+
+import "time"
+
+type CaseOverview struct {
+	CaseID        string    `json:"case_id"`
+	Kind          string    `json:"kind"`
+	Status        string    `json:"status"`
+	CorrelationID string    `json:"correlation_id,omitempty"`
+	SubjectRef    string    `json:"subject_ref,omitempty"`
+	OpenedAt      time.Time `json:"opened_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+type CoordinationOverview struct {
+	DecisionID   string    `json:"decision_id,omitempty"`
+	DecisionType string    `json:"decision_type,omitempty"`
+	Priority     int       `json:"priority,omitempty"`
+	Reason       string    `json:"reason,omitempty"`
+	CreatedAt    time.Time `json:"created_at,omitempty"`
+}
+
+type PolicyApprovalOverview struct {
+	PolicyDecisionID      string     `json:"policy_decision_id,omitempty"`
+	Outcome               string     `json:"outcome,omitempty"`
+	Reason                string     `json:"reason,omitempty"`
+	CreatedAt             time.Time  `json:"created_at,omitempty"`
+	ApprovalRequestID     string     `json:"approval_request_id,omitempty"`
+	ApprovalRequestStatus string     `json:"approval_request_status,omitempty"`
+	RequestedFromRole     string     `json:"requested_from_role,omitempty"`
+	ApprovalRequestedAt   time.Time  `json:"approval_requested_at,omitempty"`
+	ApprovalResolvedAt    *time.Time `json:"approval_resolved_at,omitempty"`
+	ResolutionNote        string     `json:"resolution_note,omitempty"`
+}
+
+type ProposalOverview struct {
+	ProposalID    string    `json:"proposal_id,omitempty"`
+	Type          string    `json:"type,omitempty"`
+	Status        string    `json:"status,omitempty"`
+	ActorID       string    `json:"actor_id,omitempty"`
+	Justification string    `json:"justification,omitempty"`
+	ActionPlanID  string    `json:"action_plan_id,omitempty"`
+	CreatedAt     time.Time `json:"created_at,omitempty"`
+	UpdatedAt     time.Time `json:"updated_at,omitempty"`
+}
+
+type StepExecutionOverview struct {
+	StepExecutionID string     `json:"step_execution_id"`
+	ActionID        string     `json:"action_id"`
+	StepIndex       int        `json:"step_index"`
+	Status          string     `json:"status"`
+	StartedAt       *time.Time `json:"started_at,omitempty"`
+	FinishedAt      *time.Time `json:"finished_at,omitempty"`
+	FailureReason   string     `json:"failure_reason,omitempty"`
+}
+
+type WALRecordOverview struct {
+	WALRecordID     string    `json:"wal_record_id"`
+	StepExecutionID string    `json:"step_execution_id,omitempty"`
+	ActionID        string    `json:"action_id,omitempty"`
+	Type            string    `json:"type"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+type ExecutionOverview struct {
+	SessionID            string                  `json:"session_id,omitempty"`
+	Status               string                  `json:"session_status,omitempty"`
+	CurrentStepIndex     int                     `json:"current_step_index,omitempty"`
+	FailureReason        string                  `json:"failure_reason,omitempty"`
+	CreatedAt            time.Time               `json:"created_at,omitempty"`
+	UpdatedAt            time.Time               `json:"updated_at,omitempty"`
+	RecentStepExecutions []StepExecutionOverview `json:"recent_step_executions,omitempty"`
+	RecentWALRecords     []WALRecordOverview     `json:"recent_wal_records,omitempty"`
+}
+
+type WorkItemOverview struct {
+	WorkItemID         string                 `json:"work_item_id"`
+	CaseID             string                 `json:"case_id"`
+	QueueID            string                 `json:"queue_id"`
+	Type               string                 `json:"type"`
+	Status             string                 `json:"status"`
+	Priority           string                 `json:"priority,omitempty"`
+	AssignedEmployeeID string                 `json:"assigned_employee_id,omitempty"`
+	PlanID             string                 `json:"plan_id,omitempty"`
+	CreatedAt          time.Time              `json:"created_at"`
+	UpdatedAt          time.Time              `json:"updated_at"`
+	Coordination       CoordinationOverview   `json:"coordination,omitempty"`
+	PolicyApproval     PolicyApprovalOverview `json:"policy_approval,omitempty"`
+	Proposal           ProposalOverview       `json:"proposal,omitempty"`
+	Execution          ExecutionOverview      `json:"execution,omitempty"`
+}
+
+type ActorOverview struct {
+	ActorID           string   `json:"actor_id"`
+	Role              string   `json:"role"`
+	Enabled           bool     `json:"enabled"`
+	QueueMemberships  []string `json:"queue_memberships,omitempty"`
+	TrustLevel        string   `json:"trust_level,omitempty"`
+	AutonomyTier      string   `json:"autonomy_tier,omitempty"`
+	ProfileSummary    string   `json:"profile_summary,omitempty"`
+	CapabilitySummary string   `json:"capability_summary,omitempty"`
+}
+
+type ApprovalInboxItem struct {
+	ApprovalRequestID string                 `json:"approval_request_id"`
+	Status            string                 `json:"status"`
+	RequestedFromRole string                 `json:"requested_from_role,omitempty"`
+	CaseID            string                 `json:"case_id"`
+	WorkItemID        string                 `json:"work_item_id"`
+	QueueID           string                 `json:"queue_id"`
+	CreatedAt         time.Time              `json:"created_at"`
+	ResolvedAt        *time.Time             `json:"resolved_at,omitempty"`
+	ResolutionNote    string                 `json:"resolution_note,omitempty"`
+	Coordination      CoordinationOverview   `json:"coordination,omitempty"`
+	PolicyApproval    PolicyApprovalOverview `json:"policy_approval,omitempty"`
+}

--- a/internal/http/operator.go
+++ b/internal/http/operator.go
@@ -1,0 +1,68 @@
+package http
+
+import (
+	"net/http"
+	"strings"
+
+	"kalita/internal/controlplane"
+
+	"github.com/gin-gonic/gin"
+)
+
+func registerOperatorRoutes(group *gin.RouterGroup, svc controlplane.Service) {
+	if svc == nil {
+		return
+	}
+
+	operator := group.Group("/operator")
+	operator.GET("/cases", func(c *gin.Context) {
+		payload, err := svc.ListCases(c.Request.Context())
+		respondOperator(c, payload, err)
+	})
+	operator.GET("/cases/:id", func(c *gin.Context) {
+		payload, err := svc.GetCaseOverview(c.Request.Context(), c.Param("id"))
+		respondOperator(c, payload, err)
+	})
+	operator.GET("/work-items", func(c *gin.Context) {
+		payload, err := svc.ListWorkItems(c.Request.Context())
+		respondOperator(c, payload, err)
+	})
+	operator.GET("/work-items/:id", func(c *gin.Context) {
+		payload, err := svc.GetWorkItemOverview(c.Request.Context(), c.Param("id"))
+		respondOperator(c, payload, err)
+	})
+	operator.GET("/actors", func(c *gin.Context) {
+		payload, err := svc.ListActors(c.Request.Context())
+		respondOperator(c, payload, err)
+	})
+	operator.GET("/actors/:id", func(c *gin.Context) {
+		payload, err := svc.GetActorOverview(c.Request.Context(), c.Param("id"))
+		respondOperator(c, payload, err)
+	})
+	operator.GET("/approvals", func(c *gin.Context) {
+		payload, err := svc.GetApprovalInbox(c.Request.Context())
+		respondOperator(c, payload, err)
+	})
+	operator.GET("/blocked-work", func(c *gin.Context) {
+		payload, err := svc.GetBlockedOrDeferredWork(c.Request.Context())
+		respondOperator(c, payload, err)
+	})
+}
+
+func respondOperator[T any](c *gin.Context, payload T, err error) {
+	if err != nil {
+		c.JSON(statusForOperatorError(err), gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, payload)
+}
+
+func statusForOperatorError(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+	if strings.HasSuffix(err.Error(), " not found") {
+		return http.StatusNotFound
+	}
+	return http.StatusInternalServerError
+}

--- a/internal/http/operator_test.go
+++ b/internal/http/operator_test.go
@@ -1,0 +1,135 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"kalita/internal/capability"
+	"kalita/internal/caseruntime"
+	"kalita/internal/controlplane"
+	"kalita/internal/employee"
+	"kalita/internal/executionruntime"
+	"kalita/internal/policy"
+	"kalita/internal/profile"
+	"kalita/internal/proposal"
+	"kalita/internal/trust"
+	"kalita/internal/workplan"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestOperatorEndpointsReturnAggregatedJSON(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	svc := controlplaneSeededService(t)
+	r := gin.New()
+	api := r.Group("/api")
+	registerOperatorRoutes(api, svc)
+
+	for _, tc := range []struct {
+		path  string
+		check func(*testing.T, *httptest.ResponseRecorder)
+	}{
+		{path: "/api/operator/cases", check: func(t *testing.T, rec *httptest.ResponseRecorder) {
+			var payload []map[string]any
+			decode(t, rec, &payload)
+			if len(payload) != 1 || payload[0]["case_id"] != "case-1" {
+				t.Fatalf("payload = %#v", payload)
+			}
+		}},
+		{path: "/api/operator/work-items/work-1", check: func(t *testing.T, rec *httptest.ResponseRecorder) {
+			var payload map[string]any
+			decode(t, rec, &payload)
+			if payload["work_item_id"] != "work-1" {
+				t.Fatalf("payload = %#v", payload)
+			}
+			coord := payload["coordination"].(map[string]any)
+			if coord["decision_type"] != "defer" {
+				t.Fatalf("coordination = %#v", coord)
+			}
+		}},
+		{path: "/api/operator/approvals", check: func(t *testing.T, rec *httptest.ResponseRecorder) {
+			var payload []map[string]any
+			decode(t, rec, &payload)
+			if len(payload) != 1 || payload[0]["approval_request_id"] != "approval-1" {
+				t.Fatalf("payload = %#v", payload)
+			}
+		}},
+	} {
+		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s status=%d body=%s", tc.path, w.Code, w.Body.String())
+		}
+		tc.check(t, w)
+	}
+}
+
+func TestOperatorEndpointReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	api := r.Group("/api")
+	registerOperatorRoutes(api, controlplaneSeededService(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/operator/actors/missing", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func controlplaneSeededService(t *testing.T) controlplane.Service {
+	t.Helper()
+	ctx := context.Background()
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	coordRepo := workplan.NewInMemoryCoordinationRepository()
+	policyRepo := policy.NewInMemoryRepository()
+	proposalRepo := proposal.NewInMemoryRepository()
+	directory := employee.NewInMemoryDirectory()
+	trustRepo := trust.NewInMemoryRepository()
+	profileRepo := profile.NewInMemoryRepository()
+	capRepo := capability.NewInMemoryRepository()
+	execRepo := executionruntime.NewInMemoryExecutionRepository()
+	wal := executionruntime.NewInMemoryWAL()
+	base := time.Date(2026, 3, 23, 10, 0, 0, 0, time.UTC)
+
+	mustNoErr(t, caseRepo.Save(ctx, caseruntime.Case{ID: "case-1", Kind: "workflow.action", Status: "open", CorrelationID: "corr-1", SubjectRef: "subject-1", OpenedAt: base, UpdatedAt: base}))
+	mustNoErr(t, queueRepo.SaveQueue(ctx, workplan.WorkQueue{ID: "queue-1", Name: "Ops"}))
+	mustNoErr(t, queueRepo.SaveWorkItem(ctx, workplan.WorkItem{ID: "work-1", CaseID: "case-1", QueueID: "queue-1", Type: "workflow.action", Status: "open", PlanID: "plan-1", AssignedEmployeeID: "actor-1", CreatedAt: base, UpdatedAt: base}))
+	mustNoErr(t, coordRepo.SaveDecision(ctx, workplan.CoordinationDecision{ID: "coord-1", WorkItemID: "work-1", CaseID: "case-1", QueueID: "queue-1", DecisionType: workplan.CoordinationDefer, Priority: 2, Reason: "awaiting approval", CreatedAt: base.Add(time.Minute)}))
+	mustNoErr(t, policyRepo.SaveDecision(ctx, policy.PolicyDecision{ID: "policy-1", CoordinationDecisionID: "coord-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Outcome: policy.PolicyRequireApproval, Reason: "review", CreatedAt: base.Add(2 * time.Minute)}))
+	mustNoErr(t, policyRepo.SaveApprovalRequest(ctx, policy.ApprovalRequest{ID: "approval-1", CoordinationDecisionID: "coord-1", PolicyDecisionID: "policy-1", CaseID: "case-1", WorkItemID: "work-1", QueueID: "queue-1", Status: policy.ApprovalPending, CreatedAt: base.Add(3 * time.Minute)}))
+	mustNoErr(t, proposalRepo.Save(ctx, proposal.Proposal{ID: "proposal-1", Type: proposal.ProposalTypeActionIntent, Status: proposal.ProposalCompiled, ActorID: "actor-1", CaseID: "case-1", WorkItemID: "work-1", Justification: "ready", ActionPlanID: "plan-compiled", CreatedAt: base.Add(4 * time.Minute), UpdatedAt: base.Add(4 * time.Minute)}))
+	mustNoErr(t, directory.SaveEmployee(ctx, employee.DigitalEmployee{ID: "actor-1", Role: "operator", Enabled: true, QueueMemberships: []string{"queue-1"}}))
+	mustNoErr(t, trustRepo.Save(ctx, trust.TrustProfile{ActorID: "actor-1", TrustLevel: trust.TrustMedium, AutonomyTier: trust.AutonomySupervised, UpdatedAt: base.Add(5 * time.Minute)}))
+	mustNoErr(t, profileRepo.SaveProfile(ctx, profile.CompetencyProfile{ID: "profile-1", ActorID: "actor-1", Name: "Operator", MaxComplexity: 3}))
+	mustNoErr(t, capRepo.SaveCapability(ctx, capability.Capability{ID: "cap-1", Code: "workflow.execute", Level: 1}))
+	mustNoErr(t, capRepo.AssignCapability(ctx, capability.ActorCapability{ActorID: "actor-1", CapabilityID: "cap-1", Level: 1}))
+	mustNoErr(t, execRepo.SaveSession(ctx, executionruntime.ExecutionSession{ID: "exec-1", WorkItemID: "work-1", Status: executionruntime.ExecutionSessionFailed, CurrentStepIndex: 1, FailureReason: "waiting", CreatedAt: base.Add(6 * time.Minute), UpdatedAt: base.Add(6 * time.Minute)}))
+	mustNoErr(t, wal.Append(ctx, executionruntime.WALRecord{ID: "wal-1", ExecutionSessionID: "exec-1", ActionID: "action-1", Type: executionruntime.WALStepResult, CreatedAt: base.Add(6 * time.Minute)}))
+
+	return controlplane.NewService(caseRepo, queueRepo, coordRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, execRepo, wal)
+}
+
+func decode(t *testing.T, rec *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	if err := json.Unmarshal(rec.Body.Bytes(), target); err != nil {
+		t.Fatalf("json.Unmarshal error = %v body=%s", err, rec.Body.String())
+	}
+}
+
+func mustNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -5,6 +5,7 @@ import (
 
 	"kalita/internal/caseruntime"
 	"kalita/internal/command"
+	"kalita/internal/controlplane"
 	"kalita/internal/employee"
 	"kalita/internal/runtime"
 	"kalita/internal/schema"
@@ -13,14 +14,14 @@ import (
 )
 
 func RunServer(addr string, storage *runtime.Storage) {
-	RunServerWithServices(addr, storage, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	RunServerWithServices(addr, storage, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func RunServerWithCommandBus(addr string, storage *runtime.Storage, commandBus command.CommandBus) {
-	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil, nil, nil, nil, nil)
+	RunServerWithServices(addr, storage, commandBus, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
-func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, coordinator coordinator, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, proposalService proposalService, employeeDirectory employee.Directory, employeeServices ...employeeService) {
+func RunServerWithServices(addr string, storage *runtime.Storage, commandBus command.CommandBus, caseService *caseruntime.Service, workService workItemIntakeService, coordinator coordinator, policyService policyService, constraintsService constraintsService, actionPlanService actionPlanService, proposalService proposalService, employeeDirectory employee.Directory, operatorService controlplane.Service, employeeServices ...employeeService) {
 	// fail-fast, если есть критичные проблемы схемы
 	if issues := schema.Lint(storage.Schemas); len(issues) > 0 {
 		for _, it := range issues {
@@ -32,6 +33,7 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 
 	apiGroup := r.Group("/api")
 	{
+		registerOperatorRoutes(apiGroup, operatorService)
 
 		//r.GET("/api/meta", MetaListHandler(storage))
 		//r.GET("/api/meta/:module/:entity", MetaEntityHandler(storage))

--- a/internal/policy/repository.go
+++ b/internal/policy/repository.go
@@ -90,6 +90,16 @@ func (r *InMemoryRepository) GetApprovalRequest(_ context.Context, id string) (A
 	return a, true, nil
 }
 
+func (r *InMemoryRepository) ListApprovalRequests(_ context.Context) ([]ApprovalRequest, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]ApprovalRequest, 0, len(r.approvalOrder))
+	for _, id := range r.approvalOrder {
+		out = append(out, r.approvalsByID[id])
+	}
+	return out, nil
+}
+
 func (r *InMemoryRepository) ListApprovalRequestsByCoordinationDecision(_ context.Context, coordinationDecisionID string) ([]ApprovalRequest, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -55,6 +55,7 @@ type PolicyRepository interface {
 
 	SaveApprovalRequest(ctx context.Context, r ApprovalRequest) error
 	GetApprovalRequest(ctx context.Context, id string) (ApprovalRequest, bool, error)
+	ListApprovalRequests(ctx context.Context) ([]ApprovalRequest, error)
 	ListApprovalRequestsByCoordinationDecision(ctx context.Context, coordinationDecisionID string) ([]ApprovalRequest, error)
 }
 


### PR DESCRIPTION
### Motivation
- Provide a minimal Control Plane / Operator Console layer so the governed runtime becomes visible and operable without changing core runtime logic. 
- Expose deterministic, aggregated read models for cases, work items, coordination/policy/proposal/execution artifacts, actors, and approvals for operator inspection. 

### Description
- Add a transport-free query service `internal/controlplane` with view models and a `Service` interface and implementation that aggregates existing repositories (new files: `internal/controlplane/queries.go`, `internal/controlplane/viewmodels.go`, `internal/controlplane/service.go`).
- Wire a thin HTTP operator surface under `/api/operator/...` with JSON-only endpoints and thin handlers that delegate aggregation to the control plane service (new `internal/http/operator.go` and updated router wiring in `internal/http/router.go`).
- Extend in-memory repository interfaces and implementations to support listing needed by the control plane: `caseruntime.CaseRepository` gains `List`, and `policy.PolicyRepository` gains `ListApprovalRequests`, with corresponding in-memory implementations updated (`internal/caseruntime/*`, `internal/policy/*`).
- Bootstrap the control plane service in app startup and pass it into `RunServerWithServices` so operator routes are available at runtime (`internal/app/bootstrap.go`, `cmd/server/main.go`).
- Deterministic “latest” selection is explicitly documented and implemented: newest timestamp wins and lexical ID order breaks ties (see `latestBy` in `internal/controlplane/service.go`).

### Testing
- Ran `go test ./internal/controlplane` and `go test ./internal/http` and both packages passed their unit tests (service aggregation tests and HTTP operator endpoint tests succeeded). 
- Targeted service tests cover case/work-item/actor aggregation, approval inbox composition, blocked/deferred work listing, and deterministic latest-artifact selection (`internal/controlplane/service_test.go`).
- HTTP tests validate endpoint responses and not-found behavior for the operator routes (`internal/http/operator_test.go`).
- Note: `internal/app` bootstrap test was attempted in the environment but did not complete reliably within the short execution window here, so full bootstrap verification should be confirmed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c130c536988324851ec0696012d2d6)