### PR TITLE
Add deterministic "Container Incident Handling" demo and control-plane visibility

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -218,7 +218,7 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	workService := workplan.NewService(queueRepo, assignmentRouter, planner, coordinator, eventLog, clock, ids)
 	employeeSelector := employee.NewSelectorWithMatcher(employeeDirectory, profile.NewMatcher(profileRepo, profileRepo, capabilityRepo, capabilityRepo, trustService))
 	employeeService := employee.NewService(assignmentRepo, employeeSelector, executionRuntime, eventLog, clock, ids, trustService)
-	controlPlaneService := controlplane.NewService(caseRepo, queueRepo, coordinationRepo, policyRepo, proposalRepo, employeeDirectory, trustRepo, profileRepo, capabilityRepo, executionRepo, executionWAL)
+	controlPlaneService := controlplane.NewService(caseRepo, queueRepo, coordinationRepo, policyRepo, proposalRepo, employeeDirectory, trustRepo, profileRepo, capabilityRepo, executionRepo, executionWAL, eventLog)
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}

--- a/internal/controlplane/queries.go
+++ b/internal/controlplane/queries.go
@@ -3,6 +3,9 @@ package controlplane
 import "context"
 
 type Service interface {
+	GetSummary(ctx context.Context) (Summary, error)
+	GetCaseTimeline(ctx context.Context, caseID string) ([]TimelineEntry, error)
+
 	GetCaseOverview(ctx context.Context, caseID string) (CaseOverview, error)
 	ListCases(ctx context.Context) ([]CaseOverview, error)
 

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -9,6 +9,7 @@ import (
 	"kalita/internal/capability"
 	"kalita/internal/caseruntime"
 	"kalita/internal/employee"
+	"kalita/internal/eventcore"
 	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
 	"kalita/internal/profile"
@@ -44,6 +45,7 @@ type service struct {
 	capabilities capability.InMemoryCapabilityRepository
 	executions   executionruntime.ExecutionRepository
 	wal          executionruntime.WAL
+	eventLog     eventcore.EventLog
 }
 
 func NewService(
@@ -58,6 +60,7 @@ func NewService(
 	capRepo *capability.InMemoryCapabilityRepository,
 	executions executionruntime.ExecutionRepository,
 	wal executionruntime.WAL,
+	eventLog eventcore.EventLog,
 ) Service {
 	var caseLister CaseLister
 	if l, ok := cases.(CaseLister); ok {
@@ -71,7 +74,63 @@ func NewService(
 	if l, ok := policies.(ApprovalRequestLister); ok {
 		approvals = l
 	}
-	return &service{cases: cases, caseLister: caseLister, workItems: workItems, workLister: workLister, coordination: coordination, policies: policies, approvals: approvals, proposals: proposals, actors: actors, trust: trustRepo, profiles: profiles, capabilities: *capRepo, executions: executions, wal: wal}
+	return &service{cases: cases, caseLister: caseLister, workItems: workItems, workLister: workLister, coordination: coordination, policies: policies, approvals: approvals, proposals: proposals, actors: actors, trust: trustRepo, profiles: profiles, capabilities: *capRepo, executions: executions, wal: wal, eventLog: eventLog}
+}
+
+func (s *service) GetSummary(ctx context.Context) (Summary, error) {
+	cases, err := s.ListCases(ctx)
+	if err != nil {
+		return Summary{}, err
+	}
+	items, err := s.ListWorkItems(ctx)
+	if err != nil {
+		return Summary{}, err
+	}
+	approvals, err := s.GetApprovalInbox(ctx)
+	if err != nil {
+		return Summary{}, err
+	}
+	blocked, err := s.GetBlockedOrDeferredWork(ctx)
+	if err != nil {
+		return Summary{}, err
+	}
+	summary := Summary{WorkItemCount: len(items), ApprovalPendingCount: len(approvals), BlockedOrDeferredCount: len(blocked)}
+	for _, c := range cases {
+		if c.Status == string(caseruntime.CaseOpen) || c.Status == "open" {
+			summary.OpenCaseCount++
+		}
+	}
+	return summary, nil
+}
+
+func (s *service) GetCaseTimeline(ctx context.Context, caseID string) ([]TimelineEntry, error) {
+	c, ok, err := s.cases.GetByID(ctx, caseID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("case %s not found", caseID)
+	}
+	if s.eventLog == nil {
+		return []TimelineEntry{}, nil
+	}
+	_, executionEvents, err := s.eventLog.ListByCorrelation(ctx, c.CorrelationID)
+	if err != nil {
+		return nil, err
+	}
+	timeline := make([]TimelineEntry, 0, len(executionEvents))
+	for _, e := range executionEvents {
+		if e.CaseID != "" && e.CaseID != caseID {
+			continue
+		}
+		step, include := normalizeTimelineStep(e)
+		if !include {
+			continue
+		}
+		timeline = append(timeline, TimelineEntry{Step: step, Status: e.Status, OccurredAt: e.OccurredAt, Payload: clonePayload(e.Payload)})
+	}
+	sort.SliceStable(timeline, func(i, j int) bool { return timeline[i].OccurredAt.Before(timeline[j].OccurredAt) })
+	return timeline, nil
 }
 
 func (s *service) GetCaseOverview(ctx context.Context, caseID string) (CaseOverview, error) {
@@ -356,4 +415,37 @@ func latestBy[T any](items []T, id func(T) string, ts func(T) int64) T {
 		}
 	}
 	return latest
+}
+
+func normalizeTimelineStep(e eventcore.ExecutionEvent) (string, bool) {
+	switch e.Step {
+	case "case_resolution":
+		if e.Status == "opened_new" {
+			return "case_created", true
+		}
+		return "case_resolved", true
+	case "work_item_intake":
+		return "work_item_created", true
+	case "coordination_decision_made":
+		return "coordination_decided", true
+	case "policy_evaluation":
+		return "policy_decided", true
+	case "approval_request_created":
+		return "approval_requested", true
+	case "execution_session_created":
+		return "execution_started", true
+	default:
+		return "", false
+	}
+}
+
+func clonePayload(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/controlplane/service_test.go
+++ b/internal/controlplane/service_test.go
@@ -8,6 +8,7 @@ import (
 	"kalita/internal/capability"
 	"kalita/internal/caseruntime"
 	"kalita/internal/employee"
+	"kalita/internal/eventcore"
 	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
 	"kalita/internal/profile"
@@ -131,7 +132,7 @@ func seededService(t *testing.T) Service {
 	must(t, wal.Append(ctx, executionruntime.WALRecord{ID: "wal-1", ExecutionSessionID: "exec-2", ActionID: "action-1", Type: executionruntime.WALStepIntent, CreatedAt: base.Add(11 * time.Minute)}))
 	must(t, wal.Append(ctx, executionruntime.WALRecord{ID: "wal-2", ExecutionSessionID: "exec-2", ActionID: "action-2", Type: executionruntime.WALStepResult, CreatedAt: base.Add(12 * time.Minute)}))
 
-	return NewService(caseRepo, queueRepo, coordRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, execRepo, wal)
+	return NewService(caseRepo, queueRepo, coordRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, execRepo, wal, eventcore.NewInMemoryEventLog())
 }
 
 func must(t *testing.T, err error) {

--- a/internal/controlplane/viewmodels.go
+++ b/internal/controlplane/viewmodels.go
@@ -2,6 +2,20 @@ package controlplane
 
 import "time"
 
+type Summary struct {
+	OpenCaseCount          int `json:"open_case_count"`
+	WorkItemCount          int `json:"work_item_count"`
+	ApprovalPendingCount   int `json:"approval_pending_count"`
+	BlockedOrDeferredCount int `json:"blocked_or_deferred_count"`
+}
+
+type TimelineEntry struct {
+	Step       string         `json:"step"`
+	Status     string         `json:"status,omitempty"`
+	OccurredAt time.Time      `json:"occurred_at"`
+	Payload    map[string]any `json:"payload,omitempty"`
+}
+
 type CaseOverview struct {
 	CaseID        string    `json:"case_id"`
 	Kind          string    `json:"kind"`

--- a/internal/demo/scenario.go
+++ b/internal/demo/scenario.go
@@ -1,0 +1,235 @@
+package demo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"kalita/internal/actionplan"
+	"kalita/internal/capability"
+	"kalita/internal/caseruntime"
+	"kalita/internal/command"
+	"kalita/internal/controlplane"
+	"kalita/internal/employee"
+	"kalita/internal/eventcore"
+	"kalita/internal/executionruntime"
+	"kalita/internal/policy"
+	"kalita/internal/profile"
+	"kalita/internal/proposal"
+	"kalita/internal/trust"
+	"kalita/internal/workplan"
+)
+
+const (
+	DemoEventID           = "evt-demo-container-incident"
+	DemoCommandID         = "cmd-demo-container-incident"
+	DemoCorrelationID     = "corr-demo-container-incident"
+	DemoExecutionID       = "exec-demo-container-incident"
+	DemoCaseID            = "case-demo-container-incident"
+	DemoWorkItemID        = "work-demo-container-incident"
+	DemoPlanID            = "plan-demo-container-incident"
+	DemoCoordinationID    = "coord-demo-container-incident"
+	DemoPolicyDecisionID  = "policy-demo-container-incident"
+	DemoApprovalRequestID = "approval-demo-container-incident"
+	DemoQueueID           = "queue-demo-container-incidents"
+)
+
+type ScenarioResult struct {
+	ControlPlane      controlplane.Service
+	EventLog          eventcore.EventLog
+	CaseID            string
+	WorkItemID        string
+	CoordinationID    string
+	PolicyDecisionID  string
+	ApprovalRequestID string
+	CorrelationID     string
+	ExecutionID       string
+	BaseTime          time.Time
+	CaseRepo          caseruntime.CaseRepository
+	QueueRepo         *workplan.InMemoryQueueRepository
+	CoordinationRepo  *workplan.InMemoryCoordinationRepository
+	PolicyRepo        *policy.InMemoryRepository
+	ExecutionRepo     *executionruntime.InMemoryExecutionRepository
+}
+
+func RunDemoScenario(ctx context.Context) (*ScenarioResult, error) {
+	baseTime := time.Date(2026, 3, 23, 12, 0, 0, 0, time.UTC)
+	clock := &scriptedClock{times: []time.Time{
+		baseTime,
+		baseTime.Add(1 * time.Minute),
+		baseTime.Add(2 * time.Minute),
+		baseTime.Add(3 * time.Minute),
+		baseTime.Add(4 * time.Minute),
+		baseTime.Add(5 * time.Minute),
+		baseTime.Add(6 * time.Minute),
+		baseTime.Add(7 * time.Minute),
+	}}
+	ids := &fixedIDs{ids: []string{
+		"execevt-command-admission",
+		DemoCaseID, "execevt-case-created",
+		DemoWorkItemID, "execevt-work-item-created", DemoPlanID, "execevt-plan-intake",
+		"demo-id-intake-default-coordination", "demo-id-intake-default-coordination-event",
+		DemoCoordinationID, "execevt-coordination",
+		DemoPolicyDecisionID, "execevt-policy",
+		DemoApprovalRequestID, "execevt-approval",
+	}}
+
+	eventLog := eventcore.NewInMemoryEventLog()
+	caseRepo := caseruntime.NewInMemoryCaseRepository()
+	queueRepo := workplan.NewInMemoryQueueRepository()
+	coordinationRepo := workplan.NewInMemoryCoordinationRepository()
+	policyRepo := policy.NewInMemoryRepository()
+	proposalRepo := proposal.NewInMemoryRepository()
+	directory := employee.NewInMemoryDirectory()
+	trustRepo := trust.NewInMemoryRepository()
+	profileRepo := profile.NewInMemoryRepository()
+	capRepo := capability.NewInMemoryRepository()
+	executionRepo := executionruntime.NewInMemoryExecutionRepository()
+	wal := executionruntime.NewInMemoryWAL()
+
+	if err := seedDemoScenario(ctx, baseTime, queueRepo, directory, trustRepo, profileRepo, capRepo); err != nil {
+		return nil, err
+	}
+
+	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
+	caseService := caseruntime.NewService(caseruntime.NewResolver(caseRepo, clock, ids), eventLog, clock, ids)
+	planner := workplan.NewPlanner(workplan.NewInMemoryPlanRepository(), eventLog, clock, ids)
+	coordinator := workplan.NewCoordinator(coordinationRepo, eventLog, clock, ids)
+	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, DemoQueueID), planner, coordinator, eventLog, clock, ids)
+	policyService := policy.NewService(policyRepo, policy.NewEvaluator(), eventLog, clock, ids)
+	controlPlaneService := controlplane.NewService(caseRepo, queueRepo, coordinationRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, executionRepo, wal, eventLog)
+
+	if err := eventLog.AppendEvent(ctx, eventcore.Event{ID: DemoEventID, Type: "container_incident_detected", OccurredAt: baseTime, Source: "demo.scenario", CorrelationID: DemoCorrelationID, CausationID: DemoEventID, ExecutionID: DemoExecutionID, Payload: map[string]any{"container_id": "container-demo-001", "severity": "high", "namespace": "payments"}}); err != nil {
+		return nil, fmt.Errorf("append demo event: %w", err)
+	}
+
+	cmd, err := commandBus.Submit(ctx, eventcore.Command{Type: "container_incident_detected", ID: DemoCommandID, CorrelationID: DemoCorrelationID, CausationID: DemoEventID, ExecutionID: DemoExecutionID, RequestedAt: baseTime.Add(30 * time.Second), TargetRef: "container-demo-001", Payload: map[string]any{"namespace": "payments", "severity": "high"}})
+	if err != nil {
+		return nil, fmt.Errorf("submit demo command: %w", err)
+	}
+	resolved, err := caseService.ResolveCommand(ctx, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("resolve demo command: %w", err)
+	}
+	intake, err := workService.IntakeCommand(ctx, resolved)
+	if err != nil {
+		return nil, fmt.Errorf("intake demo command: %w", err)
+	}
+
+	actors, profiles, err := demoCoordinationInputs(ctx, directory, trustRepo, profileRepo)
+	if err != nil {
+		return nil, err
+	}
+	coordinationCtx := workplan.ContextWithPlanningExecution(ctx, workplan.PlanningExecutionContext{ExecutionID: cmd.ExecutionID, CorrelationID: cmd.CorrelationID, CausationID: cmd.ID})
+	decision, err := coordinator.Decide(coordinationCtx, intake.WorkItem, workplan.CoordinationContext{ActionTypes: []string{"legacy_workflow_action"}, Complexity: 1, Actors: actors, Profiles: profiles})
+	if err != nil {
+		return nil, fmt.Errorf("coordinate demo work item: %w", err)
+	}
+	policyCtx := policy.ContextWithExecution(ctx, policy.ExecutionContext{ExecutionID: cmd.ExecutionID, CorrelationID: cmd.CorrelationID, CausationID: cmd.ID})
+	policyDecision, approvalRequest, err := policyService.EvaluateAndRecord(policyCtx, decision)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate demo policy: %w", err)
+	}
+	if approvalRequest == nil {
+		return nil, fmt.Errorf("demo scenario expected approval request")
+	}
+
+	return &ScenarioResult{ControlPlane: controlPlaneService, EventLog: eventLog, CaseID: resolved.Case.ID, WorkItemID: intake.WorkItem.ID, CoordinationID: decision.ID, PolicyDecisionID: policyDecision.ID, ApprovalRequestID: approvalRequest.ID, CorrelationID: cmd.CorrelationID, ExecutionID: cmd.ExecutionID, BaseTime: baseTime, CaseRepo: caseRepo, QueueRepo: queueRepo, CoordinationRepo: coordinationRepo, PolicyRepo: policyRepo, ExecutionRepo: executionRepo}, nil
+}
+
+func seedDemoScenario(ctx context.Context, now time.Time, queueRepo *workplan.InMemoryQueueRepository, directory *employee.InMemoryDirectory, trustRepo *trust.InMemoryRepository, profileRepo *profile.InMemoryRepository, capRepo *capability.InMemoryCapabilityRepository) error {
+	if err := queueRepo.SaveQueue(ctx, workplan.WorkQueue{ID: DemoQueueID, Name: "Demo Container Incident Intake", Department: "operations", Purpose: "Deterministic demo queue for container incidents", AllowedCaseKinds: []string{"container_incident_detected"}}); err != nil {
+		return fmt.Errorf("seed demo queue: %w", err)
+	}
+	actors := []employee.DigitalEmployee{
+		{ID: "actor-low-1", Code: "container_triage_low_1", Role: "container_triage", Enabled: true, QueueMemberships: []string{DemoQueueID}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}, AllowedCommandTypes: []string{"container_incident_detected"}, CreatedAt: now, UpdatedAt: now},
+		{ID: "actor-low-2", Code: "container_triage_low_2", Role: "container_triage", Enabled: true, QueueMemberships: []string{DemoQueueID}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}, AllowedCommandTypes: []string{"container_incident_detected"}, CreatedAt: now, UpdatedAt: now},
+	}
+	for _, actor := range actors {
+		if err := directory.SaveEmployee(ctx, actor); err != nil {
+			return fmt.Errorf("seed actor %s: %w", actor.ID, err)
+		}
+	}
+	if err := capRepo.SaveCapability(ctx, capability.Capability{ID: "cap-demo-container-ops", Code: "workflow.execute", Type: capability.CapabilitySkill, Level: 1}); err != nil {
+		return fmt.Errorf("seed capability: %w", err)
+	}
+	for _, actorID := range []string{"actor-low-1", "actor-low-2"} {
+		if err := capRepo.AssignCapability(ctx, capability.ActorCapability{ActorID: actorID, CapabilityID: "cap-demo-container-ops", Level: 1}); err != nil {
+			return fmt.Errorf("assign capability %s: %w", actorID, err)
+		}
+		if err := trustRepo.Save(ctx, trust.TrustProfile{ActorID: actorID, TrustLevel: trust.TrustLow, AutonomyTier: trust.AutonomyRestricted, UpdatedAt: now}); err != nil {
+			return fmt.Errorf("seed trust %s: %w", actorID, err)
+		}
+	}
+	profiles := []profile.CompetencyProfile{
+		{ID: "profile-low-1", ActorID: "actor-low-1", Name: "Low Trust Container Triage 1", MaxComplexity: 2, PreferredWorkKinds: []string{"container_incident_detected"}},
+		{ID: "profile-low-2", ActorID: "actor-low-2", Name: "Low Trust Container Triage 2", MaxComplexity: 2, PreferredWorkKinds: []string{"container_incident_detected"}},
+	}
+	for _, prof := range profiles {
+		if err := profileRepo.SaveProfile(ctx, prof); err != nil {
+			return fmt.Errorf("seed profile %s: %w", prof.ID, err)
+		}
+	}
+	return nil
+}
+
+func demoCoordinationInputs(ctx context.Context, directory *employee.InMemoryDirectory, trustRepo *trust.InMemoryRepository, profileRepo *profile.InMemoryRepository) ([]workplan.CoordinationActor, map[string]workplan.CoordinationActorProfile, error) {
+	employees, err := directory.ListEmployees(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list demo employees: %w", err)
+	}
+	actors := make([]workplan.CoordinationActor, 0, len(employees))
+	profiles := make(map[string]workplan.CoordinationActorProfile, len(employees))
+	for _, emp := range employees {
+		actions := make([]string, 0, len(emp.AllowedActionTypes))
+		for _, actionType := range emp.AllowedActionTypes {
+			actions = append(actions, string(actionType))
+		}
+		actors = append(actors, workplan.CoordinationActor{ID: emp.ID, Enabled: emp.Enabled, QueueMemberships: append([]string(nil), emp.QueueMemberships...), AllowedActionTypes: actions})
+		coordProfile := workplan.CoordinationActorProfile{ActorID: emp.ID}
+		if prof, ok, err := profileRepo.GetProfileByActor(ctx, emp.ID); err != nil {
+			return nil, nil, fmt.Errorf("get profile for %s: %w", emp.ID, err)
+		} else if ok {
+			coordProfile.MaxComplexity = prof.MaxComplexity
+		}
+		if trustProfile, ok, err := trustRepo.GetByActor(ctx, emp.ID); err != nil {
+			return nil, nil, fmt.Errorf("get trust for %s: %w", emp.ID, err)
+		} else if ok {
+			coordProfile.TrustLevel = string(trustProfile.TrustLevel)
+			coordProfile.TrustAvailable = true
+		}
+		profiles[emp.ID] = coordProfile
+	}
+	return actors, profiles, nil
+}
+
+type fixedIDs struct {
+	ids []string
+	idx int
+}
+
+func (f *fixedIDs) NewID() string {
+	if f.idx >= len(f.ids) {
+		return fmt.Sprintf("demo-id-%02d", f.idx)
+	}
+	id := f.ids[f.idx]
+	f.idx++
+	return id
+}
+
+type scriptedClock struct {
+	times []time.Time
+	idx   int
+}
+
+func (c *scriptedClock) Now() time.Time {
+	if len(c.times) == 0 {
+		return time.Date(2026, 3, 23, 12, 0, 0, 0, time.UTC)
+	}
+	if c.idx >= len(c.times) {
+		return c.times[len(c.times)-1]
+	}
+	t := c.times[c.idx]
+	c.idx++
+	return t
+}

--- a/internal/demo/scenario_test.go
+++ b/internal/demo/scenario_test.go
@@ -1,0 +1,102 @@
+package demo
+
+import (
+	"context"
+	"testing"
+
+	"kalita/internal/policy"
+	"kalita/internal/workplan"
+)
+
+func TestRunDemoScenarioProducesDeferredApprovalPathVisibleInControlPlane(t *testing.T) {
+	t.Parallel()
+
+	result, err := RunDemoScenario(context.Background())
+	if err != nil {
+		t.Fatalf("RunDemoScenario error = %v", err)
+	}
+
+	summary, err := result.ControlPlane.GetSummary(context.Background())
+	if err != nil {
+		t.Fatalf("GetSummary error = %v", err)
+	}
+	if summary.OpenCaseCount != 1 || summary.WorkItemCount != 1 || summary.ApprovalPendingCount != 1 || summary.BlockedOrDeferredCount != 1 {
+		t.Fatalf("summary = %#v", summary)
+	}
+
+	cases, err := result.ControlPlane.ListCases(context.Background())
+	if err != nil {
+		t.Fatalf("ListCases error = %v", err)
+	}
+	if len(cases) != 1 || cases[0].CaseID != DemoCaseID {
+		t.Fatalf("cases = %#v", cases)
+	}
+
+	caseOverview, err := result.ControlPlane.GetCaseOverview(context.Background(), DemoCaseID)
+	if err != nil {
+		t.Fatalf("GetCaseOverview error = %v", err)
+	}
+	if caseOverview.Kind != "container_incident_detected" || caseOverview.CorrelationID != DemoCorrelationID {
+		t.Fatalf("caseOverview = %#v", caseOverview)
+	}
+
+	workItems, err := result.ControlPlane.ListWorkItems(context.Background())
+	if err != nil {
+		t.Fatalf("ListWorkItems error = %v", err)
+	}
+	if len(workItems) != 1 {
+		t.Fatalf("workItems = %#v", workItems)
+	}
+	if workItems[0].Coordination.DecisionType != string(workplan.CoordinationDefer) {
+		t.Fatalf("coordination = %#v", workItems[0].Coordination)
+	}
+	if workItems[0].PolicyApproval.Outcome != string(policy.PolicyRequireApproval) || workItems[0].PolicyApproval.ApprovalRequestID != DemoApprovalRequestID {
+		t.Fatalf("policy approval = %#v", workItems[0].PolicyApproval)
+	}
+	if workItems[0].Execution.SessionID != "" {
+		t.Fatalf("expected no execution session, got %#v", workItems[0].Execution)
+	}
+
+	approvals, err := result.ControlPlane.GetApprovalInbox(context.Background())
+	if err != nil {
+		t.Fatalf("GetApprovalInbox error = %v", err)
+	}
+	if len(approvals) != 1 || approvals[0].ApprovalRequestID != DemoApprovalRequestID {
+		t.Fatalf("approvals = %#v", approvals)
+	}
+
+	timeline, err := result.ControlPlane.GetCaseTimeline(context.Background(), DemoCaseID)
+	if err != nil {
+		t.Fatalf("GetCaseTimeline error = %v", err)
+	}
+	steps := make([]string, 0, len(timeline))
+	for _, entry := range timeline {
+		steps = append(steps, entry.Step)
+	}
+	want := []string{"case_created", "work_item_created", "coordination_decided", "policy_decided", "approval_requested"}
+	for _, step := range want {
+		if !contains(steps, step) {
+			t.Fatalf("timeline steps = %#v, missing %q", steps, step)
+		}
+	}
+	if contains(steps, "execution_started") {
+		t.Fatalf("timeline unexpectedly contains execution_started: %#v", steps)
+	}
+	for i := 1; i < len(timeline); i++ {
+		if timeline[i].OccurredAt.Before(timeline[i-1].OccurredAt) {
+			t.Fatalf("timeline not ordered: %#v", timeline)
+		}
+	}
+	if got := workItems[0].Coordination.Reason; got != "only low-trust actors available: actor-low-1,actor-low-2; defer until stronger trust or supervised release" {
+		t.Fatalf("coordination reason = %q", got)
+	}
+}
+
+func contains(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/http/operator.go
+++ b/internal/http/operator.go
@@ -19,8 +19,16 @@ func registerOperatorRoutes(group *gin.RouterGroup, svc controlplane.Service) {
 		payload, err := svc.ListCases(c.Request.Context())
 		respondOperator(c, payload, err)
 	})
+	operator.GET("/summary", func(c *gin.Context) {
+		payload, err := svc.GetSummary(c.Request.Context())
+		respondOperator(c, payload, err)
+	})
 	operator.GET("/cases/:id", func(c *gin.Context) {
 		payload, err := svc.GetCaseOverview(c.Request.Context(), c.Param("id"))
+		respondOperator(c, payload, err)
+	})
+	operator.GET("/cases/:id/timeline", func(c *gin.Context) {
+		payload, err := svc.GetCaseTimeline(c.Request.Context(), c.Param("id"))
 		respondOperator(c, payload, err)
 	})
 	operator.GET("/work-items", func(c *gin.Context) {

--- a/internal/http/operator_test.go
+++ b/internal/http/operator_test.go
@@ -12,6 +12,7 @@ import (
 	"kalita/internal/caseruntime"
 	"kalita/internal/controlplane"
 	"kalita/internal/employee"
+	"kalita/internal/eventcore"
 	"kalita/internal/executionruntime"
 	"kalita/internal/policy"
 	"kalita/internal/profile"
@@ -117,7 +118,7 @@ func controlplaneSeededService(t *testing.T) controlplane.Service {
 	mustNoErr(t, execRepo.SaveSession(ctx, executionruntime.ExecutionSession{ID: "exec-1", WorkItemID: "work-1", Status: executionruntime.ExecutionSessionFailed, CurrentStepIndex: 1, FailureReason: "waiting", CreatedAt: base.Add(6 * time.Minute), UpdatedAt: base.Add(6 * time.Minute)}))
 	mustNoErr(t, wal.Append(ctx, executionruntime.WALRecord{ID: "wal-1", ExecutionSessionID: "exec-1", ActionID: "action-1", Type: executionruntime.WALStepResult, CreatedAt: base.Add(6 * time.Minute)}))
 
-	return controlplane.NewService(caseRepo, queueRepo, coordRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, execRepo, wal)
+	return controlplane.NewService(caseRepo, queueRepo, coordRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, execRepo, wal, eventcore.NewInMemoryEventLog())
 }
 
 func decode(t *testing.T, rec *httptest.ResponseRecorder, target any) {

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -40,9 +40,6 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 		apiGroup.GET("/meta", MetaListHandler(storage))
 		apiGroup.GET("/meta/:module/:entity", MetaEntityHandler(storage))
 		apiGroup.GET("/meta/catalog/:name", MetaCatalogHandler(storage)) // если пользуешься catalog=
-		apiGroup.GET("/operator/cases/:id", OperatorCaseDetailHandler(controlPlane))
-		apiGroup.GET("/operator/cases/:id/timeline", OperatorCaseTimelineHandler(controlPlane))
-		apiGroup.GET("/operator/summary", OperatorSummaryHandler(controlPlane))
 
 		apiGroup.POST("/:module/:entity/:id/_file/:field", UploadFileHandler(storage))
 		apiGroup.POST("/:module/:entity/:id/_actions/:action", ActionHandlerWithServices(storage, commandBus, caseService, workService, coordinator, policyService, constraintsService, actionPlanService, proposalService, employeeDirectory, employeeServices...))

--- a/internal/workplan/repository.go
+++ b/internal/workplan/repository.go
@@ -111,6 +111,16 @@ func (r *InMemoryQueueRepository) ListWorkItemsByQueue(_ context.Context, queueI
 	return out, nil
 }
 
+func (r *InMemoryQueueRepository) ListWorkItems(_ context.Context) ([]WorkItem, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]WorkItem, 0, len(r.workItemOrder))
+	for _, id := range r.workItemOrder {
+		out = append(out, cloneWorkItem(r.workItemsByID[id]))
+	}
+	return out, nil
+}
+
 func cloneQueue(q WorkQueue) WorkQueue {
 	out := q
 	out.AllowedCaseKinds = append([]string(nil), q.AllowedCaseKinds...)


### PR DESCRIPTION
### Motivation
- Provide a deterministic end-to-end demo that exercises the full runtime pipeline (event → case → work → coordination → policy → execution decisions) and is observable from the control plane. 
- Demonstrate the `defer + approval_required` path when only low-trust actors are available, without changing core runtime logic or adding operator mutation endpoints. 

### Description
- Add a deterministic scenario runner `RunDemoScenario` and deterministic seed in `internal/demo/scenario.go` that emits a `container_incident_detected` event, drives the command → case → work intake flow, re-runs coordination with seeded low-trust actors, and produces a policy approval request. 
- Add an integration-style test `internal/demo/scenario_test.go` that asserts the expected final state: 1 case, 1 work item, coordination `defer`, `policy=require_approval`, approval request exists, no execution session, and timeline entries include `case_created`, `work_item_created`, `coordination_decided`, `policy_decided`, `approval_requested`. 
- Extend the control plane with summary and timeline queries and view models (`GetSummary`, `GetCaseTimeline`, `Summary`, `TimelineEntry`) and normalize execution events into human-friendly timeline steps so the demo is visible through operator reads. 
- Expose read-only operator routes for the summary and case timeline at `GET /api/operator/summary` and `GET /api/operator/cases/{id}/timeline`. 
- Add `ListWorkItems` to the in-memory queue repository and wire the shared `eventLog` into control plane bootstrap so timeline and summary are backed by real runtime events. 

### Testing
- Ran unit/integration tests for the impacted packages with `go test ./internal/demo ./internal/controlplane ./internal/http ./internal/workplan ./internal/app`, and all targeted tests passed. 
- The demo test `TestRunDemoScenarioProducesDeferredApprovalPathVisibleInControlPlane` exercises the full flow and verifies timeline ordering and expected artifacts (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c140961f348324aaccdde34b1d4310)