### PR TITLE
Add operator approval endpoints and approval lifecycle handling

### DIFF
--- a/internal/controlplane/queries.go
+++ b/internal/controlplane/queries.go
@@ -17,4 +17,7 @@ type Service interface {
 
 	GetApprovalInbox(ctx context.Context) ([]ApprovalInboxItem, error)
 	GetBlockedOrDeferredWork(ctx context.Context) ([]WorkItemOverview, error)
+
+	ApproveApprovalRequest(ctx context.Context, approvalRequestID string) (ApprovalInboxItem, error)
+	RejectApprovalRequest(ctx context.Context, approvalRequestID string) (ApprovalInboxItem, error)
 }

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"kalita/internal/capability"
 	"kalita/internal/caseruntime"
@@ -46,6 +47,7 @@ type service struct {
 	executions   executionruntime.ExecutionRepository
 	wal          executionruntime.WAL
 	eventLog     eventcore.EventLog
+	coordinator  workplan.Coordinator
 }
 
 func NewService(
@@ -61,6 +63,7 @@ func NewService(
 	executions executionruntime.ExecutionRepository,
 	wal executionruntime.WAL,
 	eventLog eventcore.EventLog,
+	coordinators ...workplan.Coordinator,
 ) Service {
 	var caseLister CaseLister
 	if l, ok := cases.(CaseLister); ok {
@@ -74,7 +77,163 @@ func NewService(
 	if l, ok := policies.(ApprovalRequestLister); ok {
 		approvals = l
 	}
-	return &service{cases: cases, caseLister: caseLister, workItems: workItems, workLister: workLister, coordination: coordination, policies: policies, approvals: approvals, proposals: proposals, actors: actors, trust: trustRepo, profiles: profiles, capabilities: *capRepo, executions: executions, wal: wal, eventLog: eventLog}
+	var coordinator workplan.Coordinator
+	if len(coordinators) > 0 {
+		coordinator = coordinators[0]
+	}
+	return &service{cases: cases, caseLister: caseLister, workItems: workItems, workLister: workLister, coordination: coordination, policies: policies, approvals: approvals, proposals: proposals, actors: actors, trust: trustRepo, profiles: profiles, capabilities: *capRepo, executions: executions, wal: wal, eventLog: eventLog, coordinator: coordinator}
+}
+
+func (s *service) ApproveApprovalRequest(ctx context.Context, approvalRequestID string) (ApprovalInboxItem, error) {
+	return s.resolveApprovalRequest(ctx, approvalRequestID, policy.ApprovalApproved, "approval_granted")
+}
+
+func (s *service) RejectApprovalRequest(ctx context.Context, approvalRequestID string) (ApprovalInboxItem, error) {
+	return s.resolveApprovalRequest(ctx, approvalRequestID, policy.ApprovalRejected, "approval_rejected")
+}
+
+func (s *service) resolveApprovalRequest(ctx context.Context, approvalRequestID string, target policy.ApprovalStatus, step string) (ApprovalInboxItem, error) {
+	req, ok, err := s.policies.GetApprovalRequest(ctx, approvalRequestID)
+	if err != nil {
+		return ApprovalInboxItem{}, err
+	}
+	if !ok {
+		return ApprovalInboxItem{}, fmt.Errorf("approval request %s not found", approvalRequestID)
+	}
+	if req.Status == target || req.Status != policy.ApprovalPending {
+		return s.buildApprovalInboxItem(ctx, req), nil
+	}
+	now := s.approvalResolutionTime(ctx, req)
+	req.Status = target
+	req.ResolvedAt = &now
+	req.ResolutionNote = string(target)
+	if err := s.policies.SaveApprovalRequest(ctx, req); err != nil {
+		return ApprovalInboxItem{}, err
+	}
+	if err := s.appendApprovalEvent(ctx, req, step, string(target), now); err != nil {
+		return ApprovalInboxItem{}, err
+	}
+	if target == policy.ApprovalApproved && s.coordinator != nil {
+		if err := s.recoordinateApprovedWorkItem(ctx, req); err != nil {
+			return ApprovalInboxItem{}, err
+		}
+	}
+	return s.buildApprovalInboxItem(ctx, req), nil
+}
+
+func (s *service) buildApprovalInboxItem(ctx context.Context, req policy.ApprovalRequest) ApprovalInboxItem {
+	coord, _ := s.latestCoordination(ctx, req.WorkItemID)
+	policyOverview, _ := s.latestPolicyApproval(ctx, coord)
+	return ApprovalInboxItem{ApprovalRequestID: req.ID, Status: string(req.Status), RequestedFromRole: req.RequestedFromRole, CaseID: req.CaseID, WorkItemID: req.WorkItemID, QueueID: req.QueueID, CreatedAt: req.CreatedAt, ResolvedAt: req.ResolvedAt, ResolutionNote: req.ResolutionNote, Coordination: coord, PolicyApproval: policyOverview}
+}
+
+func (s *service) approvalResolutionTime(ctx context.Context, req policy.ApprovalRequest) time.Time {
+	if req.ResolvedAt != nil {
+		return *req.ResolvedAt
+	}
+	coord, ok, err := s.coordination.GetDecision(ctx, req.CoordinationDecisionID)
+	if err == nil && ok {
+		return coord.CreatedAt.Add(time.Nanosecond)
+	}
+	return req.CreatedAt.Add(time.Nanosecond)
+}
+
+func (s *service) appendApprovalEvent(ctx context.Context, req policy.ApprovalRequest, step string, status string, now time.Time) error {
+	if s.eventLog == nil {
+		return nil
+	}
+	c, ok, err := s.cases.GetByID(ctx, req.CaseID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return s.eventLog.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{
+		ID:            fmt.Sprintf("%s-%s", req.ID, step),
+		ExecutionID:   fmt.Sprintf("approval:%s", req.ID),
+		CaseID:        req.CaseID,
+		Step:          step,
+		Status:        status,
+		OccurredAt:    now,
+		CorrelationID: c.CorrelationID,
+		CausationID:   req.ID,
+		Payload: map[string]any{
+			"approval_request_id":      req.ID,
+			"coordination_decision_id": req.CoordinationDecisionID,
+			"policy_decision_id":       req.PolicyDecisionID,
+			"case_id":                  req.CaseID,
+			"work_item_id":             req.WorkItemID,
+			"queue_id":                 req.QueueID,
+			"approval_request_status":  req.Status,
+			"approval_resolution_note": req.ResolutionNote,
+		},
+	})
+}
+
+func (s *service) recoordinateApprovedWorkItem(ctx context.Context, req policy.ApprovalRequest) error {
+	wi, ok, err := s.workItems.GetWorkItem(ctx, req.WorkItemID)
+	if err != nil || !ok {
+		return err
+	}
+	coordinationCtx, err := s.buildCoordinationContext(ctx, wi)
+	if err != nil {
+		return err
+	}
+	planningCtx := workplan.ContextWithPlanningExecution(ctx, workplan.PlanningExecutionContext{
+		ExecutionID:   fmt.Sprintf("approval:%s", req.ID),
+		CorrelationID: s.caseCorrelationID(ctx, req.CaseID),
+		CausationID:   req.ID,
+	})
+	_, err = s.coordinator.Decide(planningCtx, wi, coordinationCtx)
+	return err
+}
+
+func (s *service) caseCorrelationID(ctx context.Context, caseID string) string {
+	c, ok, err := s.cases.GetByID(ctx, caseID)
+	if err == nil && ok {
+		return c.CorrelationID
+	}
+	return ""
+}
+
+func (s *service) buildCoordinationContext(ctx context.Context, wi workplan.WorkItem) (workplan.CoordinationContext, error) {
+	employees, err := s.actors.ListEmployees(ctx)
+	if err != nil {
+		return workplan.CoordinationContext{}, err
+	}
+	actors := make([]workplan.CoordinationActor, 0, len(employees))
+	profiles := make(map[string]workplan.CoordinationActorProfile, len(employees))
+	for _, emp := range employees {
+		actionTypes := make([]string, 0, len(emp.AllowedActionTypes))
+		for _, actionType := range emp.AllowedActionTypes {
+			actionTypes = append(actionTypes, string(actionType))
+		}
+		actors = append(actors, workplan.CoordinationActor{ID: emp.ID, Enabled: emp.Enabled, QueueMemberships: append([]string(nil), emp.QueueMemberships...), AllowedActionTypes: actionTypes})
+		profileView := workplan.CoordinationActorProfile{ActorID: emp.ID}
+		if prof, ok, err := s.profiles.GetProfileByActor(ctx, emp.ID); err != nil {
+			return workplan.CoordinationContext{}, err
+		} else if ok {
+			profileView.MaxComplexity = prof.MaxComplexity
+		}
+		if trustProfile, ok, err := s.trust.GetByActor(ctx, emp.ID); err != nil {
+			return workplan.CoordinationContext{}, err
+		} else if ok {
+			profileView.TrustLevel = string(trustProfile.TrustLevel)
+			profileView.TrustAvailable = true
+		}
+		profiles[emp.ID] = profileView
+	}
+	actionTypes := []string{"legacy_workflow_action"}
+	complexity := 1
+	if wi.ActionPlan != nil && len(wi.ActionPlan.Actions) > 0 {
+		actionTypes = make([]string, 0, len(wi.ActionPlan.Actions))
+		for _, action := range wi.ActionPlan.Actions {
+			actionTypes = append(actionTypes, string(action.Type))
+		}
+		complexity = len(actionTypes)
+	}
+	return workplan.CoordinationContext{ActionTypes: actionTypes, Complexity: complexity, Actors: actors, Profiles: profiles}, nil
 }
 
 func (s *service) GetSummary(ctx context.Context) (Summary, error) {
@@ -229,9 +388,10 @@ func (s *service) GetApprovalInbox(ctx context.Context) ([]ApprovalInboxItem, er
 	}
 	out := make([]ApprovalInboxItem, 0, len(requests))
 	for _, req := range requests {
-		coord, _ := s.latestCoordination(ctx, req.WorkItemID)
-		policyOverview, _ := s.latestPolicyApproval(ctx, coord)
-		out = append(out, ApprovalInboxItem{ApprovalRequestID: req.ID, Status: string(req.Status), RequestedFromRole: req.RequestedFromRole, CaseID: req.CaseID, WorkItemID: req.WorkItemID, QueueID: req.QueueID, CreatedAt: req.CreatedAt, ResolvedAt: req.ResolvedAt, ResolutionNote: req.ResolutionNote, Coordination: coord, PolicyApproval: policyOverview})
+		if req.Status != policy.ApprovalPending {
+			continue
+		}
+		out = append(out, s.buildApprovalInboxItem(ctx, req))
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].CreatedAt.After(out[j].CreatedAt) })
 	return out, nil
@@ -254,6 +414,9 @@ func (s *service) GetBlockedOrDeferredWork(ctx context.Context) ([]WorkItemOverv
 func (s *service) buildWorkItemOverview(ctx context.Context, wi workplan.WorkItem) (WorkItemOverview, error) {
 	coord, coordDecision := s.latestCoordination(ctx, wi.ID)
 	policyOverview, _ := s.latestPolicyApproval(ctx, coord)
+	if policyOverview.PolicyDecisionID == "" && policyOverview.ApprovalRequestID == "" {
+		policyOverview = s.latestPolicyApprovalForWorkItem(ctx, wi.ID)
+	}
 	proposalOverview, _ := s.latestProposal(ctx, wi.ID)
 	execOverview, _ := s.latestExecution(ctx, wi.ID)
 	assigned := wi.AssignedEmployeeID
@@ -267,6 +430,51 @@ func (s *service) buildWorkItemOverview(ctx context.Context, wi workplan.WorkIte
 	}
 	_ = coordDecision
 	return WorkItemOverview{WorkItemID: wi.ID, CaseID: wi.CaseID, QueueID: wi.QueueID, Type: wi.Type, Status: wi.Status, Priority: wi.Priority, AssignedEmployeeID: assigned, PlanID: wi.PlanID, CreatedAt: wi.CreatedAt, UpdatedAt: wi.UpdatedAt, Coordination: coord, PolicyApproval: policyOverview, Proposal: proposalOverview, Execution: execOverview}, nil
+}
+
+func (s *service) latestPolicyApprovalForWorkItem(ctx context.Context, workItemID string) PolicyApprovalOverview {
+	decisions, err := s.coordination.ListByWorkItem(ctx, workItemID)
+	if err != nil || len(decisions) == 0 {
+		return PolicyApprovalOverview{}
+	}
+	var (
+		latestDecision *policy.PolicyDecision
+		latestApproval *policy.ApprovalRequest
+	)
+	for _, decision := range decisions {
+		policyDecisions, err := s.policies.ListByCoordinationDecision(ctx, decision.ID)
+		if err == nil && len(policyDecisions) > 0 {
+			current := latestBy(policyDecisions, func(d policy.PolicyDecision) string { return d.ID }, func(d policy.PolicyDecision) int64 { return d.CreatedAt.UnixNano() })
+			if latestDecision == nil || current.CreatedAt.After(latestDecision.CreatedAt) || (current.CreatedAt.Equal(latestDecision.CreatedAt) && current.ID > latestDecision.ID) {
+				copy := current
+				latestDecision = &copy
+			}
+		}
+		approvals, err := s.policies.ListApprovalRequestsByCoordinationDecision(ctx, decision.ID)
+		if err == nil && len(approvals) > 0 {
+			current := latestBy(approvals, func(a policy.ApprovalRequest) string { return a.ID }, func(a policy.ApprovalRequest) int64 { return a.CreatedAt.UnixNano() })
+			if latestApproval == nil || current.CreatedAt.After(latestApproval.CreatedAt) || (current.CreatedAt.Equal(latestApproval.CreatedAt) && current.ID > latestApproval.ID) {
+				copy := current
+				latestApproval = &copy
+			}
+		}
+	}
+	overview := PolicyApprovalOverview{}
+	if latestDecision != nil {
+		overview.PolicyDecisionID = latestDecision.ID
+		overview.Outcome = string(latestDecision.Outcome)
+		overview.Reason = latestDecision.Reason
+		overview.CreatedAt = latestDecision.CreatedAt
+	}
+	if latestApproval != nil {
+		overview.ApprovalRequestID = latestApproval.ID
+		overview.ApprovalRequestStatus = string(latestApproval.Status)
+		overview.RequestedFromRole = latestApproval.RequestedFromRole
+		overview.ApprovalRequestedAt = latestApproval.CreatedAt
+		overview.ApprovalResolvedAt = latestApproval.ResolvedAt
+		overview.ResolutionNote = latestApproval.ResolutionNote
+	}
+	return overview
 }
 
 func (s *service) buildActorOverview(ctx context.Context, actor employee.DigitalEmployee) (ActorOverview, error) {
@@ -432,6 +640,10 @@ func normalizeTimelineStep(e eventcore.ExecutionEvent) (string, bool) {
 		return "policy_decided", true
 	case "approval_request_created":
 		return "approval_requested", true
+	case "approval_granted":
+		return "approval_granted", true
+	case "approval_rejected":
+		return "approval_rejected", true
 	case "execution_session_created":
 		return "execution_started", true
 	default:

--- a/internal/demo/scenario.go
+++ b/internal/demo/scenario.go
@@ -97,7 +97,7 @@ func RunDemoScenario(ctx context.Context) (*ScenarioResult, error) {
 	coordinator := workplan.NewCoordinator(coordinationRepo, eventLog, clock, ids)
 	workService := workplan.NewService(queueRepo, workplan.NewRouter(queueRepo, DemoQueueID), planner, coordinator, eventLog, clock, ids)
 	policyService := policy.NewService(policyRepo, policy.NewEvaluator(), eventLog, clock, ids)
-	controlPlaneService := controlplane.NewService(caseRepo, queueRepo, coordinationRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, executionRepo, wal, eventLog)
+	controlPlaneService := controlplane.NewService(caseRepo, queueRepo, coordinationRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, executionRepo, wal, eventLog, coordinator)
 
 	if err := eventLog.AppendEvent(ctx, eventcore.Event{ID: DemoEventID, Type: "container_incident_detected", OccurredAt: baseTime, Source: "demo.scenario", CorrelationID: DemoCorrelationID, CausationID: DemoEventID, ExecutionID: DemoExecutionID, Payload: map[string]any{"container_id": "container-demo-001", "severity": "high", "namespace": "payments"}}); err != nil {
 		return nil, fmt.Errorf("append demo event: %w", err)

--- a/internal/demo/scenario_test.go
+++ b/internal/demo/scenario_test.go
@@ -92,6 +92,59 @@ func TestRunDemoScenarioProducesDeferredApprovalPathVisibleInControlPlane(t *tes
 	}
 }
 
+func TestRunDemoScenarioApprovalContinuesPipeline(t *testing.T) {
+	t.Parallel()
+
+	result, err := RunDemoScenario(context.Background())
+	if err != nil {
+		t.Fatalf("RunDemoScenario error = %v", err)
+	}
+
+	approved, err := result.ControlPlane.ApproveApprovalRequest(context.Background(), DemoApprovalRequestID)
+	if err != nil {
+		t.Fatalf("ApproveApprovalRequest error = %v", err)
+	}
+	if approved.Status != string(policy.ApprovalApproved) || approved.ResolvedAt == nil {
+		t.Fatalf("approved = %#v", approved)
+	}
+
+	approvedAgain, err := result.ControlPlane.ApproveApprovalRequest(context.Background(), DemoApprovalRequestID)
+	if err != nil {
+		t.Fatalf("second ApproveApprovalRequest error = %v", err)
+	}
+	if approvedAgain.Status != string(policy.ApprovalApproved) {
+		t.Fatalf("approvedAgain = %#v", approvedAgain)
+	}
+
+	workItem, err := result.ControlPlane.GetWorkItemOverview(context.Background(), DemoWorkItemID)
+	if err != nil {
+		t.Fatalf("GetWorkItemOverview error = %v", err)
+	}
+	if workItem.PolicyApproval.ApprovalRequestStatus != string(policy.ApprovalApproved) {
+		t.Fatalf("workItem = %#v", workItem)
+	}
+	if got := workItem.Coordination.DecisionType; got != string(workplan.CoordinationDefer) && got != string(workplan.CoordinationEscalate) && got != string(workplan.CoordinationExecuteNow) {
+		t.Fatalf("coordination decision = %#v", workItem.Coordination)
+	}
+
+	timeline, err := result.ControlPlane.GetCaseTimeline(context.Background(), DemoCaseID)
+	if err != nil {
+		t.Fatalf("GetCaseTimeline error = %v", err)
+	}
+	steps := make([]string, 0, len(timeline))
+	for _, entry := range timeline {
+		steps = append(steps, entry.Step)
+	}
+	for _, step := range []string{"approval_requested", "approval_granted", "coordination_decided"} {
+		if !contains(steps, step) {
+			t.Fatalf("timeline steps = %#v, missing %q", steps, step)
+		}
+	}
+	if countOccurrences(steps, "coordination_decided") < 2 {
+		t.Fatalf("timeline steps = %#v", steps)
+	}
+}
+
 func contains(items []string, target string) bool {
 	for _, item := range items {
 		if item == target {
@@ -99,4 +152,14 @@ func contains(items []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func countOccurrences(items []string, target string) int {
+	count := 0
+	for _, item := range items {
+		if item == target {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/http/operator.go
+++ b/internal/http/operator.go
@@ -51,6 +51,14 @@ func registerOperatorRoutes(group *gin.RouterGroup, svc controlplane.Service) {
 		payload, err := svc.GetApprovalInbox(c.Request.Context())
 		respondOperator(c, payload, err)
 	})
+	operator.POST("/approvals/:id/approve", func(c *gin.Context) {
+		payload, err := svc.ApproveApprovalRequest(c.Request.Context(), c.Param("id"))
+		respondOperator(c, payload, err)
+	})
+	operator.POST("/approvals/:id/reject", func(c *gin.Context) {
+		payload, err := svc.RejectApprovalRequest(c.Request.Context(), c.Param("id"))
+		respondOperator(c, payload, err)
+	})
 	operator.GET("/blocked-work", func(c *gin.Context) {
 		payload, err := svc.GetBlockedOrDeferredWork(c.Request.Context())
 		respondOperator(c, payload, err)

--- a/internal/http/operator_test.go
+++ b/internal/http/operator_test.go
@@ -87,6 +87,32 @@ func TestOperatorEndpointReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestOperatorApprovalEndpointsResolveRequestsIdempotently(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	api := r.Group("/api")
+	registerOperatorRoutes(api, controlplaneSeededService(t))
+
+	for _, path := range []string{
+		"/api/operator/approvals/approval-1/approve",
+		"/api/operator/approvals/approval-1/approve",
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("POST %s status=%d body=%s", path, w.Code, w.Body.String())
+		}
+		var payload map[string]any
+		decode(t, w, &payload)
+		if payload["status"] != "approved" {
+			t.Fatalf("payload = %#v", payload)
+		}
+	}
+}
+
 func controlplaneSeededService(t *testing.T) controlplane.Service {
 	t.Helper()
 	ctx := context.Background()
@@ -101,6 +127,7 @@ func controlplaneSeededService(t *testing.T) controlplane.Service {
 	capRepo := capability.NewInMemoryRepository()
 	execRepo := executionruntime.NewInMemoryExecutionRepository()
 	wal := executionruntime.NewInMemoryWAL()
+	eventLog := eventcore.NewInMemoryEventLog()
 	base := time.Date(2026, 3, 23, 10, 0, 0, 0, time.UTC)
 
 	mustNoErr(t, caseRepo.Save(ctx, caseruntime.Case{ID: "case-1", Kind: "workflow.action", Status: "open", CorrelationID: "corr-1", SubjectRef: "subject-1", OpenedAt: base, UpdatedAt: base}))
@@ -118,7 +145,7 @@ func controlplaneSeededService(t *testing.T) controlplane.Service {
 	mustNoErr(t, execRepo.SaveSession(ctx, executionruntime.ExecutionSession{ID: "exec-1", WorkItemID: "work-1", Status: executionruntime.ExecutionSessionFailed, CurrentStepIndex: 1, FailureReason: "waiting", CreatedAt: base.Add(6 * time.Minute), UpdatedAt: base.Add(6 * time.Minute)}))
 	mustNoErr(t, wal.Append(ctx, executionruntime.WALRecord{ID: "wal-1", ExecutionSessionID: "exec-1", ActionID: "action-1", Type: executionruntime.WALStepResult, CreatedAt: base.Add(6 * time.Minute)}))
 
-	return controlplane.NewService(caseRepo, queueRepo, coordRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, execRepo, wal, eventcore.NewInMemoryEventLog())
+	return controlplane.NewService(caseRepo, queueRepo, coordRepo, policyRepo, proposalRepo, directory, trustRepo, profileRepo, capRepo, execRepo, wal, eventLog, workplan.NewCoordinator(coordRepo, eventLog, nil, nil))
 }
 
 func decode(t *testing.T, rec *httptest.ResponseRecorder, target any) {


### PR DESCRIPTION
### Motivation

- Introduce minimal operator interaction to resolve policy approval requests (approve/reject) while preserving the existing governance model and avoiding any direct execution control. 
- Ensure approval actions are deterministic and idempotent and that the control plane surface (case overview/timeline) reflects approval outcomes and follow-up coordination decisions.

### Description

- Added two operator API endpoints: `POST /api/operator/approvals/:id/approve` and `POST /api/operator/approvals/:id/reject` and wired them to the control plane service. (changes: `internal/http/operator.go`).
- Extended the `controlplane.Service` API with `ApproveApprovalRequest` and `RejectApprovalRequest`, implemented idempotent resolution logic, event emission and re-evaluation of coordination after approval without triggering execution directly. (changes: `internal/controlplane/queries.go`, `internal/controlplane/service.go`).
- Emit domain events for approvals and expose new timeline kinds `approval_granted` and `approval_rejected` so case timelines include approval resolution and the subsequent coordination decision. (changes: `internal/controlplane/service.go`).
- Ensure the approval inbox only lists pending approvals and work-item views surface the latest policy/approval artifacts deterministically. (changes: `internal/controlplane/service.go`).
- Wire the demo scenario control plane to receive a `Coordinator` so approving a demo approval request re-runs coordination using existing coordination logic, keeping operator ≠ executor separation. (changes: `internal/demo/scenario.go`).
- Add automated tests: `TestOperatorApprovalEndpointsResolveRequestsIdempotently` (HTTP-level idempotency) and `TestRunDemoScenarioApprovalContinuesPipeline` (end-to-end demo flow covering approval resolution, re-coordination and timeline updates). (changes: `internal/http/operator_test.go`, `internal/demo/scenario_test.go`).

### Testing

- Added tests `TestOperatorApprovalEndpointsResolveRequestsIdempotently` and `TestRunDemoScenarioApprovalContinuesPipeline` to assert idempotent approval handling and visible pipeline continuation after approval. 
- Ran repository checks with `git diff --check` which passed. 
- Attempted a full `go test` across affected packages (`./internal/controlplane ./internal/http ./internal/demo ./internal/policy`) but the Go test run did not complete within the environment timeout so a complete test-suite pass could not be observed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c145522d20832485b81f5b2d44cc31)