### PR TITLE
docs: prefer direct commits to `main` and avoid PRs by default

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -2,10 +2,11 @@
 
 ## Default workflow
 
-- Work directly on the current branch.
-- Implement changes on the current branch instead of creating topic branches.
+- Work directly on the current branch (typically `main`).
+- Implement changes directly in `main` instead of creating topic branches.
 - Create focused, slice-sized local commits with clear messages.
-- Do not open a pull request or prepare pull request metadata unless explicitly requested.
+- Do not create a PR by default.
+- Do not open a pull request or prepare PR metadata unless explicitly requested.
 - Do not use PR flow for routine incremental slices.
 - Use direct branch commits unless the task is explicitly marked as a review checkpoint.
 


### PR DESCRIPTION
### Motivation
- Clarify the default contributor workflow to prefer direct, focused commits to `main` for routine slices instead of creating topic branches and PRs.

### Description
- Updated the Default workflow section in `AGENT_GUIDE.md` to state work should be done directly on the current branch (typically `main`).
- Added explicit guidance to "Do not create a PR by default" while retaining the rule to prepare PR metadata when explicitly requested.
- Kept other existing guidance to create focused, slice-sized commits and to only use PR flow for review checkpoints.

### Testing
- No automated tests required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2781a2ebc8324b1760d840b48d6cc)