### PR TITLE
Add operator demo console

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,10 +2,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"kalita/internal/app"
-	"kalita/internal/controlplane"
+	"kalita/internal/demo"
 	"kalita/internal/http"
 )
 
@@ -17,7 +18,17 @@ func main() {
 		panic(err)
 	}
 
+	operatorService := result.ControlPlane
+	if result.Config.DemoMode {
+		demoResult, err := demo.RunDemoScenario(context.Background())
+		if err != nil {
+			panic(err)
+		}
+		operatorService = demoResult.ControlPlane
+		fmt.Printf("Kalita demo mode enabled at /demo with seeded case %s and approval %s\n", demoResult.CaseID, demoResult.ApprovalRequestID)
+	}
+
 	// HTTP
 	fmt.Printf("Стартуем сервер Kalita на :%s...\n", result.Config.Port)
-	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.Coordinator, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.ProposalService, result.EmployeeDirectory, result.ControlPlane, result.EmployeeService)
+	http.RunServerWithServices(":"+result.Config.Port, result.Storage, result.CommandBus, result.CaseService, result.WorkService, result.Coordinator, result.PolicyService, result.ConstraintsService, result.ActionPlanService, result.ProposalService, result.EmployeeDirectory, operatorService, result.EmployeeService)
 }

--- a/config/config.json
+++ b/config/config.json
@@ -4,12 +4,11 @@
   "enumsDir": "reference/enums",
   "dbUrl": "postgresql://postgres:gogagoga123@192.168.1.4:9091/postgres",
   "autoMigrate": true,
-
   "blobDriver": "local",
   "filesRoot": "uploads",
-
   "s3Region": "",
   "s3Bucket": "",
   "s3Prefix": "",
