### PR TITLE
Add governed operator workbench inputs (events, endpoints, demo UI, tests)

### DIFF
--- a/internal/controlplane/queries.go
+++ b/internal/controlplane/queries.go
@@ -20,4 +20,8 @@ type Service interface {
 
 	ApproveApprovalRequest(ctx context.Context, approvalRequestID string) (ApprovalInboxItem, error)
 	RejectApprovalRequest(ctx context.Context, approvalRequestID string) (ApprovalInboxItem, error)
+	AcknowledgeCase(ctx context.Context, caseID string) (CaseOverview, error)
+	AddCaseNote(ctx context.Context, caseID string, text string) (CaseOverview, error)
+	RequestCaseRecoordination(ctx context.Context, caseID string) (CaseOverview, error)
+	RecordExternalInput(ctx context.Context, caseID string, source string, text string) (CaseOverview, error)
 }

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -321,7 +321,11 @@ func (s *service) GetCaseOverview(ctx context.Context, caseID string) (CaseOverv
 	if !ok {
 		return CaseOverview{}, fmt.Errorf("case %s not found", caseID)
 	}
-	return mapCase(c), nil
+	overview := mapCase(c)
+	if err := s.populateOperatorCaseData(ctx, &overview); err != nil {
+		return CaseOverview{}, err
+	}
+	return overview, nil
 }
 
 func (s *service) ListCases(ctx context.Context) ([]CaseOverview, error) {
@@ -334,10 +338,113 @@ func (s *service) ListCases(ctx context.Context) ([]CaseOverview, error) {
 	}
 	out := make([]CaseOverview, 0, len(cases))
 	for _, c := range cases {
-		out = append(out, mapCase(c))
+		overview := mapCase(c)
+		if err := s.populateOperatorCaseData(ctx, &overview); err != nil {
+			return nil, err
+		}
+		out = append(out, overview)
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].OpenedAt.Before(out[j].OpenedAt) })
 	return out, nil
