### PR TITLE
Add file-backed persistence, snapshots and replay; bootstrap wiring

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 
 	"kalita/internal/actionplan"
@@ -18,6 +19,7 @@ import (
 	"kalita/internal/eventcore"
 	"kalita/internal/executioncontrol"
 	"kalita/internal/executionruntime"
+	"kalita/internal/persistence"
 	"kalita/internal/policy"
 	"kalita/internal/postgres"
 	"kalita/internal/profile"
@@ -73,14 +75,12 @@ type BootstrapResult struct {
 	Config             config.Config
 }
 
-// Bootstrap initializes the application with all required components
 func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	cfg := config.LoadWithPath(cfgPath)
 
-	fmt.Printf("Kalita starting on :%s (db=%s, autoMigrate=%v, blob=%s)\n",
-		cfg.Port, tern(cfg.DBURL != "", "pg", "memory"), cfg.AutoMigrate, cfg.BlobDriver)
+	fmt.Printf("Kalita starting on :%s (db=%s, autoMigrate=%v, blob=%s, persistence=%v)\n",
+		cfg.Port, tern(cfg.DBURL != "", "pg", "memory"), cfg.AutoMigrate, cfg.BlobDriver, cfg.PersistenceEnabled)
 
-	// DSL
 	entityMap, err := schema.LoadAllEntities(cfg.DSLDir)
 	if err != nil {
 		return nil, fmt.Errorf("ошибка загрузки DSL из %q: %w", cfg.DSLDir, err)
@@ -91,7 +91,6 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		entities = append(entities, e)
 	}
 
-	// --- PostgreSQL: подключение + (опц.) add-only DDL
 	if cfg.DBURL != "" {
 		db, err := postgres.Open(cfg.DBURL)
 		if err != nil {
@@ -99,7 +98,6 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		}
 		defer db.Close()
 		log.Printf("PG connected")
-
 		if cfg.AutoMigrate {
 			ddl, err := postgres.GenerateDDL(entityMap)
 			if err != nil {
@@ -112,43 +110,80 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 		}
 	}
 
-	// Enums
 	enumCatalog, err := catalog.LoadEnumCatalog(cfg.EnumsDir)
 	if err != nil {
 		return nil, fmt.Errorf("ошибка загрузки enum-справочников из %q: %w", cfg.EnumsDir, err)
 	}
 	fmt.Printf("Загружено enum-справочников: %d\n", len(enumCatalog))
 
-	// In-memory API (данные пока в памяти; PG — только схема)
 	st := runtime.NewStorage(entities, enumCatalog)
-	eventLog := eventcore.NewInMemoryEventLog()
 	clock := eventcore.RealClock{}
 	ids := eventcore.NewULIDGenerator()
+	planRepo := workplan.NewInMemoryPlanRepository()
+	baseEventLog := eventcore.NewInMemoryEventLog()
+	baseCaseRepo := caseruntime.NewInMemoryCaseRepository()
+	baseQueueRepo := workplan.NewInMemoryQueueRepository()
+	baseCoordinationRepo := workplan.NewInMemoryCoordinationRepository()
+	basePolicyRepo := policy.NewInMemoryRepository()
+	baseProposalRepo := proposal.NewInMemoryRepository()
+	baseExecutionRepo := executionruntime.NewInMemoryExecutionRepository()
+	baseExecutionWAL := executionruntime.NewInMemoryWAL()
+	baseEmployeeDirectory := employee.NewInMemoryDirectory()
+	baseAssignmentRepo := employee.NewInMemoryAssignmentRepository()
+	baseTrustRepo := trust.NewInMemoryRepository()
+	baseCapabilityRepo := capability.NewInMemoryRepository()
+	baseProfileRepo := profile.NewInMemoryRepository()
+
+	var persistMgr *persistence.Manager
+	if cfg.PersistenceEnabled {
+		persistDir := cfg.PersistenceDir
+		if strings.TrimSpace(persistDir) == "" {
+			persistDir = filepath.Join(filepath.Dir(cfgPath), ".kalita-persistence")
+		}
+		persistMgr = persistence.NewManager(persistence.NewFileEventStore(persistDir), persistence.NewFileSnapshotStore(persistDir), cfg.SnapshotEvery)
+	}
+
+	eventLog := persistence.WrapEventLog(baseEventLog, persistMgr)
+	caseRepo := persistence.WrapCaseRepository(baseCaseRepo, persistMgr)
+	queueRepo := persistence.WrapQueueRepository(baseQueueRepo, persistMgr)
+	coordinationRepo := persistence.WrapCoordinationRepository(baseCoordinationRepo, persistMgr)
+	policyRepo := persistence.WrapPolicyRepository(basePolicyRepo, persistMgr)
+	proposalRepo := persistence.WrapProposalRepository(baseProposalRepo, persistMgr)
+	executionRepo := persistence.WrapExecutionRepository(baseExecutionRepo, persistMgr)
+	executionWAL := persistence.WrapWAL(baseExecutionWAL, persistMgr)
+	employeeDirectory := persistence.WrapDirectory(baseEmployeeDirectory, persistMgr)
+	assignmentRepo := persistence.WrapAssignments(baseAssignmentRepo, persistMgr)
+	trustRepo := persistence.WrapTrustRepository(baseTrustRepo, persistMgr)
+	capabilityRepo := persistence.WrapCapabilityRepository(baseCapabilityRepo, persistMgr)
+	profileRepo := persistence.WrapProfileRepository(baseProfileRepo, persistMgr)
+
+	if persistMgr != nil && persistMgr.Enabled() {
+		persistMgr.BindCollector(&persistence.StateCollector{
+			Cases: baseCaseRepo, Queues: baseQueueRepo, Coordinations: baseCoordinationRepo, Policies: basePolicyRepo,
+			Proposals: baseProposalRepo, Employees: baseEmployeeDirectory, Assignments: baseAssignmentRepo,
+			Trust: baseTrustRepo, Profiles: baseProfileRepo, Capabilities: baseCapabilityRepo,
+			Executions: baseExecutionRepo, WAL: baseExecutionWAL, EventLog: baseEventLog,
+		})
+		if err := persistMgr.Restore(context.Background(), &persistence.Restorer{
+			Cases: baseCaseRepo, Queues: baseQueueRepo, Coordinations: baseCoordinationRepo, Policies: basePolicyRepo,
+			Proposals: baseProposalRepo, Employees: baseEmployeeDirectory, Assignments: baseAssignmentRepo,
+			Trust: baseTrustRepo, Profiles: baseProfileRepo, Capabilities: baseCapabilityRepo,
+			Executions: baseExecutionRepo, WAL: baseExecutionWAL, EventLog: baseEventLog,
+		}); err != nil {
+			return nil, fmt.Errorf("restore persisted runtime state: %w", err)
+		}
+	}
+
 	commandBus := command.NewService(eventLog, command.PassThroughAdmissionPolicy{}, clock, ids)
-	caseRepo := caseruntime.NewInMemoryCaseRepository()
 	caseResolver := caseruntime.NewResolver(caseRepo, clock, ids)
 	caseService := caseruntime.NewService(caseResolver, eventLog, clock, ids)
-	queueRepo := workplan.NewInMemoryQueueRepository()
-	planRepo := workplan.NewInMemoryPlanRepository()
-	defaultQueue := workplan.WorkQueue{
-		ID:               "default-intake",
-		Name:             "Default Intake",
-		Department:       "operations",
-		Purpose:          "Default operational intake for resolved cases",
-		AllowedCaseKinds: []string{"workflow.action"},
-	}
-	if err := queueRepo.SaveQueue(context.Background(), defaultQueue); err != nil {
-		return nil, fmt.Errorf("seed default queue: %w", err)
-	}
-	assignmentRouter := workplan.NewRouter(queueRepo, defaultQueue.ID)
-	planner := workplan.NewPlanner(planRepo, eventLog, clock, ids)
-	coordinationRepo := workplan.NewInMemoryCoordinationRepository()
-	policyRepo := policy.NewInMemoryRepository()
 	policyEvaluator := policy.NewEvaluator()
 	policyService := policy.NewService(policyRepo, policyEvaluator, eventLog, clock, ids)
 	constraintsRepo := executioncontrol.NewInMemoryConstraintsRepository()
 	constraintsPlanner := executioncontrol.NewPlanner()
 	constraintsService := executioncontrol.NewService(constraintsRepo, constraintsPlanner, eventLog, clock, ids)
+	trustScorer := trust.NewDeterministicScorer(clock.Now)
+	trustService := trust.NewService(trustRepo, trustScorer)
 	actionRegistry := actionplan.NewRegistry()
 	actionRegistry.Register(actionplan.ActionDefinition{
 		Type:          "legacy_workflow_action",
@@ -170,113 +205,94 @@ func Bootstrap(cfgPath string) (*BootstrapResult, error) {
 	actionCompiler := actionplan.NewCompiler(actionRegistry, clock, ids)
 	actionValidator := actionplan.NewValidator(actionRegistry)
 	actionPlanService := actionplan.NewService(actionCompiler, actionValidator, eventLog, clock, ids)
-	proposalRepo := proposal.NewInMemoryRepository()
 	proposalValidator := proposal.NewValidator()
 	proposalCompiler := proposal.NewCompilerAdapter(actionPlanService)
 	proposalService := proposal.NewService(proposalRepo, proposalValidator, proposalCompiler, eventLog, clock, ids)
-	executionRepo := executionruntime.NewInMemoryExecutionRepository()
-	executionWAL := executionruntime.NewInMemoryWAL()
 	actionExecutor := executionruntime.NewStubExecutor()
 	executionRunner := executionruntime.NewRunner(executionRepo, executionWAL, actionExecutor, eventLog, clock, ids, trustService)
 	executionRuntime := executionruntime.NewService(executionRunner)
-	employeeDirectory := employee.NewInMemoryDirectory()
-	assignmentRepo := employee.NewInMemoryAssignmentRepository()
-	trustRepo := trust.NewInMemoryRepository()
-	trustScorer := trust.NewDeterministicScorer(clock.Now)
-	trustService := trust.NewService(trustRepo, trustScorer)
-	capabilityRepo := capability.NewInMemoryRepository()
-	profileRepo := profile.NewInMemoryRepository()
-	defaultEmployee := employee.DigitalEmployee{
-		ID:                  "employee-legacy-operator",
-		Code:                "legacy_operator_default",
-		Role:                "legacy_operator",
-		Enabled:             true,
-		QueueMemberships:    []string{defaultQueue.ID},
-		AllowedActionTypes:  []actionplan.ActionType{"legacy_workflow_action"},
-		AllowedCommandTypes: []string{"workflow.action"},
-		PolicyProfile:       "default",
-		ExecutionProfile:    "default",
-		CreatedAt:           clock.Now(),
-		UpdatedAt:           clock.Now(),
+
+	defaultQueue := workplan.WorkQueue{ID: "default-intake", Name: "Default Intake", Department: "operations", Purpose: "Default operational intake for resolved cases", AllowedCaseKinds: []string{"workflow.action"}}
+	if _, ok, err := baseQueueRepo.GetQueue(context.Background(), defaultQueue.ID); err != nil {
+		return nil, fmt.Errorf("load default queue: %w", err)
+	} else if !ok {
+		if err := queueRepo.SaveQueue(context.Background(), defaultQueue); err != nil {
+			return nil, fmt.Errorf("seed default queue: %w", err)
+		}
 	}
-	if err := employeeDirectory.SaveEmployee(context.Background(), defaultEmployee); err != nil {
-		return nil, fmt.Errorf("seed default employee: %w", err)
-	}
-	if err := capabilityRepo.SaveCapability(context.Background(), capability.Capability{ID: "cap-legacy-workflow", Code: "workflow.execute", Type: capability.CapabilitySkill, Level: 1}); err != nil {
-		return nil, fmt.Errorf("seed workflow capability: %w", err)
-	}
-	if err := capabilityRepo.AssignCapability(context.Background(), capability.ActorCapability{ActorID: defaultEmployee.ID, CapabilityID: "cap-legacy-workflow", Level: 1}); err != nil {
-		return nil, fmt.Errorf("assign workflow capability: %w", err)
-	}
-	if err := profileRepo.SaveRequirement(context.Background(), profile.CapabilityRequirement{ActionType: "legacy_workflow_action", CapabilityCodes: []string{"workflow.execute"}, MinimumLevel: 1}); err != nil {
-		return nil, fmt.Errorf("seed capability requirement: %w", err)
-	}
-	if err := profileRepo.SaveProfile(context.Background(), profile.CompetencyProfile{ID: "profile-legacy-operator", ActorID: defaultEmployee.ID, Name: "Legacy Operator", MaxComplexity: 10, PreferredWorkKinds: []string{"workflow.action"}}); err != nil {
-		return nil, fmt.Errorf("seed competency profile: %w", err)
-	}
+	assignmentRouter := workplan.NewRouter(queueRepo, defaultQueue.ID)
+	planner := workplan.NewPlanner(planRepo, eventLog, clock, ids)
 	coordinator := workplan.NewCoordinator(coordinationRepo, eventLog, clock, ids)
 	workService := workplan.NewService(queueRepo, assignmentRouter, planner, coordinator, eventLog, clock, ids)
+
+	defaultEmployee := employee.DigitalEmployee{ID: "employee-legacy-operator", Code: "legacy_operator_default", Role: "legacy_operator", Enabled: true, QueueMemberships: []string{defaultQueue.ID}, AllowedActionTypes: []actionplan.ActionType{"legacy_workflow_action"}, AllowedCommandTypes: []string{"workflow.action"}, PolicyProfile: "default", ExecutionProfile: "default", CreatedAt: clock.Now(), UpdatedAt: clock.Now()}
+	if _, ok, err := baseEmployeeDirectory.GetEmployee(context.Background(), defaultEmployee.ID); err != nil {
+		return nil, fmt.Errorf("load default employee: %w", err)
+	} else if !ok {
+		if err := employeeDirectory.SaveEmployee(context.Background(), defaultEmployee); err != nil {
+			return nil, fmt.Errorf("seed default employee: %w", err)
+		}
+	}
+	if _, ok, err := baseCapabilityRepo.GetCapability(context.Background(), "cap-legacy-workflow"); err != nil {
+		return nil, fmt.Errorf("load workflow capability: %w", err)
+	} else if !ok {
+		if err := capabilityRepo.SaveCapability(context.Background(), capability.Capability{ID: "cap-legacy-workflow", Code: "workflow.execute", Type: capability.CapabilitySkill, Level: 1}); err != nil {
+			return nil, fmt.Errorf("seed workflow capability: %w", err)
+		}
+	}
+	actorCapabilities, err := baseCapabilityRepo.ListByActor(context.Background(), defaultEmployee.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load actor capabilities: %w", err)
+	}
+	if len(actorCapabilities) == 0 {
+		if err := capabilityRepo.AssignCapability(context.Background(), capability.ActorCapability{ActorID: defaultEmployee.ID, CapabilityID: "cap-legacy-workflow", Level: 1}); err != nil {
+			return nil, fmt.Errorf("assign workflow capability: %w", err)
+		}
+	}
+	if _, ok, err := baseProfileRepo.GetProfileByActor(context.Background(), defaultEmployee.ID); err != nil {
+		return nil, fmt.Errorf("load competency profile: %w", err)
+	} else if !ok {
+		if err := profileRepo.SaveProfile(context.Background(), profile.CompetencyProfile{ID: "profile-legacy-operator", ActorID: defaultEmployee.ID, Name: "Legacy Operator", MaxComplexity: 10, PreferredWorkKinds: []string{"workflow.action"}}); err != nil {
+			return nil, fmt.Errorf("seed competency profile: %w", err)
+		}
+	}
+	requirements, err := baseProfileRepo.ListRequirements(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("load capability requirements: %w", err)
+	}
+	if len(requirements) == 0 {
+		if err := profileRepo.SaveRequirement(context.Background(), profile.CapabilityRequirement{ActionType: "legacy_workflow_action", CapabilityCodes: []string{"workflow.execute"}, MinimumLevel: 1}); err != nil {
+			return nil, fmt.Errorf("seed capability requirement: %w", err)
+		}
+	}
+
 	employeeSelector := employee.NewSelectorWithMatcher(employeeDirectory, profile.NewMatcher(profileRepo, profileRepo, capabilityRepo, capabilityRepo, trustService))
 	employeeService := employee.NewService(assignmentRepo, employeeSelector, executionRuntime, eventLog, clock, ids, trustService)
-	controlPlaneService := controlplane.NewService(caseRepo, queueRepo, coordinationRepo, policyRepo, proposalRepo, employeeDirectory, trustRepo, profileRepo, capabilityRepo, executionRepo, executionWAL, eventLog)
+	controlPlaneService := controlplane.NewService(caseRepo, queueRepo, coordinationRepo, policyRepo, proposalRepo, employeeDirectory, trustRepo, profileRepo, baseCapabilityRepo, executionRepo, executionWAL, eventLog, coordinator)
+	if persistMgr != nil && persistMgr.Enabled() {
+		if err := persistMgr.SaveSnapshot(context.Background()); err != nil {
+			return nil, fmt.Errorf("save runtime snapshot: %w", err)
+		}
+	}
+
 	if strings.EqualFold(cfg.BlobDriver, "s3") {
 		log.Printf("[warn] blob=s3 ещё не подключён — используем локальное хранилище (root=%q)\n", cfg.FilesRoot)
 	}
 	st.Blob = &blob.LocalBlobStore{Root: cfg.FilesRoot}
 
-	return &BootstrapResult{
-		Storage:            st,
-		EventLog:           eventLog,
-		CommandBus:         commandBus,
-		CaseRepo:           caseRepo,
-		CaseResolver:       caseResolver,
-		CaseService:        caseService,
-		QueueRepo:          queueRepo,
-		PlanRepo:           planRepo,
-		CoordinationRepo:   coordinationRepo,
-		AssignmentRouter:   assignmentRouter,
-		Planner:            planner,
-		Coordinator:        coordinator,
-		WorkService:        workService,
-		PolicyRepo:         policyRepo,
-		PolicyEvaluator:    policyEvaluator,
-		PolicyService:      policyService,
-		ConstraintsRepo:    constraintsRepo,
-		ConstraintsPlanner: constraintsPlanner,
-		ConstraintsService: constraintsService,
-		ActionRegistry:     actionRegistry,
-		ActionCompiler:     actionCompiler,
-		ActionValidator:    actionValidator,
-		ActionPlanService:  actionPlanService,
-		ProposalRepo:       proposalRepo,
-		ProposalValidator:  proposalValidator,
-		ProposalCompiler:   proposalCompiler,
-		ProposalService:    proposalService,
-		EmployeeDirectory:  employeeDirectory,
-		AssignmentRepo:     assignmentRepo,
-		EmployeeSelector:   employeeSelector,
-		EmployeeService:    employeeService,
-		TrustRepo:          trustRepo,
-		TrustScorer:        trustScorer,
-		TrustService:       trustService,
-		ExecutionRepo:      executionRepo,
-		ExecutionWAL:       executionWAL,
-		ActionExecutor:     actionExecutor,
-		ExecutionRunner:    executionRunner,
-		ExecutionRuntime:   executionRuntime,
-		ControlPlane:       controlPlaneService,
-		Config:             cfg,
-	}, nil
+	return &BootstrapResult{Storage: st, EventLog: eventLog, CommandBus: commandBus, CaseRepo: caseRepo, CaseResolver: caseResolver, CaseService: caseService, QueueRepo: queueRepo, PlanRepo: planRepo, CoordinationRepo: coordinationRepo, AssignmentRouter: assignmentRouter, Planner: planner, Coordinator: coordinator, WorkService: workService, PolicyRepo: policyRepo, PolicyEvaluator: policyEvaluator, PolicyService: policyService, ConstraintsRepo: constraintsRepo, ConstraintsPlanner: constraintsPlanner, ConstraintsService: constraintsService, ActionRegistry: actionRegistry, ActionCompiler: actionCompiler, ActionValidator: actionValidator, ActionPlanService: actionPlanService, ProposalRepo: proposalRepo, ProposalValidator: proposalValidator, ProposalCompiler: proposalCompiler, ProposalService: proposalService, EmployeeDirectory: employeeDirectory, AssignmentRepo: assignmentRepo, EmployeeSelector: employeeSelector, EmployeeService: employeeService, TrustRepo: trustRepo, TrustScorer: trustScorer, TrustService: trustService, ExecutionRepo: executionRepo, ExecutionWAL: executionWAL, ActionExecutor: actionExecutor, ExecutionRunner: executionRunner, ExecutionRuntime: executionRuntime, ControlPlane: controlPlaneService, Config: cfg}, nil
 }
 
-func tern[T any](cond bool, a, b T) T {
-	if cond {
-		return a
+func tern(condition bool, yes string, no string) string {
+	if condition {
+		return yes
 	}
-	return b
+	return no
 }
 
 func stringValue(v any) string {
-	s, _ := v.(string)
-	return s
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
 }

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
+	"time"
 
 	"kalita/internal/actionplan"
+	"kalita/internal/caseruntime"
+	"kalita/internal/eventcore"
+	"kalita/internal/policy"
 	"kalita/internal/trust"
 	"kalita/internal/workplan"
 )
@@ -193,5 +198,104 @@ func TestBootstrapExposesTrustService(t *testing.T) {
 	}
 	if !ok || got != profile {
 		t.Fatalf("GetTrustProfile = %#v, %v", got, ok)
+	}
+}
+
+func TestBootstrapRestoresPersistentStateAcrossRestart(t *testing.T) {
+	t.Parallel()
+	persistDir := filepath.Join(t.TempDir(), "persist")
+	cfg := `{
+  "port": "8080",
+  "dslDir": "../../dsl",
+  "enumsDir": "../../reference/enums",
+  "dbUrl": "",
+  "autoMigrate": false,
+  "persistenceEnabled": true,
+  "persistenceDir": "` + persistDir + `",
+  "snapshotEvery": 1,
+  "blobDriver": "local",
+  "filesRoot": "../../uploads"
+}`
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	first, err := Bootstrap(cfgPath)
+	if err != nil {
+		t.Fatalf("Bootstrap(first) error = %v", err)
+	}
+	now := time.Date(2026, 3, 23, 12, 0, 0, 0, time.UTC)
+	caseRecord := caseruntime.Case{ID: "case-persist-1", Kind: "missed_container_pickup_review", Status: string(caseruntime.CaseOpen), Title: "Persistent case", SubjectRef: "route:R-42/container:SITE-42", CorrelationID: "corr-persist-1", OpenedAt: now, UpdatedAt: now, OwnerQueueID: "default-intake"}
+	if err := first.CaseRepo.Save(context.Background(), caseRecord); err != nil {
+		t.Fatalf("CaseRepo.Save error = %v", err)
+	}
+	workItem := workplan.WorkItem{ID: "work-persist-1", CaseID: caseRecord.ID, QueueID: "default-intake", Type: "missed_container_pickup_review", Status: string(workplan.WorkItemOpen), Priority: "high", Reason: "persist me", CreatedAt: now, UpdatedAt: now}
+	if err := first.QueueRepo.SaveWorkItem(context.Background(), workItem); err != nil {
+		t.Fatalf("SaveWorkItem error = %v", err)
+	}
+	decision := workplan.CoordinationDecision{ID: "coord-persist-1", WorkItemID: workItem.ID, CaseID: caseRecord.ID, QueueID: "default-intake", DecisionType: workplan.CoordinationDefer, Reason: "need approval", Priority: workplan.CoordinationPriorityDefer, CreatedAt: now}
+	if err := first.CoordinationRepo.SaveDecision(context.Background(), decision); err != nil {
+		t.Fatalf("SaveDecision error = %v", err)
+	}
+	policyDecision := policy.PolicyDecision{ID: "policy-persist-1", CoordinationDecisionID: decision.ID, CaseID: caseRecord.ID, WorkItemID: workItem.ID, QueueID: "default-intake", Outcome: policy.PolicyRequireApproval, Reason: "trust low", CreatedAt: now.Add(time.Minute)}
+	if err := first.PolicyRepo.SaveDecision(context.Background(), policyDecision); err != nil {
+		t.Fatalf("SaveDecision(policy) error = %v", err)
+	}
+	approval := policy.ApprovalRequest{ID: "approval-persist-1", CoordinationDecisionID: decision.ID, PolicyDecisionID: policyDecision.ID, CaseID: caseRecord.ID, WorkItemID: workItem.ID, QueueID: "default-intake", Status: policy.ApprovalPending, RequestedFromRole: "supervisor", CreatedAt: now.Add(2 * time.Minute)}
+	if err := first.PolicyRepo.SaveApprovalRequest(context.Background(), approval); err != nil {
+		t.Fatalf("SaveApprovalRequest error = %v", err)
+	}
+	trustProfile := trust.TrustProfile{ActorID: "employee-legacy-operator", Metrics: trust.TrustMetrics{SuccessCount: 2, FailureCount: 1}, CompletedExecutions: 3, FailedExecutions: 1, TrustLevel: trust.TrustLow, AutonomyTier: trust.AutonomyRestricted, UpdatedAt: now.Add(3 * time.Minute)}
+	if err := first.TrustRepo.Save(context.Background(), trustProfile); err != nil {
+		t.Fatalf("TrustRepo.Save error = %v", err)
+	}
+	for _, execEvent := range []eventcore.ExecutionEvent{
+		{ID: "exec-persist-1", ExecutionID: "approval:approval-persist-1", CaseID: caseRecord.ID, Step: "approval_request_created", Status: "pending", OccurredAt: now.Add(2 * time.Minute), CorrelationID: caseRecord.CorrelationID, CausationID: approval.ID, Payload: map[string]any{"approval_request_id": approval.ID}},
+		{ID: "exec-persist-2", ExecutionID: "approval:approval-persist-1", CaseID: caseRecord.ID, Step: "coordination_decision_made", Status: string(workplan.CoordinationDefer), OccurredAt: now.Add(4 * time.Minute), CorrelationID: caseRecord.CorrelationID, CausationID: decision.ID, Payload: map[string]any{"coordination_decision_id": decision.ID}},
+		{ID: "exec-persist-3", ExecutionID: "exec-persist-actor", CaseID: caseRecord.ID, Step: "trust_updated", Status: string(trust.TrustLow), OccurredAt: now.Add(5 * time.Minute), CorrelationID: caseRecord.CorrelationID, CausationID: "exec-persist-actor", Payload: map[string]any{"actor_id": trustProfile.ActorID, "trust_level": trustProfile.TrustLevel}},
+	} {
+		if err := first.EventLog.AppendExecutionEvent(context.Background(), execEvent); err != nil {
+			t.Fatalf("AppendExecutionEvent(%s) error = %v", execEvent.ID, err)
+		}
+	}
+
+	second, err := Bootstrap(cfgPath)
+	if err != nil {
+		t.Fatalf("Bootstrap(second) error = %v", err)
+	}
+
+	caseOverview, err := second.ControlPlane.GetCaseOverview(context.Background(), caseRecord.ID)
+	if err != nil {
+		t.Fatalf("GetCaseOverview error = %v", err)
+	}
+	if caseOverview.CorrelationID != caseRecord.CorrelationID || caseOverview.SubjectRef != caseRecord.SubjectRef {
+		t.Fatalf("caseOverview = %#v", caseOverview)
+	}
+	workOverview, err := second.ControlPlane.GetWorkItemOverview(context.Background(), workItem.ID)
+	if err != nil {
+		t.Fatalf("GetWorkItemOverview error = %v", err)
+	}
+	if workOverview.Coordination.DecisionType != string(workplan.CoordinationDefer) || workOverview.PolicyApproval.Outcome != string(policy.PolicyRequireApproval) || workOverview.PolicyApproval.ApprovalRequestID != approval.ID {
+		t.Fatalf("workOverview = %#v", workOverview)
+	}
+	gotTrust, ok, err := second.TrustService.GetTrustProfile(context.Background(), trustProfile.ActorID)
+	if err != nil {
+		t.Fatalf("GetTrustProfile error = %v", err)
+	}
+	if !ok || !reflect.DeepEqual(gotTrust, trustProfile) {
+		t.Fatalf("trust profile = %#v, ok=%v want %#v", gotTrust, ok, trustProfile)
+	}
+	timeline, err := second.ControlPlane.GetCaseTimeline(context.Background(), caseRecord.ID)
+	if err != nil {
+		t.Fatalf("GetCaseTimeline error = %v", err)
+	}
+	steps := make([]string, 0, len(timeline))
+	for _, entry := range timeline {
+		steps = append(steps, entry.Step)
+	}
+	wantSteps := []string{"approval_requested", "coordination_decided", "trust_updated"}
+	if !reflect.DeepEqual(steps, wantSteps) {
+		t.Fatalf("timeline steps = %#v, want %#v", steps, wantSteps)
 	}
 }

--- a/internal/capability/repository.go
+++ b/internal/capability/repository.go
@@ -86,3 +86,15 @@ func cloneCapability(c Capability) Capability {
 	}
 	return out
 }
+
+func (r *InMemoryCapabilityRepository) ListActorCapabilities(_ context.Context) ([]ActorCapability, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]ActorCapability, 0)
+	for _, assignments := range r.actorByID {
+		for _, assignment := range assignments {
+			out = append(out, assignment)
+		}
+	}
+	return out, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,12 +9,15 @@ import (
 )
 
 type Config struct {
-	Port        string `json:"port"`
-	DemoMode    bool   `json:"demoMode"`
-	DSLDir      string `json:"dslDir"`
-	EnumsDir    string `json:"enumsDir"`
-	DBURL       string `json:"dbUrl"`
-	AutoMigrate bool   `json:"autoMigrate"`
+	Port               string `json:"port"`
+	DemoMode           bool   `json:"demoMode"`
+	DSLDir             string `json:"dslDir"`
+	EnumsDir           string `json:"enumsDir"`
+	DBURL              string `json:"dbUrl"`
+	AutoMigrate        bool   `json:"autoMigrate"`
+	PersistenceEnabled bool   `json:"persistenceEnabled"`
+	PersistenceDir     string `json:"persistenceDir"`
+	SnapshotEvery      int    `json:"snapshotEvery"`
 
 	// Файлы (локально) и задел под S3
 	BlobDriver string `json:"blobDriver"` // "local" (default) | "s3"
@@ -29,12 +32,15 @@ type Config struct {
 
 func def() Config {
 	return Config{
-		Port:        "8080",
-		DemoMode:    false,
-		DSLDir:      "dsl",
-		EnumsDir:    "reference/enums",
-		DBURL:       "",
-		AutoMigrate: false,
+		Port:               "8080",
+		DemoMode:           false,
+		DSLDir:             "dsl",
+		EnumsDir:           "reference/enums",
+		DBURL:              "",
+		AutoMigrate:        false,
+		PersistenceEnabled: false,
+		PersistenceDir:     "",
+		SnapshotEvery:      50,
 
 		BlobDriver: "local",
 		FilesRoot:  "uploads",
@@ -95,6 +101,13 @@ func LoadWithPath(jsonPath string) Config {
 	cfg.EnumsDir = getenv("KALITA_ENUMS_DIR", cfg.EnumsDir)
 	cfg.DBURL = getenv("KALITA_DB_URL", cfg.DBURL)
 	cfg.AutoMigrate = getenvBool("KALITA_AUTO_MIGRATE", cfg.AutoMigrate)
+	cfg.PersistenceEnabled = getenvBool("KALITA_PERSISTENCE_ENABLED", cfg.PersistenceEnabled)
+	cfg.PersistenceDir = getenv("KALITA_PERSISTENCE_DIR", cfg.PersistenceDir)
+	if v := getenv("KALITA_SNAPSHOT_EVERY", ""); strings.TrimSpace(v) != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.SnapshotEvery = n
+		}
+	}
 
 	cfg.BlobDriver = getenv("KALITA_BLOB_DRIVER", cfg.BlobDriver)
 	cfg.FilesRoot = getenv("KALITA_FILES_ROOT", cfg.FilesRoot)
@@ -113,6 +126,9 @@ func LoadWithPath(jsonPath string) Config {
 	enums := fs.String("enums", cfg.EnumsDir, "Path to enums directory")
 	db := fs.String("db", cfg.DBURL, "Postgres URL (empty = in-memory)")
 	auto := fs.String("auto-migrate", strconv.FormatBool(cfg.AutoMigrate), "Auto-migrate add-only (true/false)")
+	persistenceEnabled := fs.String("persistence-enabled", strconv.FormatBool(cfg.PersistenceEnabled), "Enable file-based persistence (true/false)")
+	persistenceDir := fs.String("persistence-dir", cfg.PersistenceDir, "Persistence working directory")
+	snapshotEvery := fs.String("snapshot-every", strconv.Itoa(cfg.SnapshotEvery), "Snapshot cadence in persisted events")
 
 	blob := fs.String("blob-driver", cfg.BlobDriver, "Blob driver (local/s3)")
 	files := fs.String("files-root", cfg.FilesRoot, "Local files root (if blob=local)")
@@ -121,7 +137,7 @@ func LoadWithPath(jsonPath string) Config {
 	s3p := fs.String("s3-prefix", cfg.S3Prefix, "S3 key prefix")
 	s3e := fs.String("s3-endpoint", cfg.S3Endpoint, "S3 custom endpoint")
 
-	_ = fs.Parse(os.Args[1:])
+	_ = fs.Parse(filterKnownArgs(os.Args[1:]))
 
 	// Если через флаг передали другой конфиг — перечитаем
 	if *configPath != jsonPath {
@@ -138,6 +154,13 @@ func LoadWithPath(jsonPath string) Config {
 	cfg.AutoMigrate = strings.EqualFold(strings.TrimSpace(*auto), "true") ||
 		strings.EqualFold(strings.TrimSpace(*auto), "1") ||
 		strings.EqualFold(strings.TrimSpace(*auto), "yes")
+	cfg.PersistenceEnabled = strings.EqualFold(strings.TrimSpace(*persistenceEnabled), "true") ||
+		strings.EqualFold(strings.TrimSpace(*persistenceEnabled), "1") ||
+		strings.EqualFold(strings.TrimSpace(*persistenceEnabled), "yes")
+	cfg.PersistenceDir = strings.TrimSpace(*persistenceDir)
+	if n, err := strconv.Atoi(strings.TrimSpace(*snapshotEvery)); err == nil {
+		cfg.SnapshotEvery = n
+	}
 
 	cfg.BlobDriver = strings.TrimSpace(*blob)
 	cfg.FilesRoot = strings.TrimSpace(*files)
@@ -147,4 +170,15 @@ func LoadWithPath(jsonPath string) Config {
 	cfg.S3Endpoint = strings.TrimSpace(*s3e)
 
 	return cfg
+}
+
+func filterKnownArgs(args []string) []string {
+	filtered := make([]string, 0, len(args))
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-test.") {
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered
 }

--- a/internal/employee/repository.go
+++ b/internal/employee/repository.go
@@ -161,3 +161,13 @@ func removeString(items []string, target string) []string {
 	}
 	return out
 }
+
+func (r *InMemoryAssignmentRepository) ListAssignments(_ context.Context) ([]Assignment, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Assignment, 0, len(r.assignmentOrder))
+	for _, id := range r.assignmentOrder {
+		out = append(out, r.assignmentsByID[id])
+	}
+	return out, nil
+}

--- a/internal/eventcore/log.go
+++ b/internal/eventcore/log.go
@@ -55,3 +55,13 @@ func (l *InMemoryEventLog) ListByCorrelation(_ context.Context, correlationID st
 
 	return events, executionEvents, nil
 }
+
+func (l *InMemoryEventLog) ListAll(_ context.Context) ([]Event, []ExecutionEvent, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	events := make([]Event, len(l.events))
+	copy(events, l.events)
+	executionEvents := make([]ExecutionEvent, len(l.executionEvents))
+	copy(executionEvents, l.executionEvents)
+	return events, executionEvents, nil
+}

--- a/internal/executionruntime/repository.go
+++ b/internal/executionruntime/repository.go
@@ -105,3 +105,27 @@ func cloneStep(s StepExecution) StepExecution {
 	}
 	return out
 }
+
+func (r *InMemoryExecutionRepository) ListSessions(_ context.Context) ([]ExecutionSession, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]ExecutionSession, 0, len(r.sessions))
+	for _, sessionIDs := range r.sessionsByWorkItem {
+		for _, id := range sessionIDs {
+			out = append(out, r.sessions[id])
+		}
+	}
+	return out, nil
+}
+
+func (r *InMemoryExecutionRepository) ListSteps(_ context.Context) ([]StepExecution, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]StepExecution, 0, len(r.steps))
+	for _, stepIDs := range r.stepsBySession {
+		for _, id := range stepIDs {
+			out = append(out, cloneStep(r.steps[id]))
+		}
+	}
+	return out, nil
+}

--- a/internal/executionruntime/wal.go
+++ b/internal/executionruntime/wal.go
@@ -39,3 +39,13 @@ func cloneWALRecord(r WALRecord) WALRecord {
 	}
 	return out
 }
+
+func (w *InMemoryWAL) ListAll(_ context.Context) ([]WALRecord, error) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	out := make([]WALRecord, 0, len(w.records))
+	for _, record := range w.records {
+		out = append(out, cloneWALRecord(record))
+	}
+	return out, nil
+}

--- a/internal/persistence/adapters.go
+++ b/internal/persistence/adapters.go
@@ -1,0 +1,427 @@
+package persistence
+
+import (
+	"context"
+
+	"kalita/internal/capability"
+	"kalita/internal/caseruntime"
+	"kalita/internal/employee"
+	"kalita/internal/eventcore"
+	"kalita/internal/executionruntime"
+	"kalita/internal/policy"
+	"kalita/internal/profile"
+	"kalita/internal/proposal"
+	"kalita/internal/trust"
+	"kalita/internal/workplan"
+)
+
+type persistentEventLog struct {
+	base *eventcore.InMemoryEventLog
+	mgr  *Manager
+}
+
+func WrapEventLog(base *eventcore.InMemoryEventLog, mgr *Manager) eventcore.EventLog {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &persistentEventLog{base: base, mgr: mgr}
+}
+func (l *persistentEventLog) AppendEvent(ctx context.Context, e eventcore.Event) error {
+	if err := l.base.AppendEvent(ctx, e); err != nil {
+		return err
+	}
+	return l.mgr.Record("domain_event_appended", e)
+}
+func (l *persistentEventLog) AppendExecutionEvent(ctx context.Context, e eventcore.ExecutionEvent) error {
+	if err := l.base.AppendExecutionEvent(ctx, e); err != nil {
+		return err
+	}
+	return l.mgr.Record("execution_event_appended", e)
+}
+func (l *persistentEventLog) ListByCorrelation(ctx context.Context, correlationID string) ([]eventcore.Event, []eventcore.ExecutionEvent, error) {
+	return l.base.ListByCorrelation(ctx, correlationID)
+}
+
+type PersistentCaseRepository struct {
+	base *caseruntime.InMemoryCaseRepository
+	mgr  *Manager
+}
+
+func WrapCaseRepository(base *caseruntime.InMemoryCaseRepository, mgr *Manager) caseruntime.CaseRepository {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &PersistentCaseRepository{base: base, mgr: mgr}
+}
+func (r *PersistentCaseRepository) Save(ctx context.Context, c caseruntime.Case) error {
+	if err := r.base.Save(ctx, c); err != nil {
+		return err
+	}
+	return r.mgr.Record("case_saved", c)
+}
+func (r *PersistentCaseRepository) GetByID(ctx context.Context, id string) (caseruntime.Case, bool, error) {
+	return r.base.GetByID(ctx, id)
+}
+func (r *PersistentCaseRepository) List(ctx context.Context) ([]caseruntime.Case, error) {
+	return r.base.List(ctx)
+}
+func (r *PersistentCaseRepository) FindByCorrelation(ctx context.Context, correlationID string) (caseruntime.Case, bool, error) {
+	return r.base.FindByCorrelation(ctx, correlationID)
+}
+func (r *PersistentCaseRepository) FindBySubjectRef(ctx context.Context, subjectRef string) (caseruntime.Case, bool, error) {
+	return r.base.FindBySubjectRef(ctx, subjectRef)
+}
+
+type PersistentQueueRepository struct {
+	base *workplan.InMemoryQueueRepository
+	mgr  *Manager
+}
+
+func WrapQueueRepository(base *workplan.InMemoryQueueRepository, mgr *Manager) *PersistentQueueRepository {
+	if mgr == nil || !mgr.Enabled() {
+		return &PersistentQueueRepository{base: base}
+	}
+	return &PersistentQueueRepository{base: base, mgr: mgr}
+}
+func (r *PersistentQueueRepository) SaveQueue(ctx context.Context, q workplan.WorkQueue) error {
+	if err := r.base.SaveQueue(ctx, q); err != nil {
+		return err
+	}
+	if r.mgr != nil {
+		return r.mgr.Record("queue_saved", q)
+	}
+	return nil
+}
+func (r *PersistentQueueRepository) GetQueue(ctx context.Context, id string) (workplan.WorkQueue, bool, error) {
+	return r.base.GetQueue(ctx, id)
+}
+func (r *PersistentQueueRepository) ListQueues(ctx context.Context) ([]workplan.WorkQueue, error) {
+	return r.base.ListQueues(ctx)
+}
+func (r *PersistentQueueRepository) SaveWorkItem(ctx context.Context, wi workplan.WorkItem) error {
+	if err := r.base.SaveWorkItem(ctx, wi); err != nil {
+		return err
+	}
+	if r.mgr != nil {
+		return r.mgr.Record("work_item_saved", wi)
+	}
+	return nil
+}
+func (r *PersistentQueueRepository) GetWorkItem(ctx context.Context, id string) (workplan.WorkItem, bool, error) {
+	return r.base.GetWorkItem(ctx, id)
+}
+func (r *PersistentQueueRepository) ListWorkItemsByCase(ctx context.Context, caseID string) ([]workplan.WorkItem, error) {
+	return r.base.ListWorkItemsByCase(ctx, caseID)
+}
+func (r *PersistentQueueRepository) ListWorkItemsByQueue(ctx context.Context, queueID string) ([]workplan.WorkItem, error) {
+	return r.base.ListWorkItemsByQueue(ctx, queueID)
+}
+func (r *PersistentQueueRepository) ListWorkItems(ctx context.Context) ([]workplan.WorkItem, error) {
+	return r.base.ListWorkItems(ctx)
+}
+
+type PersistentCoordinationRepository struct {
+	base *workplan.InMemoryCoordinationRepository
+	mgr  *Manager
+}
+
+func WrapCoordinationRepository(base *workplan.InMemoryCoordinationRepository, mgr *Manager) workplan.CoordinationRepository {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &PersistentCoordinationRepository{base: base, mgr: mgr}
+}
+func (r *PersistentCoordinationRepository) SaveDecision(ctx context.Context, d workplan.CoordinationDecision) error {
+	if err := r.base.SaveDecision(ctx, d); err != nil {
+		return err
+	}
+	return r.mgr.Record("coordination_saved", d)
+}
+func (r *PersistentCoordinationRepository) GetDecision(ctx context.Context, id string) (workplan.CoordinationDecision, bool, error) {
+	return r.base.GetDecision(ctx, id)
+}
+func (r *PersistentCoordinationRepository) ListByWorkItem(ctx context.Context, workItemID string) ([]workplan.CoordinationDecision, error) {
+	return r.base.ListByWorkItem(ctx, workItemID)
+}
+func (r *PersistentCoordinationRepository) ListByCase(ctx context.Context, caseID string) ([]workplan.CoordinationDecision, error) {
+	return r.base.ListByCase(ctx, caseID)
+}
+func (r *PersistentCoordinationRepository) ListByQueue(ctx context.Context, queueID string) ([]workplan.CoordinationDecision, error) {
+	return r.base.ListByQueue(ctx, queueID)
+}
+
+type PersistentPolicyRepository struct {
+	base *policy.InMemoryRepository
+	mgr  *Manager
+}
+
+func WrapPolicyRepository(base *policy.InMemoryRepository, mgr *Manager) policy.PolicyRepository {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &PersistentPolicyRepository{base: base, mgr: mgr}
+}
+func (r *PersistentPolicyRepository) SaveDecision(ctx context.Context, d policy.PolicyDecision) error {
+	if err := r.base.SaveDecision(ctx, d); err != nil {
+		return err
+	}
+	return r.mgr.Record("policy_decision_saved", d)
+}
+func (r *PersistentPolicyRepository) GetDecision(ctx context.Context, id string) (policy.PolicyDecision, bool, error) {
+	return r.base.GetDecision(ctx, id)
+}
+func (r *PersistentPolicyRepository) ListByCoordinationDecision(ctx context.Context, id string) ([]policy.PolicyDecision, error) {
+	return r.base.ListByCoordinationDecision(ctx, id)
+}
+func (r *PersistentPolicyRepository) SaveApprovalRequest(ctx context.Context, a policy.ApprovalRequest) error {
+	if err := r.base.SaveApprovalRequest(ctx, a); err != nil {
+		return err
+	}
+	return r.mgr.Record("approval_request_saved", a)
+}
+func (r *PersistentPolicyRepository) GetApprovalRequest(ctx context.Context, id string) (policy.ApprovalRequest, bool, error) {
+	return r.base.GetApprovalRequest(ctx, id)
+}
+func (r *PersistentPolicyRepository) ListApprovalRequests(ctx context.Context) ([]policy.ApprovalRequest, error) {
+	return r.base.ListApprovalRequests(ctx)
+}
+func (r *PersistentPolicyRepository) ListApprovalRequestsByCoordinationDecision(ctx context.Context, id string) ([]policy.ApprovalRequest, error) {
+	return r.base.ListApprovalRequestsByCoordinationDecision(ctx, id)
+}
+
+type PersistentProposalRepository struct {
+	base *proposal.InMemoryRepository
+	mgr  *Manager
+}
+
+func WrapProposalRepository(base *proposal.InMemoryRepository, mgr *Manager) proposal.Repository {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &PersistentProposalRepository{base: base, mgr: mgr}
+}
+func (r *PersistentProposalRepository) Save(ctx context.Context, p proposal.Proposal) error {
+	if err := r.base.Save(ctx, p); err != nil {
+		return err
+	}
+	return r.mgr.Record("proposal_saved", p)
+}
+func (r *PersistentProposalRepository) Get(ctx context.Context, id string) (proposal.Proposal, bool, error) {
+	return r.base.Get(ctx, id)
+}
+func (r *PersistentProposalRepository) ListByWorkItem(ctx context.Context, workItemID string) ([]proposal.Proposal, error) {
+	return r.base.ListByWorkItem(ctx, workItemID)
+}
+func (r *PersistentProposalRepository) ListByActor(ctx context.Context, actorID string) ([]proposal.Proposal, error) {
+	return r.base.ListByActor(ctx, actorID)
+}
+
+type PersistentDirectory struct {
+	base *employee.InMemoryDirectory
+	mgr  *Manager
+}
+
+func WrapDirectory(base *employee.InMemoryDirectory, mgr *Manager) employee.Directory {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &PersistentDirectory{base: base, mgr: mgr}
+}
+func (r *PersistentDirectory) SaveEmployee(ctx context.Context, e employee.DigitalEmployee) error {
+	if err := r.base.SaveEmployee(ctx, e); err != nil {
+		return err
+	}
+	return r.mgr.Record("employee_saved", e)
+}
+func (r *PersistentDirectory) GetEmployee(ctx context.Context, id string) (employee.DigitalEmployee, bool, error) {
+	return r.base.GetEmployee(ctx, id)
+}
+func (r *PersistentDirectory) ListEmployees(ctx context.Context) ([]employee.DigitalEmployee, error) {
+	return r.base.ListEmployees(ctx)
+}
+func (r *PersistentDirectory) ListEmployeesByQueue(ctx context.Context, queueID string) ([]employee.DigitalEmployee, error) {
+	return r.base.ListEmployeesByQueue(ctx, queueID)
+}
+
+type PersistentAssignments struct {
+	base *employee.InMemoryAssignmentRepository
+	mgr  *Manager
+}
+
+func WrapAssignments(base *employee.InMemoryAssignmentRepository, mgr *Manager) employee.AssignmentRepository {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &PersistentAssignments{base: base, mgr: mgr}
+}
+func (r *PersistentAssignments) SaveAssignment(ctx context.Context, a employee.Assignment) error {
+	if err := r.base.SaveAssignment(ctx, a); err != nil {
+		return err
+	}
+	return r.mgr.Record("assignment_saved", a)
+}
+func (r *PersistentAssignments) GetAssignment(ctx context.Context, id string) (employee.Assignment, bool, error) {
+	return r.base.GetAssignment(ctx, id)
+}
+func (r *PersistentAssignments) ListAssignmentsByWorkItem(ctx context.Context, workItemID string) ([]employee.Assignment, error) {
+	return r.base.ListAssignmentsByWorkItem(ctx, workItemID)
+}
+func (r *PersistentAssignments) ListAssignmentsByEmployee(ctx context.Context, employeeID string) ([]employee.Assignment, error) {
+	return r.base.ListAssignmentsByEmployee(ctx, employeeID)
+}
+
+type PersistentTrustRepository struct {
+	base *trust.InMemoryRepository
+	mgr  *Manager
+}
+
+func WrapTrustRepository(base *trust.InMemoryRepository, mgr *Manager) trust.Repository {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &PersistentTrustRepository{base: base, mgr: mgr}
+}
+func (r *PersistentTrustRepository) Save(ctx context.Context, p trust.TrustProfile) error {
+	if err := r.base.Save(ctx, p); err != nil {
+		return err
+	}
+	return r.mgr.Record("trust_saved", p)
+}
+func (r *PersistentTrustRepository) GetByActor(ctx context.Context, actorID string) (trust.TrustProfile, bool, error) {
+	return r.base.GetByActor(ctx, actorID)
+}
+func (r *PersistentTrustRepository) List(ctx context.Context) ([]trust.TrustProfile, error) {
+	return r.base.List(ctx)
+}
+
+type PersistentProfileRepository struct {
+	base *profile.InMemoryRepository
+	mgr  *Manager
+}
+
+func WrapProfileRepository(base *profile.InMemoryRepository, mgr *Manager) *PersistentProfileRepository {
+	if mgr == nil || !mgr.Enabled() {
+		return &PersistentProfileRepository{base: base}
+	}
+	return &PersistentProfileRepository{base: base, mgr: mgr}
+}
+func (r *PersistentProfileRepository) SaveProfile(ctx context.Context, p profile.CompetencyProfile) error {
+	if err := r.base.SaveProfile(ctx, p); err != nil {
+		return err
+	}
+	return r.mgr.Record("profile_saved", p)
+}
+func (r *PersistentProfileRepository) GetProfile(ctx context.Context, id string) (profile.CompetencyProfile, bool, error) {
+	return r.base.GetProfile(ctx, id)
+}
+func (r *PersistentProfileRepository) GetProfileByActor(ctx context.Context, actorID string) (profile.CompetencyProfile, bool, error) {
+	return r.base.GetProfileByActor(ctx, actorID)
+}
+func (r *PersistentProfileRepository) ListProfiles(ctx context.Context) ([]profile.CompetencyProfile, error) {
+	return r.base.ListProfiles(ctx)
+}
+func (r *PersistentProfileRepository) SaveRequirement(ctx context.Context, req profile.CapabilityRequirement) error {
+	if err := r.base.SaveRequirement(ctx, req); err != nil {
+		return err
+	}
+	return r.mgr.Record("requirement_saved", req)
+}
+func (r *PersistentProfileRepository) ListRequirements(ctx context.Context) ([]profile.CapabilityRequirement, error) {
+	return r.base.ListRequirements(ctx)
+}
+
+type PersistentCapabilityRepository struct {
+	base *capability.InMemoryCapabilityRepository
+	mgr  *Manager
+}
+
+func WrapCapabilityRepository(base *capability.InMemoryCapabilityRepository, mgr *Manager) *PersistentCapabilityRepository {
+	if mgr == nil || !mgr.Enabled() {
+		return &PersistentCapabilityRepository{base: base}
+	}
+	return &PersistentCapabilityRepository{base: base, mgr: mgr}
+}
+func (r *PersistentCapabilityRepository) SaveCapability(ctx context.Context, c capability.Capability) error {
+	if err := r.base.SaveCapability(ctx, c); err != nil {
+		return err
+	}
+	if r.mgr != nil {
+		return r.mgr.Record("capability_saved", c)
+	}
+	return nil
+}
+func (r *PersistentCapabilityRepository) GetCapability(ctx context.Context, id string) (capability.Capability, bool, error) {
+	return r.base.GetCapability(ctx, id)
+}
+func (r *PersistentCapabilityRepository) ListCapabilities(ctx context.Context) ([]capability.Capability, error) {
+	return r.base.ListCapabilities(ctx)
+}
+func (r *PersistentCapabilityRepository) AssignCapability(ctx context.Context, ac capability.ActorCapability) error {
+	if err := r.base.AssignCapability(ctx, ac); err != nil {
+		return err
+	}
+	if r.mgr != nil {
+		return r.mgr.Record("actor_capability_saved", ac)
+	}
+	return nil
+}
+func (r *PersistentCapabilityRepository) ListByActor(ctx context.Context, actorID string) ([]capability.ActorCapability, error) {
+	return r.base.ListByActor(ctx, actorID)
+}
+
+type PersistentExecutionRepository struct {
+	base *executionruntime.InMemoryExecutionRepository
+	mgr  *Manager
+}
+
+func WrapExecutionRepository(base *executionruntime.InMemoryExecutionRepository, mgr *Manager) executionruntime.ExecutionRepository {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &PersistentExecutionRepository{base: base, mgr: mgr}
+}
+func (r *PersistentExecutionRepository) SaveSession(ctx context.Context, s executionruntime.ExecutionSession) error {
+	if err := r.base.SaveSession(ctx, s); err != nil {
+		return err
+	}
+	return r.mgr.Record("execution_session_saved", s)
+}
+func (r *PersistentExecutionRepository) GetSession(ctx context.Context, id string) (executionruntime.ExecutionSession, bool, error) {
+	return r.base.GetSession(ctx, id)
+}
+func (r *PersistentExecutionRepository) ListSessionsByWorkItem(ctx context.Context, workItemID string) ([]executionruntime.ExecutionSession, error) {
+	return r.base.ListSessionsByWorkItem(ctx, workItemID)
+}
+func (r *PersistentExecutionRepository) SaveStep(ctx context.Context, s executionruntime.StepExecution) error {
+	if err := r.base.SaveStep(ctx, s); err != nil {
+		return err
+	}
+	return r.mgr.Record("step_execution_saved", s)
+}
+func (r *PersistentExecutionRepository) GetStep(ctx context.Context, id string) (executionruntime.StepExecution, bool, error) {
+	return r.base.GetStep(ctx, id)
+}
+func (r *PersistentExecutionRepository) ListStepsBySession(ctx context.Context, sessionID string) ([]executionruntime.StepExecution, error) {
+	return r.base.ListStepsBySession(ctx, sessionID)
+}
+
+type PersistentWAL struct {
+	base *executionruntime.InMemoryWAL
+	mgr  *Manager
+}
+
+func WrapWAL(base *executionruntime.InMemoryWAL, mgr *Manager) executionruntime.WAL {
+	if mgr == nil || !mgr.Enabled() {
+		return base
+	}
+	return &PersistentWAL{base: base, mgr: mgr}
+}
+func (w *PersistentWAL) Append(ctx context.Context, r executionruntime.WALRecord) error {
+	if err := w.base.Append(ctx, r); err != nil {
+		return err
+	}
+	return w.mgr.Record("wal_appended", r)
+}
+func (w *PersistentWAL) ListBySession(ctx context.Context, sessionID string) ([]executionruntime.WALRecord, error) {
+	return w.base.ListBySession(ctx, sessionID)
+}

--- a/internal/persistence/collector.go
+++ b/internal/persistence/collector.go
@@ -1,0 +1,115 @@
+package persistence
+
+import (
+	"context"
+
+	"kalita/internal/capability"
+	"kalita/internal/caseruntime"
+	"kalita/internal/employee"
+	"kalita/internal/eventcore"
+	"kalita/internal/executionruntime"
+	"kalita/internal/policy"
+	"kalita/internal/profile"
+	"kalita/internal/proposal"
+	"kalita/internal/trust"
+	"kalita/internal/workplan"
+)
+
+type StateCollector struct {
+	Cases         *caseruntime.InMemoryCaseRepository
+	Queues        *workplan.InMemoryQueueRepository
+	Coordinations *workplan.InMemoryCoordinationRepository
+	Policies      *policy.InMemoryRepository
+	Proposals     *proposal.InMemoryRepository
+	Employees     *employee.InMemoryDirectory
+	Assignments   *employee.InMemoryAssignmentRepository
+	Trust         *trust.InMemoryRepository
+	Profiles      *profile.InMemoryRepository
+	Capabilities  *capability.InMemoryCapabilityRepository
+	Executions    *executionruntime.InMemoryExecutionRepository
+	WAL           *executionruntime.InMemoryWAL
+	EventLog      *eventcore.InMemoryEventLog
+}
+
+func (c *StateCollector) Collect(ctx context.Context) (SystemState, error) {
+	cases, err := c.Cases.List(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	queues, err := c.Queues.ListQueues(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	workItems, err := c.Queues.ListWorkItems(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	coordinations, err := c.Coordinations.ListAll(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	policyDecisions, err := c.Policies.ListDecisions(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	approvalRequests, err := c.Policies.ListApprovalRequests(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	proposals, err := c.Proposals.ListAll(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	employees, err := c.Employees.ListEmployees(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	assignments, err := c.Assignments.ListAssignments(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	trustProfiles, err := c.Trust.List(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	profiles, err := c.Profiles.ListProfiles(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	requirements, err := c.Profiles.ListRequirements(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	capabilities, err := c.Capabilities.ListCapabilities(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	actorCapabilities, err := c.Capabilities.ListActorCapabilities(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	sessions, err := c.Executions.ListSessions(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	steps, err := c.Executions.ListSteps(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	walRecords, err := c.WAL.ListAll(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	domainEvents, executionEvents, err := c.EventLog.ListAll(ctx)
+	if err != nil {
+		return SystemState{}, err
+	}
+	return SystemState{
+		Cases: cases, Queues: queues, WorkItems: workItems, Coordinations: coordinations,
+		PolicyDecisions: policyDecisions, ApprovalRequests: approvalRequests, Proposals: proposals,
+		Employees: employees, Assignments: assignments, TrustProfiles: trustProfiles,
+		Profiles: profiles, Requirements: requirements, Capabilities: capabilities, ActorCapabilities: actorCapabilities,
+		ExecutionSessions: sessions, StepExecutions: steps, WALRecords: walRecords,
+		DomainEvents: domainEvents, ExecutionEvents: executionEvents,
+	}, nil
+}

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -1,0 +1,435 @@
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"kalita/internal/capability"
+	"kalita/internal/caseruntime"
+	"kalita/internal/employee"
+	"kalita/internal/eventcore"
+	"kalita/internal/executionruntime"
+	"kalita/internal/policy"
+	"kalita/internal/profile"
+	"kalita/internal/proposal"
+	"kalita/internal/trust"
+	"kalita/internal/workplan"
+)
+
+type Event struct {
+	Sequence int64           `json:"sequence"`
+	Kind     string          `json:"kind"`
+	Payload  json.RawMessage `json:"payload"`
+}
+
+type EventStore interface {
+	Append(event Event) error
+	List() ([]Event, error)
+}
+
+type SnapshotStore interface {
+	SaveSnapshot(state SystemState) error
+	LoadSnapshot() (SystemState, error)
+}
+
+type SystemState struct {
+	LastSequence      int64                               `json:"last_sequence"`
+	Cases             []caseruntime.Case                  `json:"cases"`
+	Queues            []workplan.WorkQueue                `json:"queues"`
+	WorkItems         []workplan.WorkItem                 `json:"work_items"`
+	Coordinations     []workplan.CoordinationDecision     `json:"coordinations"`
+	PolicyDecisions   []policy.PolicyDecision             `json:"policy_decisions"`
+	ApprovalRequests  []policy.ApprovalRequest            `json:"approval_requests"`
+	Proposals         []proposal.Proposal                 `json:"proposals"`
+	Employees         []employee.DigitalEmployee          `json:"employees"`
+	Assignments       []employee.Assignment               `json:"assignments"`
+	TrustProfiles     []trust.TrustProfile                `json:"trust_profiles"`
+	Profiles          []profile.CompetencyProfile         `json:"profiles"`
+	Requirements      []profile.CapabilityRequirement     `json:"requirements"`
+	Capabilities      []capability.Capability             `json:"capabilities"`
+	ActorCapabilities []capability.ActorCapability        `json:"actor_capabilities"`
+	ExecutionSessions []executionruntime.ExecutionSession `json:"execution_sessions"`
+	StepExecutions    []executionruntime.StepExecution    `json:"step_executions"`
+	WALRecords        []executionruntime.WALRecord        `json:"wal_records"`
+	DomainEvents      []eventcore.Event                   `json:"domain_events"`
+	ExecutionEvents   []eventcore.ExecutionEvent          `json:"execution_events"`
+}
+
+type FileEventStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+func NewFileEventStore(dir string) *FileEventStore {
+	return &FileEventStore{path: filepath.Join(dir, "events.jsonl")}
+}
+func (s *FileEventStore) Append(event Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(s.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	return enc.Encode(event)
+}
+func (s *FileEventStore) List() ([]Event, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	lines := bytesSplitLines(b)
+	out := make([]Event, 0, len(lines))
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		var evt Event
+		if err := json.Unmarshal(line, &evt); err != nil {
+			return nil, err
+		}
+		out = append(out, evt)
+	}
+	return out, nil
+}
+
+type FileSnapshotStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+func NewFileSnapshotStore(dir string) *FileSnapshotStore {
+	return &FileSnapshotStore{path: filepath.Join(dir, "snapshot.json")}
+}
+func (s *FileSnapshotStore) SaveSnapshot(state SystemState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.path, b, 0o600)
+}
+func (s *FileSnapshotStore) LoadSnapshot() (SystemState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return SystemState{}, nil
+	}
+	if err != nil {
+		return SystemState{}, err
+	}
+	var state SystemState
+	if err := json.Unmarshal(b, &state); err != nil {
+		return SystemState{}, err
+	}
+	return state, nil
+}
+
+type Collector interface {
+	Collect(context.Context) (SystemState, error)
+}
+
+type Manager struct {
+	mu            sync.Mutex
+	enabled       bool
+	events        EventStore
+	snapshots     SnapshotStore
+	collector     Collector
+	snapshotEvery int
+	seq           int64
+}
+
+func NewManager(events EventStore, snapshots SnapshotStore, snapshotEvery int) *Manager {
+	if snapshotEvery <= 0 {
+		snapshotEvery = 50
+	}
+	return &Manager{enabled: events != nil && snapshots != nil, events: events, snapshots: snapshots, snapshotEvery: snapshotEvery}
+}
+func (m *Manager) Enabled() bool { return m != nil && m.enabled }
+func (m *Manager) BindCollector(c Collector) {
+	if m != nil {
+		m.collector = c
+	}
+}
+func (m *Manager) Record(kind string, payload any) error {
+	if !m.Enabled() {
+		return nil
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.seq++
+	seq := m.seq
+	m.mu.Unlock()
+	if err := m.events.Append(Event{Sequence: seq, Kind: kind, Payload: raw}); err != nil {
+		return err
+	}
+	if m.collector != nil && m.snapshotEvery > 0 && seq%int64(m.snapshotEvery) == 0 {
+		return m.SaveSnapshot(context.Background())
+	}
+	return nil
+}
+func (m *Manager) SaveSnapshot(ctx context.Context) error {
+	if !m.Enabled() || m.collector == nil {
+		return nil
+	}
+	state, err := m.collector.Collect(ctx)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	state.LastSequence = m.seq
+	m.mu.Unlock()
+	return m.snapshots.SaveSnapshot(state)
+}
+func (m *Manager) Restore(ctx context.Context, r *Restorer) error {
+	if !m.Enabled() {
+		return nil
+	}
+	snap, err := m.snapshots.LoadSnapshot()
+	if err != nil {
+		return err
+	}
+	if err := r.ApplyState(ctx, snap); err != nil {
+		return err
+	}
+	events, err := m.events.List()
+	if err != nil {
+		return err
+	}
+	last := snap.LastSequence
+	for _, evt := range events {
+		if evt.Sequence <= snap.LastSequence {
+			continue
+		}
+		if err := r.ApplyEvent(ctx, evt); err != nil {
+			return fmt.Errorf("apply event %d (%s): %w", evt.Sequence, evt.Kind, err)
+		}
+		last = evt.Sequence
+	}
+	m.mu.Lock()
+	if last > m.seq {
+		m.seq = last
+	}
+	m.mu.Unlock()
+	return nil
+}
+
+type Restorer struct {
+	Cases         *caseruntime.InMemoryCaseRepository
+	Queues        *workplan.InMemoryQueueRepository
+	Coordinations *workplan.InMemoryCoordinationRepository
+	Policies      *policy.InMemoryRepository
+	Proposals     *proposal.InMemoryRepository
+	Employees     *employee.InMemoryDirectory
+	Assignments   *employee.InMemoryAssignmentRepository
+	Trust         *trust.InMemoryRepository
+	Profiles      *profile.InMemoryRepository
+	Capabilities  *capability.InMemoryCapabilityRepository
+	Executions    *executionruntime.InMemoryExecutionRepository
+	WAL           *executionruntime.InMemoryWAL
+	EventLog      *eventcore.InMemoryEventLog
+}
+
+func (r *Restorer) ApplyState(ctx context.Context, s SystemState) error {
+	for _, item := range s.Cases {
+		if err := r.Cases.Save(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.Queues {
+		if err := r.Queues.SaveQueue(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.WorkItems {
+		if err := r.Queues.SaveWorkItem(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.Coordinations {
+		if err := r.Coordinations.SaveDecision(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.PolicyDecisions {
+		if err := r.Policies.SaveDecision(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.ApprovalRequests {
+		if err := r.Policies.SaveApprovalRequest(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.Proposals {
+		if err := r.Proposals.Save(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.Employees {
+		if err := r.Employees.SaveEmployee(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.Assignments {
+		if err := r.Assignments.SaveAssignment(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.TrustProfiles {
+		if err := r.Trust.Save(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.Profiles {
+		if err := r.Profiles.SaveProfile(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.Requirements {
+		if err := r.Profiles.SaveRequirement(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.Capabilities {
+		if err := r.Capabilities.SaveCapability(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.ActorCapabilities {
+		if err := r.Capabilities.AssignCapability(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.ExecutionSessions {
+		if err := r.Executions.SaveSession(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.StepExecutions {
+		if err := r.Executions.SaveStep(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.WALRecords {
+		if err := r.WAL.Append(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.DomainEvents {
+		if err := r.EventLog.AppendEvent(ctx, item); err != nil {
+			return err
+		}
+	}
+	for _, item := range s.ExecutionEvents {
+		if err := r.EventLog.AppendExecutionEvent(ctx, item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (r *Restorer) ApplyEvent(ctx context.Context, evt Event) error {
+	switch evt.Kind {
+	case "case_saved":
+		var v caseruntime.Case
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Cases.Save(ctx, v) })
+	case "queue_saved":
+		var v workplan.WorkQueue
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Queues.SaveQueue(ctx, v) })
+	case "work_item_saved":
+		var v workplan.WorkItem
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Queues.SaveWorkItem(ctx, v) })
+	case "coordination_saved":
+		var v workplan.CoordinationDecision
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Coordinations.SaveDecision(ctx, v) })
+	case "policy_decision_saved":
+		var v policy.PolicyDecision
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Policies.SaveDecision(ctx, v) })
+	case "approval_request_saved":
+		var v policy.ApprovalRequest
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Policies.SaveApprovalRequest(ctx, v) })
+	case "proposal_saved":
+		var v proposal.Proposal
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Proposals.Save(ctx, v) })
+	case "employee_saved":
+		var v employee.DigitalEmployee
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Employees.SaveEmployee(ctx, v) })
+	case "assignment_saved":
+		var v employee.Assignment
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Assignments.SaveAssignment(ctx, v) })
+	case "trust_saved":
+		var v trust.TrustProfile
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Trust.Save(ctx, v) })
+	case "profile_saved":
+		var v profile.CompetencyProfile
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Profiles.SaveProfile(ctx, v) })
+	case "requirement_saved":
+		var v profile.CapabilityRequirement
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Profiles.SaveRequirement(ctx, v) })
+	case "capability_saved":
+		var v capability.Capability
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Capabilities.SaveCapability(ctx, v) })
+	case "actor_capability_saved":
+		var v capability.ActorCapability
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Capabilities.AssignCapability(ctx, v) })
+	case "execution_session_saved":
+		var v executionruntime.ExecutionSession
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Executions.SaveSession(ctx, v) })
+	case "step_execution_saved":
+		var v executionruntime.StepExecution
+		return unmarshalApply(evt.Payload, &v, func() error { return r.Executions.SaveStep(ctx, v) })
+	case "wal_appended":
+		var v executionruntime.WALRecord
+		return unmarshalApply(evt.Payload, &v, func() error { return r.WAL.Append(ctx, v) })
+	case "domain_event_appended":
+		var v eventcore.Event
+		return unmarshalApply(evt.Payload, &v, func() error { return r.EventLog.AppendEvent(ctx, v) })
+	case "execution_event_appended":
+		var v eventcore.ExecutionEvent
+		return unmarshalApply(evt.Payload, &v, func() error { return r.EventLog.AppendExecutionEvent(ctx, v) })
+	default:
+		return fmt.Errorf("unknown persistence event kind %q", evt.Kind)
+	}
+}
+func unmarshalApply[T any](raw []byte, target *T, apply func() error) error {
+	if err := json.Unmarshal(raw, target); err != nil {
+		return err
+	}
+	return apply()
+}
+func bytesSplitLines(b []byte) [][]byte {
+	out := make([][]byte, 0)
+	start := 0
+	for i, c := range b {
+		if c == '\n' {
+			out = append(out, b[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(b) {
+		out = append(out, b[start:])
+	}
+	return out
+}

--- a/internal/policy/repository.go
+++ b/internal/policy/repository.go
@@ -132,3 +132,13 @@ func removeID(ids []string, id string) []string {
 	}
 	return out
 }
+
+func (r *InMemoryRepository) ListDecisions(_ context.Context) ([]PolicyDecision, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]PolicyDecision, 0, len(r.decisionOrder))
+	for _, id := range r.decisionOrder {
+		out = append(out, r.decisionsByID[id])
+	}
+	return out, nil
+}

--- a/internal/proposal/repository.go
+++ b/internal/proposal/repository.go
@@ -126,3 +126,13 @@ func removeString(items []string, target string) []string {
 	}
 	return out
 }
+
+func (r *InMemoryRepository) ListAll(_ context.Context) ([]Proposal, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Proposal, 0, len(r.proposalOrder))
+	for _, id := range r.proposalOrder {
+		out = append(out, cloneProposal(r.proposalsByID[id]))
+	}
+	return out, nil
+}

--- a/internal/workplan/coordination_repository.go
+++ b/internal/workplan/coordination_repository.go
@@ -87,3 +87,13 @@ func (r *InMemoryCoordinationRepository) listByIDs(ids []string) []CoordinationD
 	}
 	return out
 }
+
+func (r *InMemoryCoordinationRepository) ListAll(_ context.Context) ([]CoordinationDecision, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]CoordinationDecision, 0, len(r.decisionOrder))
+	for _, id := range r.decisionOrder {
+		out = append(out, r.decisionsByID[id])
+	}
+	return out, nil
+}


### PR DESCRIPTION
### Motivation
- Provide durable, append-only storage and restart replay so the runtime survives restarts and reconstructs timelines without changing runtime interfaces. 
- Keep persistence as a storage-only layer (no business logic moved to DB) and preserve deterministic behavior and control-plane compatibility. 
- Enable optional snapshots to accelerate restart and avoid full replay on every boot. 

### Description
- Add a new `internal/persistence` package with `Manager`, `FileEventStore` (JSONL append-only), `FileSnapshotStore` and `Restorer` to record events, take snapshots and replay state into in-memory repositories. 
- Introduce adapters that wrap existing in-memory repositories and the in-memory event log so every mutation is recorded as an event (storage-only wrappers) and the runtime APIs remain unchanged. 
- Add a `StateCollector` implementation that enumerates repository contents (cases, queues, work items, coordination decisions, policy/approval objects, proposals, employees/assignments, trust profiles, execution sessions/steps, WAL records and events) for snapshotting. 
- Wire persistence into `Bootstrap`: new config flags (`persistenceEnabled`, `persistenceDir`, `snapshotEvery`), idempotent reseeding of defaults, restore-before-start (snapshot load + event replay), and snapshot-saving on startup when enabled. 
- Extend in-memory stores with enumeration helpers required by snapshot/collector (`ListAll` / `ListDecisions` / `ListActorCapabilities` / `ListSessions` / `ListAll` etc.) to allow full-state capture and deterministic replay. 
- Add an integration test `TestBootstrapRestoresPersistentStateAcrossRestart` that persists a case/work-item/coordination/policy/trust timeline, restarts via `Bootstrap`, and verifies the restored case overview, coordination and approval state, trust profile and reconstructed timeline. 

### Testing
- Ran `go test ./internal/app` (including `TestBootstrapRestoresPersistentStateAcrossRestart`) and it passed. 
- Ran `go test ./internal/demo` and it passed. 
- Ran `go test ./internal/persistence/... ./internal/controlplane ./internal/trust ./internal/workplan` and these suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c176652d20832488f93132f4dbdd19)