-  "s3Endpoint": ""
+  "s3Endpoint": "",
+  "demoMode": false
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 type Config struct {
 	Port        string `json:"port"`
+	DemoMode    bool   `json:"demoMode"`
 	DSLDir      string `json:"dslDir"`
 	EnumsDir    string `json:"enumsDir"`
 	DBURL       string `json:"dbUrl"`
@@ -29,6 +30,7 @@ type Config struct {
 func def() Config {
 	return Config{
 		Port:        "8080",
+		DemoMode:    false,
 		DSLDir:      "dsl",
 		EnumsDir:    "reference/enums",
 		DBURL:       "",
@@ -88,6 +90,7 @@ func LoadWithPath(jsonPath string) Config {
 
 	// ENV overrides
 	cfg.Port = getenv("KALITA_PORT", cfg.Port)
+	cfg.DemoMode = getenvBool("KALITA_DEMO_MODE", cfg.DemoMode)
 	cfg.DSLDir = getenv("KALITA_DSL_DIR", cfg.DSLDir)
 	cfg.EnumsDir = getenv("KALITA_ENUMS_DIR", cfg.EnumsDir)
 	cfg.DBURL = getenv("KALITA_DB_URL", cfg.DBURL)
@@ -105,6 +108,7 @@ func LoadWithPath(jsonPath string) Config {
 	fs.SetOutput(os.Stderr)
 	configPath := fs.String("config", jsonPath, "Path to config JSON")
 	port := fs.String("port", cfg.Port, "HTTP port")
+	demoMode := fs.String("demo-mode", strconv.FormatBool(cfg.DemoMode), "Run deterministic demo console scenario (true/false)")
 	dsl := fs.String("dsl", cfg.DSLDir, "Path to DSL directory")
 	enums := fs.String("enums", cfg.EnumsDir, "Path to enums directory")
 	db := fs.String("db", cfg.DBURL, "Postgres URL (empty = in-memory)")
@@ -125,6 +129,9 @@ func LoadWithPath(jsonPath string) Config {
 	}
 
 	cfg.Port = strings.TrimSpace(*port)
+	cfg.DemoMode = strings.EqualFold(strings.TrimSpace(*demoMode), "true") ||
+		strings.EqualFold(strings.TrimSpace(*demoMode), "1") ||
+		strings.EqualFold(strings.TrimSpace(*demoMode), "yes")
 	cfg.DSLDir = strings.TrimSpace(*dsl)
 	cfg.EnumsDir = strings.TrimSpace(*enums)
 	cfg.DBURL = strings.TrimSpace(*db)

--- a/internal/http/demo.go
+++ b/internal/http/demo.go
@@ -1,0 +1,374 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"time"
+
+	"kalita/internal/controlplane"
+
+	"github.com/gin-gonic/gin"
+)
+
+type demoOperatorClient struct{ handler http.Handler }
+
+func newDemoOperatorClient(handler http.Handler) *demoOperatorClient {
+	return &demoOperatorClient{handler: handler}
+}
+
+func (c *demoOperatorClient) get(path string, out any) error {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	c.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		return fmt.Errorf("GET %s returned %d: %s", path, rec.Code, strings.TrimSpace(rec.Body.String()))
+	}
+	return json.Unmarshal(rec.Body.Bytes(), out)
+}
+
+func (c *demoOperatorClient) post(path string, out any) error {
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(nil))
+	rec := httptest.NewRecorder()
+	c.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		return fmt.Errorf("POST %s returned %d: %s", path, rec.Code, strings.TrimSpace(rec.Body.String()))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.Unmarshal(rec.Body.Bytes(), out)
+}
+
+type dashboardMetrics struct {
+	ActiveCases            int
+	BlockedCases           int
+	DeferredWorkItems      int
+	PendingApprovals       int
+	ExecutingSessions      int
+	FailedExecutions       int
+	ActorTrustDistribution []trustBucket
+}
+
+type trustBucket struct {
+	Level string
+	Count int
+}
+
+type caseListRow struct {
+	CaseID               string
+	Type                 string
+	Status               string
+	BlockingOrDeferred   string
+	PendingApprovalCount int
+}
+
+type caseDetailPage struct {
+	Case     controlplane.CaseOverview
+	WorkItem *controlplane.WorkItemOverview
+	Timeline []controlplane.TimelineEntry
+}
+
+func registerDemoRoutes(r *gin.Engine) {
+	client := newDemoOperatorClient(r)
+	r.GET("/demo", func(c *gin.Context) { renderDemoDashboard(c, client) })
+	r.GET("/demo/cases", func(c *gin.Context) { renderDemoCases(c, client) })
+	r.GET("/demo/cases/:id", func(c *gin.Context) { renderDemoCaseDetail(c, client, c.Param("id")) })
+	r.GET("/demo/approvals", func(c *gin.Context) { renderDemoApprovals(c, client) })
+	r.POST("/demo/approvals/:id/approve", func(c *gin.Context) { postDemoApprovalAction(c, client, c.Param("id"), "approve") })
+	r.POST("/demo/approvals/:id/reject", func(c *gin.Context) { postDemoApprovalAction(c, client, c.Param("id"), "reject") })
+}
+
+func renderDemoDashboard(c *gin.Context, client *demoOperatorClient) {
+	summary, workItems, actors, err := loadDashboardData(client)
+	if err != nil {
+		renderDemoError(c, err)
+		return
+	}
+	metrics := buildDashboardMetrics(summary, workItems, actors)
+	renderDemoHTML(c, "Kalita Demo Console", demoDashboardTemplate, map[string]any{"Metrics": metrics, "Now": time.Now().UTC()})
+}
+
+func renderDemoCases(c *gin.Context, client *demoOperatorClient) {
+	cases, workItems, approvals, err := loadCaseListData(client)
+	if err != nil {
+		renderDemoError(c, err)
+		return
+	}
+	rows := buildCaseRows(cases, workItems, approvals)
+	renderDemoHTML(c, "Cases · Kalita Demo Console", demoCasesTemplate, map[string]any{"Cases": rows})
+}
+
+func renderDemoCaseDetail(c *gin.Context, client *demoOperatorClient, caseID string) {
+	overview, workItems, timeline, err := loadCaseDetailData(client, caseID)
+	if err != nil {
+		renderDemoError(c, err)
+		return
+	}
+	page := caseDetailPage{Case: overview, Timeline: timeline}
+	for _, wi := range workItems {
+		if wi.CaseID == caseID {
+			copy := wi
+			page.WorkItem = &copy
+		}
+	}
+	renderDemoHTML(c, "Case Detail · Kalita Demo Console", demoCaseDetailTemplate, map[string]any{"Page": page})
+}
+
+func renderDemoApprovals(c *gin.Context, client *demoOperatorClient) {
+	var approvals []controlplane.ApprovalInboxItem
+	if err := client.get("/api/operator/approvals", &approvals); err != nil {
+		renderDemoError(c, err)
+		return
+	}
+	renderDemoHTML(c, "Approval Inbox · Kalita Demo Console", demoApprovalsTemplate, map[string]any{"Approvals": approvals})
+}
+
+func postDemoApprovalAction(c *gin.Context, client *demoOperatorClient, approvalID string, action string) {
+	var item controlplane.ApprovalInboxItem
+	if err := client.post(fmt.Sprintf("/api/operator/approvals/%s/%s", approvalID, action), &item); err != nil {
+		renderDemoError(c, err)
+		return
+	}
+	redirectTarget := c.PostForm("redirect")
+	if strings.TrimSpace(redirectTarget) == "" {
+		redirectTarget = "/demo/approvals"
+	}
+	c.Redirect(http.StatusSeeOther, redirectTarget)
+}
+
+func loadDashboardData(client *demoOperatorClient) (controlplane.Summary, []controlplane.WorkItemOverview, []controlplane.ActorOverview, error) {
+	var summary controlplane.Summary
+	var workItems []controlplane.WorkItemOverview
+	var actors []controlplane.ActorOverview
+	if err := client.get("/api/operator/summary", &summary); err != nil {
+		return controlplane.Summary{}, nil, nil, err
+	}
+	if err := client.get("/api/operator/work-items", &workItems); err != nil {
+		return controlplane.Summary{}, nil, nil, err
+	}
+	if err := client.get("/api/operator/actors", &actors); err != nil {
+		return controlplane.Summary{}, nil, nil, err
+	}
+	return summary, workItems, actors, nil
+}
+
+func loadCaseListData(client *demoOperatorClient) ([]controlplane.CaseOverview, []controlplane.WorkItemOverview, []controlplane.ApprovalInboxItem, error) {
+	var cases []controlplane.CaseOverview
+	var workItems []controlplane.WorkItemOverview
+	var approvals []controlplane.ApprovalInboxItem
+	if err := client.get("/api/operator/cases", &cases); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := client.get("/api/operator/work-items", &workItems); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := client.get("/api/operator/approvals", &approvals); err != nil {
+		return nil, nil, nil, err
+	}
+	return cases, workItems, approvals, nil
+}
+
+func loadCaseDetailData(client *demoOperatorClient, caseID string) (controlplane.CaseOverview, []controlplane.WorkItemOverview, []controlplane.TimelineEntry, error) {
+	var overview controlplane.CaseOverview
+	var workItems []controlplane.WorkItemOverview
+	var timeline []controlplane.TimelineEntry
+	if err := client.get(fmt.Sprintf("/api/operator/cases/%s", caseID), &overview); err != nil {
+		return controlplane.CaseOverview{}, nil, nil, err
+	}
+	if err := client.get("/api/operator/work-items", &workItems); err != nil {
+		return controlplane.CaseOverview{}, nil, nil, err
+	}
+	if err := client.get(fmt.Sprintf("/api/operator/cases/%s/timeline", caseID), &timeline); err != nil {
+		return controlplane.CaseOverview{}, nil, nil, err
+	}
+	return overview, workItems, timeline, nil
+}
+
+func buildDashboardMetrics(summary controlplane.Summary, workItems []controlplane.WorkItemOverview, actors []controlplane.ActorOverview) dashboardMetrics {
+	metrics := dashboardMetrics{ActiveCases: summary.OpenCaseCount, PendingApprovals: summary.ApprovalPendingCount}
+	trustCounts := map[string]int{}
+	blockedCaseIDs := map[string]struct{}{}
+	for _, wi := range workItems {
+		if wi.Coordination.DecisionType == "defer" {
+			metrics.DeferredWorkItems++
+		}
+		if wi.Coordination.DecisionType == "block" {
+			blockedCaseIDs[wi.CaseID] = struct{}{}
+		}
+		switch wi.Execution.Status {
+		case "running":
+			metrics.ExecutingSessions++
+		case "failed":
+			metrics.FailedExecutions++
+		}
+	}
+	metrics.BlockedCases = len(blockedCaseIDs)
+	for _, actor := range actors {
+		level := actor.TrustLevel
+		if strings.TrimSpace(level) == "" {
+			level = "unclassified"
+		}
+		trustCounts[level]++
+	}
+	for level, count := range trustCounts {
+		metrics.ActorTrustDistribution = append(metrics.ActorTrustDistribution, trustBucket{Level: level, Count: count})
+	}
+	sort.Slice(metrics.ActorTrustDistribution, func(i, j int) bool {
+		return metrics.ActorTrustDistribution[i].Level < metrics.ActorTrustDistribution[j].Level
+	})
+	return metrics
+}
+
+func buildCaseRows(cases []controlplane.CaseOverview, workItems []controlplane.WorkItemOverview, approvals []controlplane.ApprovalInboxItem) []caseListRow {
+	pendingByCase := map[string]int{}
+	for _, approval := range approvals {
+		pendingByCase[approval.CaseID]++
+	}
+	workByCase := map[string][]controlplane.WorkItemOverview{}
+	for _, wi := range workItems {
+		workByCase[wi.CaseID] = append(workByCase[wi.CaseID], wi)
+	}
+	rows := make([]caseListRow, 0, len(cases))
+	for _, item := range cases {
+		row := caseListRow{CaseID: item.CaseID, Type: item.Kind, Status: item.Status, PendingApprovalCount: pendingByCase[item.CaseID]}
+		reasons := make([]string, 0)
+		for _, wi := range workByCase[item.CaseID] {
+			if wi.Coordination.Reason != "" {
+				reasons = append(reasons, wi.Coordination.Reason)
+			}
+			if wi.PolicyApproval.Reason != "" {
+				reasons = append(reasons, wi.PolicyApproval.Reason)
+			}
+		}
+		row.BlockingOrDeferred = strings.Join(uniqueStrings(reasons), " | ")
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].CaseID < rows[j].CaseID })
+	return rows
+}
+
+func uniqueStrings(items []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func renderDemoError(c *gin.Context, err error) {
+	c.String(http.StatusInternalServerError, "demo console error: %v", err)
+}
+
+func renderDemoHTML(c *gin.Context, title string, body string, data map[string]any) {
+	funcs := template.FuncMap{
+		"fmtTime": func(t time.Time) string {
+			if t.IsZero() {
+				return "-"
+			}
+			return t.UTC().Format(time.RFC3339)
+		},
+		"fmtTimePtr": func(t *time.Time) string {
+			if t == nil || t.IsZero() {
+				return "-"
+			}
+			return t.UTC().Format(time.RFC3339)
+		},
+		"payload": func(m map[string]any) string {
+			if len(m) == 0 {
+				return "-"
+			}
+			b, _ := json.Marshal(m)
+			return string(b)
+		},
+	}
+	tmpl := template.Must(template.New("page").Funcs(funcs).Parse(demoLayoutTemplate + body))
+	if data == nil {
+		data = map[string]any{}
+	}
+	data["Title"] = title
+	c.Header("Content-Type", "text/html; charset=utf-8")
+	_ = tmpl.ExecuteTemplate(c.Writer, "layout", data)
+}
+
+const demoLayoutTemplate = `{{define "layout"}}<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>{{.Title}}</title>
+<style>
+body{font-family:Arial,sans-serif;margin:24px;color:#222}nav a{margin-right:12px}table{border-collapse:collapse;width:100%;margin-top:12px}th,td{border:1px solid #ccc;padding:8px;vertical-align:top;text-align:left} .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin:16px 0}.card{border:1px solid #ccc;padding:12px}.muted{color:#666}.pill{display:inline-block;border:1px solid #999;border-radius:999px;padding:2px 8px;font-size:12px}.actions form{display:inline-block;margin-right:8px}pre{white-space:pre-wrap;word-break:break-word;margin:0}
+</style></head><body>
+<h1>{{.Title}}</h1>
+<nav><a href="/demo">Dashboard</a><a href="/demo/cases">Cases</a><a href="/demo/approvals">Approval Inbox</a></nav>
+{{template "body" .}}
+</body></html>{{end}}`
+
+const demoDashboardTemplate = `{{define "body"}}
+<div class="cards">
+  <div class="card"><strong>Active cases</strong><div>{{.Metrics.ActiveCases}}</div></div>
+  <div class="card"><strong>Blocked cases</strong><div>{{.Metrics.BlockedCases}}</div></div>
+  <div class="card"><strong>Deferred work items</strong><div>{{.Metrics.DeferredWorkItems}}</div></div>
+  <div class="card"><strong>Pending approvals</strong><div>{{.Metrics.PendingApprovals}}</div></div>
+  <div class="card"><strong>Executing sessions</strong><div>{{.Metrics.ExecutingSessions}}</div></div>
+  <div class="card"><strong>Failed executions</strong><div>{{.Metrics.FailedExecutions}}</div></div>
+</div>
+<h2>Actor trust distribution</h2>
+<table><thead><tr><th>Trust level</th><th>Actors</th></tr></thead><tbody>
+{{range .Metrics.ActorTrustDistribution}}<tr><td>{{.Level}}</td><td>{{.Count}}</td></tr>{{else}}<tr><td colspan="2">No actors found.</td></tr>{{end}}
+</tbody></table>
+<p class="muted">Refresh the page after approving work to watch the timeline continue.</p>
+{{end}}`
+
+const demoCasesTemplate = `{{define "body"}}
+<table><thead><tr><th>Case ID</th><th>Type</th><th>Status</th><th>Blocking / deferred reason</th><th>Pending approval</th></tr></thead><tbody>
+{{range .Cases}}<tr><td><a href="/demo/cases/{{.CaseID}}">{{.CaseID}}</a></td><td>{{.Type}}</td><td>{{.Status}}</td><td>{{if .BlockingOrDeferred}}{{.BlockingOrDeferred}}{{else}}-{{end}}</td><td>{{if gt .PendingApprovalCount 0}}<span class="pill">pending ({{.PendingApprovalCount}})</span>{{else}}-{{end}}</td></tr>{{else}}<tr><td colspan="5">No cases found.</td></tr>{{end}}
+</tbody></table>
+{{end}}`
+
+const demoCaseDetailTemplate = `{{define "body"}}
+<h2>Case header</h2>
+<table><tbody>
+<tr><th>Case ID</th><td>{{.Page.Case.CaseID}}</td></tr>
+<tr><th>Type</th><td>{{.Page.Case.Kind}}</td></tr>
+<tr><th>Status</th><td>{{.Page.Case.Status}}</td></tr>
+<tr><th>Correlation ID</th><td>{{.Page.Case.CorrelationID}}</td></tr>
+<tr><th>Subject</th><td>{{.Page.Case.SubjectRef}}</td></tr>
+</tbody></table>
+{{if .Page.WorkItem}}
+<h2>Latest work item</h2>
+<table><tbody>
+<tr><th>Work item</th><td>{{.Page.WorkItem.WorkItemID}}</td></tr>
+<tr><th>Status</th><td>{{.Page.WorkItem.Status}}</td></tr>
+<tr><th>Queue</th><td>{{.Page.WorkItem.QueueID}}</td></tr>
+<tr><th>Latest coordination</th><td>{{.Page.WorkItem.Coordination.DecisionType}} {{if .Page.WorkItem.Coordination.Reason}}— {{.Page.WorkItem.Coordination.Reason}}{{end}}</td></tr>
+<tr><th>Latest policy</th><td>{{.Page.WorkItem.PolicyApproval.Outcome}} {{if .Page.WorkItem.PolicyApproval.Reason}}— {{.Page.WorkItem.PolicyApproval.Reason}}{{end}}</td></tr>
+<tr><th>Latest approval state</th><td>{{if .Page.WorkItem.PolicyApproval.ApprovalRequestID}}{{.Page.WorkItem.PolicyApproval.ApprovalRequestStatus}} ({{.Page.WorkItem.PolicyApproval.ApprovalRequestID}}){{else}}-{{end}}</td></tr>
+<tr><th>Latest execution state</th><td>{{if .Page.WorkItem.Execution.SessionID}}{{.Page.WorkItem.Execution.Status}} ({{.Page.WorkItem.Execution.SessionID}}){{else}}not started{{end}}</td></tr>
+</tbody></table>
+{{if and .Page.WorkItem.PolicyApproval.ApprovalRequestID (eq .Page.WorkItem.PolicyApproval.ApprovalRequestStatus "pending")}}
+<div class="actions"><form method="post" action="/demo/approvals/{{.Page.WorkItem.PolicyApproval.ApprovalRequestID}}/approve"><input type="hidden" name="redirect" value="/demo/cases/{{.Page.Case.CaseID}}"><button type="submit">Approve</button></form><form method="post" action="/demo/approvals/{{.Page.WorkItem.PolicyApproval.ApprovalRequestID}}/reject"><input type="hidden" name="redirect" value="/demo/cases/{{.Page.Case.CaseID}}"><button type="submit">Reject</button></form></div>
+{{end}}
+{{end}}
+<h2>Timeline</h2>
+<table><thead><tr><th>Occurred at</th><th>Step</th><th>Status</th><th>Payload</th></tr></thead><tbody>
+{{range .Page.Timeline}}<tr><td>{{fmtTime .OccurredAt}}</td><td>{{.Step}}</td><td>{{if .Status}}{{.Status}}{{else}}-{{end}}</td><td><pre>{{payload .Payload}}</pre></td></tr>{{else}}<tr><td colspan="4">No timeline entries found.</td></tr>{{end}}
+</tbody></table>
+{{end}}`
+
+const demoApprovalsTemplate = `{{define "body"}}
+<table><thead><tr><th>Approval</th><th>Case</th><th>Work item</th><th>Requested role</th><th>Reason</th><th>Created</th><th>Action</th></tr></thead><tbody>
+{{range .Approvals}}<tr><td>{{.ApprovalRequestID}}</td><td><a href="/demo/cases/{{.CaseID}}">{{.CaseID}}</a></td><td>{{.WorkItemID}}</td><td>{{if .RequestedFromRole}}{{.RequestedFromRole}}{{else}}-{{end}}</td><td>{{if .PolicyApproval.Reason}}{{.PolicyApproval.Reason}}{{else}}{{.Coordination.Reason}}{{end}}</td><td>{{fmtTime .CreatedAt}}</td><td class="actions"><form method="post" action="/demo/approvals/{{.ApprovalRequestID}}/approve"><button type="submit">Approve</button></form><form method="post" action="/demo/approvals/{{.ApprovalRequestID}}/reject"><button type="submit">Reject</button></form></td></tr>{{else}}<tr><td colspan="7">No pending approvals.</td></tr>{{end}}
+</tbody></table>
+{{end}}`

--- a/internal/http/demo_test.go
+++ b/internal/http/demo_test.go
@@ -1,0 +1,94 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"kalita/internal/demo"
+
+	"github.com/gin-gonic/gin"
+)
+
+func demoRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	result, err := demo.RunDemoScenario(t.Context())
+	if err != nil {
+		t.Fatalf("RunDemoScenario error = %v", err)
+	}
+	r := gin.New()
+	api := r.Group("/api")
+	registerOperatorRoutes(api, result.ControlPlane)
+	registerDemoRoutes(r)
+	return r
+}
+
+func TestDemoDashboardRendersSummaryData(t *testing.T) {
+	t.Parallel()
+	r := demoRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/demo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /demo status=%d body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{"Active cases", ">1<", "Deferred work items", "Pending approvals", "low", "2"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestDemoCaseDetailRendersTimelineData(t *testing.T) {
+	t.Parallel()
+	r := demoRouter(t)
+
+	path := fmt.Sprintf("/demo/cases/%s", demo.DemoCaseID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET %s status=%d body=%s", path, w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{"Case header", demo.DemoCaseID, "approval_requested", "coordination_decided", "Approve"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestDemoApprovalActionUsesExistingApprovalFlow(t *testing.T) {
+	t.Parallel()
+	r := demoRouter(t)
+
+	path := fmt.Sprintf("/demo/approvals/%s/approve", demo.DemoApprovalRequestID)
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader("redirect=/demo/cases/"+demo.DemoCaseID))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("POST %s status=%d body=%s", path, w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Location"); got != "/demo/cases/"+demo.DemoCaseID {
+		t.Fatalf("redirect = %q", got)
+	}
+
+	follow := httptest.NewRequest(http.MethodGet, "/demo/cases/"+demo.DemoCaseID, nil)
+	followW := httptest.NewRecorder()
+	r.ServeHTTP(followW, follow)
+	if followW.Code != http.StatusOK {
+		t.Fatalf("GET case detail status=%d body=%s", followW.Code, followW.Body.String())
+	}
+	body := followW.Body.String()
+	for _, want := range []string{"approval_granted", "approved"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -34,6 +34,7 @@ func RunServerWithServices(addr string, storage *runtime.Storage, commandBus com
 	apiGroup := r.Group("/api")
 	{
 		registerOperatorRoutes(apiGroup, operatorService)
+		registerDemoRoutes(r)
 
 		//r.GET("/api/meta", MetaListHandler(storage))
 		//r.GET("/api/meta/:module/:entity", MetaEntityHandler(storage))


### PR DESCRIPTION
### Motivation
- Provide a minimal, deterministic investor/operator demo surface to visualize and interact with the existing operator control plane (summary, cases, timeline, approvals) without moving business logic into the UI.
- Keep the demo thin and safe by wiring only to existing `/api/operator/...` endpoints and limiting write powers to approve/reject only.

### Description
- Add a small server-rendered demo console mounted at `/demo` with Dashboard, Case List, Case Detail, and Approval Inbox pages that call existing operator APIs for data and actions (`/api/operator/summary`, `/api/operator/cases`, `/api/operator/cases/:id/timeline`, `/api/operator/approvals`, and approval `POST` endpoints). (new file `internal/http/demo.go`)
- Wire the demo routes into the main router so they ship with the server (`registerDemoRoutes` registered during `RunServerWithServices`). (`internal/http/router.go`)
- Add deterministic demo-mode bootstrapping that seeds the Phase 4 demo scenario and swaps the control plane service when `demoMode` is enabled via config (`config/config.json`), env (`KALITA_DEMO_MODE`), or flag (`--demo-mode`), implemented in server startup. (`internal/config/config.go`, `cmd/server/main.go`)
- Add focused tests that exercise demo page rendering and confirm approval actions continue the pipeline using the existing approval flow (new file `internal/http/demo_test.go`).
- No runtime/business logic was duplicated or moved into UI handlers; demo surface only proxies reads/writes to existing control-plane endpoints.

### Testing
- Ran `go test ./internal/http -run 'TestDemo|TestOperator' -count=1` and the tests passed. 
- Ran `go test ./internal/demo -count=1` and the demo scenario tests passed. 
- Ran `go test ./cmd/server -count=1` (no test files present), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c14ac9a98883249117366706dc5c9a)