+}
+
+func (s *service) AcknowledgeCase(ctx context.Context, caseID string) (CaseOverview, error) {
+	c, err := s.requireCase(ctx, caseID)
+	if err != nil {
+		return CaseOverview{}, err
+	}
+	overview, err := s.GetCaseOverview(ctx, caseID)
+	if err != nil {
+		return CaseOverview{}, err
+	}
+	if overview.Acknowledged {
+		return overview, nil
+	}
+	now := c.UpdatedAt.Add(time.Nanosecond)
+	if err := s.appendCaseEvent(ctx, c, "operator_case_acknowledged", "recorded", now, fmt.Sprintf("operator-ack:%s", caseID), map[string]any{
+		"case_id": caseID,
+	}); err != nil {
+		return CaseOverview{}, err
+	}
+	return s.GetCaseOverview(ctx, caseID)
+}
+
+func (s *service) AddCaseNote(ctx context.Context, caseID string, text string) (CaseOverview, error) {
+	c, err := s.requireCase(ctx, caseID)
+	if err != nil {
+		return CaseOverview{}, err
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return CaseOverview{}, fmt.Errorf("text is required")
+	}
+	now := c.UpdatedAt.Add(2 * time.Nanosecond)
+	if err := s.appendCaseEvent(ctx, c, "operator_note_added", "recorded", now, fmt.Sprintf("operator-note:%s:%d", caseID, now.UnixNano()), map[string]any{
+		"case_id": caseID,
+		"text":    text,
+	}); err != nil {
+		return CaseOverview{}, err
+	}
+	return s.GetCaseOverview(ctx, caseID)
+}
+
+func (s *service) RequestCaseRecoordination(ctx context.Context, caseID string) (CaseOverview, error) {
+	c, err := s.requireCase(ctx, caseID)
+	if err != nil {
+		return CaseOverview{}, err
+	}
+	workItem, err := s.latestCaseWorkItem(ctx, caseID)
+	if err != nil {
+		return CaseOverview{}, err
+	}
+	now := workItem.UpdatedAt.Add(time.Nanosecond)
+	eventID := fmt.Sprintf("operator-recoordinate:%s:%s:%d", caseID, workItem.ID, now.UnixNano())
+	if err := s.appendCaseEvent(ctx, c, "operator_recoordination_requested", "requested", now, eventID, map[string]any{
+		"case_id":      caseID,
+		"work_item_id": workItem.ID,
+		"queue_id":     workItem.QueueID,
+	}); err != nil {
+		return CaseOverview{}, err
+	}
+	if s.coordinator != nil {
+		coordinationCtx, err := s.buildCoordinationContext(ctx, workItem)
+		if err != nil {
+			return CaseOverview{}, err
+		}
+		planningCtx := workplan.ContextWithPlanningExecution(ctx, workplan.PlanningExecutionContext{
+			ExecutionID:   fmt.Sprintf("operator-recoordinate:%s", caseID),
+			CorrelationID: c.CorrelationID,
+			CausationID:   eventID,
+		})
+		if _, err := s.coordinator.Decide(planningCtx, workItem, coordinationCtx); err != nil {
+			return CaseOverview{}, err
+		}
+	}
+	return s.GetCaseOverview(ctx, caseID)
+}
+
+func (s *service) RecordExternalInput(ctx context.Context, caseID string, source string, text string) (CaseOverview, error) {
+	c, err := s.requireCase(ctx, caseID)
+	if err != nil {
+		return CaseOverview{}, err
+	}
+	source = strings.TrimSpace(source)
+	text = strings.TrimSpace(text)
+	if source == "" {
+		return CaseOverview{}, fmt.Errorf("source is required")
+	}
+	if text == "" {
+		return CaseOverview{}, fmt.Errorf("text is required")
+	}
+	now := c.UpdatedAt.Add(3 * time.Nanosecond)
+	if err := s.appendCaseEvent(ctx, c, "external_input_received", "recorded", now, fmt.Sprintf("external-input:%s:%d", caseID, now.UnixNano()), map[string]any{
+		"case_id": caseID,
+		"source":  source,
+		"text":    text,
+	}); err != nil {
+		return CaseOverview{}, err
+	}
+	return s.GetCaseOverview(ctx, caseID)
 }
 
 func (s *service) GetWorkItemOverview(ctx context.Context, workItemID string) (WorkItemOverview, error) {
@@ -682,9 +789,103 @@ func normalizeTimelineStep(e eventcore.ExecutionEvent) (string, bool) {
 		return "trust_updated", true
 	case "escalation_waiting":
 		return "escalation_waiting", true
+	case "operator_case_acknowledged":
+		return "operator_case_acknowledged", true
+	case "operator_note_added":
+		return "operator_note_added", true
+	case "operator_recoordination_requested":
+		return "operator_recoordination_requested", true
+	case "external_input_received":
+		return "external_input_received", true
 	default:
 		return "", false
 	}
+}
+
+func (s *service) requireCase(ctx context.Context, caseID string) (caseruntime.Case, error) {
+	c, ok, err := s.cases.GetByID(ctx, caseID)
+	if err != nil {
+		return caseruntime.Case{}, err
+	}
+	if !ok {
+		return caseruntime.Case{}, fmt.Errorf("case %s not found", caseID)
+	}
+	return c, nil
+}
+
+func (s *service) latestCaseWorkItem(ctx context.Context, caseID string) (workplan.WorkItem, error) {
+	items, err := s.workItems.ListWorkItemsByCase(ctx, caseID)
+	if err != nil {
+		return workplan.WorkItem{}, err
+	}
+	if len(items) == 0 {
+		return workplan.WorkItem{}, fmt.Errorf("case %s has no work items", caseID)
+	}
+	latest := items[0]
+	for _, item := range items[1:] {
+		if item.UpdatedAt.After(latest.UpdatedAt) || (item.UpdatedAt.Equal(latest.UpdatedAt) && item.ID > latest.ID) {
+			latest = item
+		}
+	}
+	return latest, nil
+}
+
+func (s *service) appendCaseEvent(ctx context.Context, c caseruntime.Case, step string, status string, occurredAt time.Time, id string, payload map[string]any) error {
+	if s.eventLog == nil {
+		return nil
+	}
+	return s.eventLog.AppendExecutionEvent(ctx, eventcore.ExecutionEvent{
+		ID:            id,
+		ExecutionID:   fmt.Sprintf("operator:%s", c.ID),
+		CaseID:        c.ID,
+		Step:          step,
+		Status:        status,
+		OccurredAt:    occurredAt,
+		CorrelationID: c.CorrelationID,
+		CausationID:   id,
+		Payload:       payload,
+	})
+}
+
+func (s *service) populateOperatorCaseData(ctx context.Context, overview *CaseOverview) error {
+	if overview == nil || s.eventLog == nil || strings.TrimSpace(overview.CorrelationID) == "" {
+		return nil
+	}
+	_, executionEvents, err := s.eventLog.ListByCorrelation(ctx, overview.CorrelationID)
+	if err != nil {
+		return err
+	}
+	for _, e := range executionEvents {
+		if e.CaseID != "" && e.CaseID != overview.CaseID {
+			continue
+		}
+		switch e.Step {
+		case "operator_case_acknowledged":
+			if !overview.Acknowledged || (overview.AcknowledgedAt != nil && e.OccurredAt.Before(*overview.AcknowledgedAt)) {
+				ackAt := e.OccurredAt
+				overview.Acknowledged = true
+				overview.AcknowledgedAt = &ackAt
+			}
+		case "operator_note_added":
+			overview.OperatorNotes = append(overview.OperatorNotes, OperatorNoteOverview{
+				Text:       fmt.Sprint(e.Payload["text"]),
+				RecordedAt: e.OccurredAt,
+			})
+		case "external_input_received":
+			overview.ExternalInputs = append(overview.ExternalInputs, ExternalInputOverview{
+				Source:     fmt.Sprint(e.Payload["source"]),
+				Text:       fmt.Sprint(e.Payload["text"]),
+				RecordedAt: e.OccurredAt,
+			})
+		}
+	}
+	sort.SliceStable(overview.OperatorNotes, func(i, j int) bool {
+		return overview.OperatorNotes[i].RecordedAt.Before(overview.OperatorNotes[j].RecordedAt)
+	})
+	sort.SliceStable(overview.ExternalInputs, func(i, j int) bool {
+		return overview.ExternalInputs[i].RecordedAt.Before(overview.ExternalInputs[j].RecordedAt)
+	})
+	return nil
 }
 
 func clonePayload(in map[string]any) map[string]any {

--- a/internal/controlplane/viewmodels.go
+++ b/internal/controlplane/viewmodels.go
@@ -20,14 +20,29 @@ type TimelineEntry struct {
 	Payload    map[string]any `json:"payload,omitempty"`
 }
 
+type OperatorNoteOverview struct {
+	Text       string    `json:"text"`
+	RecordedAt time.Time `json:"recorded_at"`
+}
+
+type ExternalInputOverview struct {
+	Source     string    `json:"source"`
+	Text       string    `json:"text"`
+	RecordedAt time.Time `json:"recorded_at"`
+}
+
 type CaseOverview struct {
-	CaseID        string    `json:"case_id"`
-	Kind          string    `json:"kind"`
-	Status        string    `json:"status"`
-	CorrelationID string    `json:"correlation_id,omitempty"`
-	SubjectRef    string    `json:"subject_ref,omitempty"`
-	OpenedAt      time.Time `json:"opened_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
+	CaseID         string                  `json:"case_id"`
+	Kind           string                  `json:"kind"`
+	Status         string                  `json:"status"`
+	CorrelationID  string                  `json:"correlation_id,omitempty"`
+	SubjectRef     string                  `json:"subject_ref,omitempty"`
+	OpenedAt       time.Time               `json:"opened_at"`
+	UpdatedAt      time.Time               `json:"updated_at"`
+	Acknowledged   bool                    `json:"acknowledged"`
+	AcknowledgedAt *time.Time              `json:"acknowledged_at,omitempty"`
+	OperatorNotes  []OperatorNoteOverview  `json:"operator_notes,omitempty"`
+	ExternalInputs []ExternalInputOverview `json:"external_inputs,omitempty"`
 }
 
 type CoordinationOverview struct {

--- a/internal/http/demo.go
+++ b/internal/http/demo.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -33,8 +34,11 @@ func (c *demoOperatorClient) get(path string, out any) error {
 	return json.Unmarshal(rec.Body.Bytes(), out)
 }
 
-func (c *demoOperatorClient) post(path string, out any) error {
-	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(nil))
+func (c *demoOperatorClient) post(path string, body []byte, contentType string, out any) error {
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
 	rec := httptest.NewRecorder()
 	c.handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -91,6 +95,7 @@ type caseDetailPage struct {
 	WorkItem      *controlplane.WorkItemOverview
 	Timeline      []caseDetailTimelineRow
 	DomainContext demo.DomainCaseContext
+	ErrorMessage  string
 }
 
 func registerDemoRoutes(r *gin.Engine) {
@@ -98,6 +103,10 @@ func registerDemoRoutes(r *gin.Engine) {
 	r.GET("/demo", func(c *gin.Context) { renderDemoDashboard(c, client) })
 	r.GET("/demo/cases", func(c *gin.Context) { renderDemoCases(c, client) })
 	r.GET("/demo/cases/:id", func(c *gin.Context) { renderDemoCaseDetail(c, client, c.Param("id")) })
+	r.POST("/demo/cases/:id/acknowledge", func(c *gin.Context) { postDemoCaseAction(c, client, c.Param("id"), "acknowledge") })
+	r.POST("/demo/cases/:id/notes", func(c *gin.Context) { postDemoCaseAction(c, client, c.Param("id"), "notes") })
+	r.POST("/demo/cases/:id/recoordinate", func(c *gin.Context) { postDemoCaseAction(c, client, c.Param("id"), "recoordinate") })
+	r.POST("/demo/cases/:id/external-input", func(c *gin.Context) { postDemoCaseAction(c, client, c.Param("id"), "external-input") })
 	r.GET("/demo/approvals", func(c *gin.Context) { renderDemoApprovals(c, client) })
 	r.POST("/demo/approvals/:id/approve", func(c *gin.Context) { postDemoApprovalAction(c, client, c.Param("id"), "approve") })
 	r.POST("/demo/approvals/:id/reject", func(c *gin.Context) { postDemoApprovalAction(c, client, c.Param("id"), "reject") })
@@ -138,7 +147,33 @@ func renderDemoCaseDetail(c *gin.Context, client *demoOperatorClient, caseID str
 	}
 	page.DomainContext = demo.BuildDomainCaseContext(overview, page.WorkItem, timeline)
 	page.Timeline = buildCaseDetailTimeline(overview.Kind, timeline)
+	page.ErrorMessage = strings.TrimSpace(c.Query("error"))
 	renderDemoHTML(c, "Case Detail · Kalita Demo Console", demoCaseDetailTemplate, map[string]any{"Page": page})
+}
+
+func postDemoCaseAction(c *gin.Context, client *demoOperatorClient, caseID string, action string) {
+	redirectTarget := "/demo/cases/" + caseID
+	var (
+		body        []byte
+		contentType string
+		updated     controlplane.CaseOverview
+	)
+	switch action {
+	case "acknowledge", "recoordinate":
+	case "notes":
+		payload := map[string]string{"text": c.PostForm("text")}
+		body, _ = json.Marshal(payload)
+		contentType = "application/json"
+	case "external-input":
+		payload := map[string]string{"source": c.PostForm("source"), "text": c.PostForm("text")}
+		body, _ = json.Marshal(payload)
+		contentType = "application/json"
+	}
+	if err := client.post(fmt.Sprintf("/api/operator/cases/%s/%s", caseID, action), body, contentType, &updated); err != nil {
+		c.Redirect(http.StatusSeeOther, redirectTarget+"?error="+url.QueryEscape(err.Error()))
+		return
+	}
+	c.Redirect(http.StatusSeeOther, redirectTarget)
 }
 
 func renderDemoApprovals(c *gin.Context, client *demoOperatorClient) {
@@ -152,7 +187,7 @@ func renderDemoApprovals(c *gin.Context, client *demoOperatorClient) {
 
 func postDemoApprovalAction(c *gin.Context, client *demoOperatorClient, approvalID string, action string) {
 	var item controlplane.ApprovalInboxItem
-	if err := client.post(fmt.Sprintf("/api/operator/approvals/%s/%s", approvalID, action), &item); err != nil {
+	if err := client.post(fmt.Sprintf("/api/operator/approvals/%s/%s", approvalID, action), nil, "", &item); err != nil {
 		renderDemoError(c, err)
 		return
 	}
@@ -427,11 +462,13 @@ const demoCasesTemplate = `{{define "body"}}
 
 const demoCaseDetailTemplate = `{{define "body"}}
 {{if .Page.DomainContext.Title}}<div class="domain"><strong>{{.Page.DomainContext.Title}}</strong><p>{{.Page.DomainContext.IncidentSummary}}</p><p class="muted">{{.Page.DomainContext.TimelineDescription}}</p></div>{{end}}
+{{if .Page.ErrorMessage}}<p class="muted">Last action error: {{.Page.ErrorMessage}}</p>{{end}}
 <h2>Incident summary</h2>
 <table><tbody>
 <tr><th>Case ID</th><td>{{.Page.Case.CaseID}}</td></tr>
 <tr><th>Operational type</th><td>{{if .Page.DomainContext.CaseTypeLabel}}{{.Page.DomainContext.CaseTypeLabel}}{{else}}{{.Page.Case.Kind}}{{end}}</td></tr>
 <tr><th>Status</th><td>{{.Page.Case.Status}}</td></tr>
+<tr><th>Acknowledged</th><td>{{if .Page.Case.Acknowledged}}{{fmtTimePtr .Page.Case.AcknowledgedAt}}{{else}}not yet{{end}}</td></tr>
 <tr><th>Correlation ID</th><td>{{.Page.Case.CorrelationID}}</td></tr>
 <tr><th>Subject</th><td>{{.Page.Case.SubjectRef}}</td></tr>
 <tr><th>Route</th><td>{{if .Page.DomainContext.RouteID}}{{.Page.DomainContext.RouteID}}{{else}}-{{end}}</td></tr>
@@ -455,6 +492,12 @@ const demoCaseDetailTemplate = `{{define "body"}}
 <div class="actions"><form method="post" action="/demo/approvals/{{.Page.WorkItem.PolicyApproval.ApprovalRequestID}}/approve"><input type="hidden" name="redirect" value="/demo/cases/{{.Page.Case.CaseID}}"><button type="submit">Approve</button></form><form method="post" action="/demo/approvals/{{.Page.WorkItem.PolicyApproval.ApprovalRequestID}}/reject"><input type="hidden" name="redirect" value="/demo/cases/{{.Page.Case.CaseID}}"><button type="submit">Reject</button></form></div>
 {{end}}
 {{end}}
+<h2 class="section-title">Operator workbench</h2>
+<div class="actions"><form method="post" action="/demo/cases/{{.Page.Case.CaseID}}/acknowledge"><button type="submit">Acknowledge</button></form><form method="post" action="/demo/cases/{{.Page.Case.CaseID}}/recoordinate"><button type="submit">Request re-coordination</button></form></div>
+<form method="post" action="/demo/cases/{{.Page.Case.CaseID}}/notes"><p><label>Operator note<br><textarea name="text" rows="3" cols="80"></textarea></label></p><button type="submit">Add note</button></form>
+<form method="post" action="/demo/cases/{{.Page.Case.CaseID}}/external-input"><p><label>External source<br><input name="source"></label></p><p><label>External input<br><textarea name="text" rows="3" cols="80"></textarea></label></p><button type="submit">Record external input</button></form>
+{{if .Page.Case.OperatorNotes}}<h3>Operator notes</h3><table><thead><tr><th>Recorded at</th><th>Note</th></tr></thead><tbody>{{range .Page.Case.OperatorNotes}}<tr><td>{{fmtTime .RecordedAt}}</td><td>{{.Text}}</td></tr>{{end}}</tbody></table>{{end}}
+{{if .Page.Case.ExternalInputs}}<h3>External inputs</h3><table><thead><tr><th>Recorded at</th><th>Source</th><th>Text</th></tr></thead><tbody>{{range .Page.Case.ExternalInputs}}<tr><td>{{fmtTime .RecordedAt}}</td><td>{{.Source}}</td><td>{{.Text}}</td></tr>{{end}}</tbody></table>{{end}}
 <h2 class="section-title">Timeline</h2>
 <table><thead><tr><th>Occurred at</th><th>Domain event</th><th>Control plane step</th><th>Status</th><th>Payload</th></tr></thead><tbody>
 {{range .Page.Timeline}}<tr><td>{{fmtTime .OccurredAt}}</td><td>{{.DomainTitle}}{{if .DomainDetail}}<div class="muted">{{.DomainDetail}}</div>{{end}}</td><td>{{.Step}}</td><td>{{if .Status}}{{.Status}}{{else}}-{{end}}</td><td><pre>{{payload .Payload}}</pre></td></tr>{{else}}<tr><td colspan="5">No timeline entries found.</td></tr>{{end}}

--- a/internal/http/demo_test.go
+++ b/internal/http/demo_test.go
@@ -128,3 +128,42 @@ func TestDemoApprovalActionUsesExistingApprovalFlow(t *testing.T) {
 		}
 	}
 }
