### PR TITLE
docs: add AGENT_GUIDE.md with default agent workflow

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -1,0 +1,19 @@
+# AGENT_GUIDE.md
+
+## Default workflow
+
+- Work directly on the current branch.
+- Implement changes on the current branch instead of creating topic branches.
+- Create focused, slice-sized local commits with clear messages.
+- Do not open a pull request or prepare pull request metadata unless explicitly requested.
+- Do not use PR flow for routine incremental slices.
+- Use direct branch commits unless the task is explicitly marked as a review checkpoint.
+
+## Change summary expectations
+
+When finishing a change, summarize:
+
+- changed files,
+- key design notes,
+- migration caveats,
+- tests and checks that were run.


### PR DESCRIPTION
### Motivation
- Provide a single, persistent place (`AGENT_GUIDE.md`) to record the default agent workflow and change-summary expectations so contributors do not need to restate them in future changes.

### Description
- Add a root `AGENT_GUIDE.md` that documents the default workflow: work directly on the current branch, make focused slice-sized local commits, avoid preparing PR metadata unless explicitly requested, and list the post-change summary items (`changed files`, `design notes`, `migration caveats`, `tests and checks run`).

### Testing
- No automated tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c136fbf83483249596fd9041590a50)