+
+func TestDemoCaseDetailOperatorWorkbenchUsesOperatorFlow(t *testing.T) {
+	t.Parallel()
+	r := demoRouter(t)
+
+	caseID := findDemoCaseIDByRoute(t, r, "R-1003")
+	for _, reqSpec := range []struct {
+		path string
+		body string
+	}{
+		{path: "/demo/cases/" + caseID + "/acknowledge"},
+		{path: "/demo/cases/" + caseID + "/notes", body: "text=Carrier+confirmed+blocked+gate"},
+		{path: "/demo/cases/" + caseID + "/external-input", body: "source=carrier_report&text=Access+restored"},
+		{path: "/demo/cases/" + caseID + "/recoordinate"},
+	} {
+		req := httptest.NewRequest(http.MethodPost, reqSpec.path, strings.NewReader(reqSpec.body))
+		if reqSpec.body != "" {
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusSeeOther {
+			t.Fatalf("POST %s status=%d body=%s", reqSpec.path, w.Code, w.Body.String())
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/demo/cases/"+caseID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET detail status=%d body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{"Operator workbench", "Carrier confirmed blocked gate", "carrier_report", "Access restored", "operator_case_acknowledged", "operator_note_added", "operator_recoordination_requested", "external_input_received"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+}

--- a/internal/http/operator.go
+++ b/internal/http/operator.go
@@ -31,6 +31,37 @@ func registerOperatorRoutes(group *gin.RouterGroup, svc controlplane.Service) {
 		payload, err := svc.GetCaseTimeline(c.Request.Context(), c.Param("id"))
 		respondOperator(c, payload, err)
 	})
+	operator.POST("/cases/:id/acknowledge", func(c *gin.Context) {
+		payload, err := svc.AcknowledgeCase(c.Request.Context(), c.Param("id"))
+		respondOperator(c, payload, err)
+	})
+	operator.POST("/cases/:id/notes", func(c *gin.Context) {
+		var req struct {
+			Text string `json:"text"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			respondOperator(c, gin.H{}, err)
+			return
+		}
+		payload, err := svc.AddCaseNote(c.Request.Context(), c.Param("id"), req.Text)
+		respondOperator(c, payload, err)
+	})
+	operator.POST("/cases/:id/recoordinate", func(c *gin.Context) {
+		payload, err := svc.RequestCaseRecoordination(c.Request.Context(), c.Param("id"))
+		respondOperator(c, payload, err)
+	})
+	operator.POST("/cases/:id/external-input", func(c *gin.Context) {
+		var req struct {
+			Source string `json:"source"`
+			Text   string `json:"text"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			respondOperator(c, gin.H{}, err)
+			return
+		}
+		payload, err := svc.RecordExternalInput(c.Request.Context(), c.Param("id"), req.Source, req.Text)
+		respondOperator(c, payload, err)
+	})
 	operator.GET("/work-items", func(c *gin.Context) {
 		payload, err := svc.ListWorkItems(c.Request.Context())
 		respondOperator(c, payload, err)
@@ -79,6 +110,9 @@ func statusForOperatorError(err error) int {
 	}
 	if strings.HasSuffix(err.Error(), " not found") {
 		return http.StatusNotFound
+	}
+	if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "invalid") || strings.Contains(err.Error(), "must not") || strings.Contains(err.Error(), "JSON") {
+		return http.StatusBadRequest
 	}
 	return http.StatusInternalServerError
 }

--- a/internal/http/operator_test.go
+++ b/internal/http/operator_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -110,6 +111,105 @@ func TestOperatorApprovalEndpointsResolveRequestsIdempotently(t *testing.T) {
 		if payload["status"] != "approved" {
 			t.Fatalf("payload = %#v", payload)
 		}
+	}
+}
+
+func TestOperatorCaseInputEndpointsRecordGovernedEvents(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	api := r.Group("/api")
+	registerOperatorRoutes(api, controlplaneSeededService(t))
+
+	for _, reqSpec := range []struct {
+		name string
+		path string
+		body string
+	}{
+		{name: "acknowledge", path: "/api/operator/cases/case-1/acknowledge"},
+		{name: "note", path: "/api/operator/cases/case-1/notes", body: `{"text":"Carrier confirmed missed pickup due to blocked access"}`},
+		{name: "external input", path: "/api/operator/cases/case-1/external-input", body: `{"source":"carrier_report","text":"Access restored, retry allowed"}`},
+		{name: "recoordinate", path: "/api/operator/cases/case-1/recoordinate"},
+	} {
+		req := httptest.NewRequest(http.MethodPost, reqSpec.path, strings.NewReader(reqSpec.body))
+		if reqSpec.body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s status=%d body=%s", reqSpec.name, w.Code, w.Body.String())
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/operator/cases/case-1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET case overview status=%d body=%s", w.Code, w.Body.String())
+	}
+	var overview map[string]any
+	decode(t, w, &overview)
+	if overview["acknowledged"] != true {
+		t.Fatalf("overview = %#v", overview)
+	}
+	if notes := overview["operator_notes"].([]any); len(notes) != 1 {
+		t.Fatalf("operator_notes = %#v", overview["operator_notes"])
+	}
+	if inputs := overview["external_inputs"].([]any); len(inputs) != 1 {
+		t.Fatalf("external_inputs = %#v", overview["external_inputs"])
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/operator/cases/case-1/timeline", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET timeline status=%d body=%s", w.Code, w.Body.String())
+	}
+	var timeline []map[string]any
+	decode(t, w, &timeline)
+	steps := map[string]bool{}
+	for _, entry := range timeline {
+		steps[entry["step"].(string)] = true
+	}
+	for _, want := range []string{"operator_case_acknowledged", "operator_note_added", "external_input_received", "operator_recoordination_requested", "coordination_decided"} {
+		if !steps[want] {
+			t.Fatalf("timeline missing %s in %#v", want, timeline)
+		}
+	}
+}
+
+func TestOperatorAcknowledgeIsIdempotent(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	api := r.Group("/api")
+	registerOperatorRoutes(api, controlplaneSeededService(t))
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/operator/cases/case-1/acknowledge", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("POST acknowledge #%d status=%d body=%s", i+1, w.Code, w.Body.String())
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/operator/cases/case-1/timeline", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	var timeline []map[string]any
+	decode(t, w, &timeline)
+	count := 0
+	for _, entry := range timeline {
+		if entry["step"] == "operator_case_acknowledged" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("ack count = %d timeline=%#v", count, timeline)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Provide a minimal, governed operator workbench so humans can record acknowledgements, notes, re-coordination requests and external input as first-class, auditable operator events without allowing direct case edits or execution control.

### Description

- Extend the control-plane API with new methods: `AcknowledgeCase`, `AddCaseNote`, `RequestCaseRecoordination`, and `RecordExternalInput`, and surface operator data on the `CaseOverview` model (acknowledged flag/timestamp, operator notes, external inputs).
- Record operator interactions as execution events via the existing `eventLog` (steps: `operator_case_acknowledged`, `operator_note_added`, `operator_recoordination_requested`, `external_input_received`) and include them in timelines via `populateOperatorCaseData` and `normalizeTimelineStep`.
- Add minimal operator HTTP endpoints under `/api/operator/cases/:id/...` for acknowledge, notes, re-coordinate and external-input with simple JSON validation and safe error-to-status mapping, and wire the demo UI to use the same runtime flow (server-rendered forms/buttons) without adding any direct overrides.
- Ensure deterministic behavior and safety: acknowledge is idempotent, notes and external inputs are append-only, re-coordinate emits a request event then re-enters the existing coordination pipeline via the coordinator's `Decide` call, and all operator inputs are recorded (no direct status/work-item mutation).

### Testing

- Added unit tests exercising the flow: `TestOperatorCaseInputEndpointsRecordGovernedEvents`, `TestOperatorAcknowledgeIsIdempotent`, and `TestDemoCaseDetailOperatorWorkbenchUsesOperatorFlow` (files: `internal/http/operator_test.go`, `internal/http/demo_test.go`).
- Ran formatting and unit tests with `gofmt -w` and `go test ./internal/http ./internal/controlplane -count=1`, and the tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c195a0499c8324b4a98daff12ae2c1)